### PR TITLE
ci: Run all checks on pull requests

### DIFF
--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -6,6 +6,7 @@ on:
       - 'health-api-library/**'
     tags-ignore:
       - '**'
+  pull_request:
   workflow_call:
 
 jobs:

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -6,6 +6,7 @@ on:
       - 'health-sdk/**'
     tags-ignore:
       - '**'
+  pull_request:
   workflow_call:
 
 jobs:


### PR DESCRIPTION
It's helpful to run all check workflows when we [open and update pull requests](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request). Should help us catch issues early.

The advantage of `pull_request` events is that the workflow is executed on the merged code. In other words the checks are executed on the state we would have after merging the PR.

This article has more info about `pull_request` events: https://frontside.com/blog/2020-05-26-github-actions-pull_request/