### PR TITLE
refactor(bank-sdk): Show how to use suspending functions from Java

### DIFF
--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/di/ViewModel.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/di/ViewModel.kt
@@ -1,9 +1,11 @@
 package net.gini.android.bank.sdk.screenapiexample.di
 
-import net.gini.android.bank.sdk.screenapiexample.pay.PayViewModel
+import net.gini.android.bank.sdk.screenapiexample.pay.PayViewModelJava
+import net.gini.android.bank.sdk.screenapiexample.pay.PayViewModelKotlin
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val viewModelModule = module {
-    viewModel { PayViewModel(get()) }
+    viewModel { PayViewModelJava(get()) }
+    viewModel { PayViewModelKotlin(get()) }
 }

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayActivity.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayActivity.kt
@@ -5,7 +5,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.flow.collect
 import net.gini.android.core.api.models.PaymentRequest
 import net.gini.android.core.api.models.ResolvePaymentInput
 import net.gini.android.bank.sdk.screenapiexample.databinding.ActivityPayBinding
@@ -15,7 +14,9 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class PayActivity : AppCompatActivity() {
 
-    private val viewModel: PayViewModel by viewModel()
+    // Replace PayViewModelKotlin with PayViewModelJava to try out
+    // using the GiniBank suspending functions from Java
+    private val viewModel: PayViewModelJava by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelInterface.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelInterface.kt
@@ -1,0 +1,23 @@
+package net.gini.android.bank.sdk.screenapiexample.pay
+
+import android.content.Context
+import kotlinx.coroutines.flow.StateFlow
+import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper
+import net.gini.android.core.api.models.PaymentRequest
+import net.gini.android.core.api.models.ResolvePaymentInput
+import net.gini.android.core.api.models.ResolvedPayment
+
+/**
+ * Created by Alpár Szotyori on 19.01.22.
+ * <p>
+ * Copyright (c) 2022 Gini GmbH.
+ */
+interface PayViewModelInterface {
+
+    val paymentRequest: StateFlow<ResultWrapper<PaymentRequest>>
+    val paymentState: StateFlow<ResultWrapper<ResolvedPayment>>
+
+    fun fetchPaymentRequest(requestId: String)
+    fun onPay(paymentDetails: ResolvePaymentInput)
+    fun returnToPaymentInitiatorApp(context: Context)
+}

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelJava.java
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelJava.java
@@ -1,0 +1,101 @@
+package net.gini.android.bank.sdk.screenapiexample.pay;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+
+import net.gini.android.bank.sdk.GiniBank;
+import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper;
+import net.gini.android.bank.sdk.util.CoroutineContinuationHelper;
+import net.gini.android.core.api.models.PaymentRequest;
+import net.gini.android.core.api.models.ResolvePaymentInput;
+import net.gini.android.core.api.models.ResolvedPayment;
+
+import kotlinx.coroutines.flow.MutableStateFlow;
+import kotlinx.coroutines.flow.StateFlow;
+import kotlinx.coroutines.flow.StateFlowKt;
+
+/**
+ * Created by Alpár Szotyori on 19.01.22.
+ * <p>
+ * Copyright (c) 2022 Gini GmbH.
+ */
+
+/**
+ * Example showing how to use the GiniBank suspending functions from Java.
+ */
+public class PayViewModelJava extends ViewModel implements PayViewModelInterface {
+
+    private final GiniBank giniBank;
+
+    private final MutableStateFlow<ResultWrapper<PaymentRequest>> _paymentRequest = StateFlowKt.MutableStateFlow(new ResultWrapper.Loading<>());
+    private final MutableStateFlow<ResultWrapper<ResolvedPayment>> _paymentState = StateFlowKt.MutableStateFlow(new ResultWrapper.Loading<>());
+
+    private String requestId = null;
+
+    public PayViewModelJava(@NonNull final GiniBank giniBank) {
+        this.giniBank = giniBank;
+    }
+
+    @NonNull
+    @Override
+    public StateFlow<ResultWrapper<PaymentRequest>> getPaymentRequest() {
+        return _paymentRequest;
+    }
+
+    @NonNull
+    @Override
+    public StateFlow<ResultWrapper<ResolvedPayment>> getPaymentState() {
+        return _paymentState;
+    }
+
+    public void fetchPaymentRequest(@NonNull final String requestId) {
+        this.requestId = requestId;
+        giniBank.getPaymentRequest(requestId, CoroutineContinuationHelper.callbackContinuation(new CoroutineContinuationHelper.ContinuationCallback<PaymentRequest>() {
+            @Override
+            public void onFinished(PaymentRequest result) {
+                _paymentRequest.setValue(new ResultWrapper.Success<>(result));
+            }
+
+            @Override
+            public void onFailed(@NonNull Throwable error) {
+                _paymentRequest.setValue(new ResultWrapper.Error<>(error));
+            }
+
+            @Override
+            public void onCancelled() {
+
+            }
+        }));
+    }
+
+    public void onPay(@NonNull final ResolvePaymentInput paymentDetails) {
+        if (requestId != null) {
+            giniBank.resolvePaymentRequest(requestId, paymentDetails, CoroutineContinuationHelper.callbackContinuation(new CoroutineContinuationHelper.ContinuationCallback<ResolvedPayment>() {
+                @Override
+                public void onFinished(ResolvedPayment result) {
+                    _paymentState.setValue(new ResultWrapper.Success<>(result));
+                }
+
+                @Override
+                public void onFailed(@NonNull Throwable error) {
+                    _paymentState.setValue(new ResultWrapper.Error<>(error));
+                }
+
+                @Override
+                public void onCancelled() {
+
+                }
+            }));
+        }
+    }
+
+    public void returnToPaymentInitiatorApp(@NonNull final Context context) {
+        if (_paymentState.getValue() instanceof ResultWrapper.Success) {
+            final ResultWrapper.Success<ResolvedPayment> paymentStateValue = (ResultWrapper.Success<ResolvedPayment>) _paymentState.getValue();
+            final ResolvedPayment resolvedPayment = paymentStateValue.getValue();
+            giniBank.returnToPaymentInitiatorApp(context, resolvedPayment);
+        }
+    }
+}

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelKotlin.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelKotlin.kt
@@ -13,19 +13,19 @@ import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper
 import net.gini.android.bank.sdk.screenapiexample.util.wrapToResult
 import net.gini.android.bank.sdk.GiniBank
 
-class PayViewModel(
+class PayViewModelKotlin(
     private val giniBank: GiniBank
-) : ViewModel() {
+) : ViewModel(), PayViewModelInterface {
 
     private val _paymentRequest = MutableStateFlow<ResultWrapper<PaymentRequest>>(ResultWrapper.Loading())
-    val paymentRequest: StateFlow<ResultWrapper<PaymentRequest>> = _paymentRequest
+    override val paymentRequest: StateFlow<ResultWrapper<PaymentRequest>> = _paymentRequest
 
     private val _paymentState = MutableStateFlow<ResultWrapper<ResolvedPayment>>(ResultWrapper.Loading())
-    val paymentState: StateFlow<ResultWrapper<ResolvedPayment>> = _paymentState
+    override val paymentState: StateFlow<ResultWrapper<ResolvedPayment>> = _paymentState
 
     private var requestId: String? = null
 
-    fun fetchPaymentRequest(requestId: String) {
+    override fun fetchPaymentRequest(requestId: String) {
         this.requestId = requestId
         _paymentRequest.value = ResultWrapper.Loading()
         viewModelScope.launch {
@@ -33,7 +33,7 @@ class PayViewModel(
         }
     }
 
-    fun onPay(paymentDetails: ResolvePaymentInput) {
+    override fun onPay(paymentDetails: ResolvePaymentInput) {
         _paymentState.value = ResultWrapper.Loading()
         requestId?.let { id ->
             viewModelScope.launch {
@@ -42,9 +42,9 @@ class PayViewModel(
         }
     }
 
-    fun returnToPaymentInitiatorApp(context: Context) {
-        val payment = paymentState.value
+    override fun returnToPaymentInitiatorApp(context: Context) {
+        val payment = _paymentState.value
         if (payment is ResultWrapper.Success)
-        giniBank.returnToPaymentInitiatorApp(context, payment.value)
+            giniBank.returnToPaymentInitiatorApp(context, payment.value)
     }
 }


### PR DESCRIPTION
Added a Java implementation of the `PayViewModel` called
`PayViewModelJava` (kotlin version was renamed to
`PayViewModelKotlin`) which shows how to use the suspending
functions from Java.