### PR TITLE
Pia 2177 update health sdk for latest health api library

### DIFF
--- a/health-api-library/README.md
+++ b/health-api-library/README.md
@@ -3,11 +3,9 @@
 Gini Health API Library for Android
 ===================================
 
-TODO: replace https://pay-api.gini.net links with the one for the Health API once it's available
-
-A library for communicating with the [Gini Health API](https://pay-api.gini.net/documentation/). It allows you to easily add
-[payment information extraction](https://pay-api.gini.net/documentation/#document-extractions-for-payment) capabilities
-to your app. It also enables your app to create or resolve [payment requests](https://pay-api.gini.net/documentation/#payments).
+A library for communicating with the [Gini Health API](https://health-api.gini.net/documentation/v3/#gini-health-api-documentation-v3-0).
+It allows you to easily add payment information extraction ([see "payment" compound extraction](https://health-api.gini.net/documentation/v3/#available-compound-extractions))
+capabilities to your app. It also enables your app to create payment requests and retrieve payment providers.
 
 The Gini Health API provides an information extraction service for analyzing invoices. Specifically it extracts information
 such as the document sender or the payment relevant information (amount to pay, IBAN, BIC, payment reference, etc.).

--- a/health-api-library/library/src/androidTest/assets/payment-provider.json
+++ b/health-api-library/library/src/androidTest/assets/payment-provider.json
@@ -11,5 +11,5 @@
     "background": "112233",
     "text": "44AAFF"
   },
-  "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+  "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
 }

--- a/health-api-library/library/src/androidTest/assets/payment-providers.json
+++ b/health-api-library/library/src/androidTest/assets/payment-providers.json
@@ -12,7 +12,7 @@
       "background": "112233",
       "text": "44AAFF"
     },
-    "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+    "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
   },
   {
     "id": "9a9b41f2-32f8-11eb-9fb5-e378350b0392",
@@ -27,6 +27,6 @@
       "background": "557788",
       "text": "00DDEE"
     },
-    "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+    "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
   }
 ]

--- a/health-api-library/library/src/androidTest/assets/payment-request.json
+++ b/health-api-library/library/src/androidTest/assets/payment-request.json
@@ -7,9 +7,9 @@
   "purpose": "ReNr AZ356789Z",
   "status": "paid",
   "_links": {
-    "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-    "payment": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-    "sourceDocumentLocation": "https://pay-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-    "_self": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
+    "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+    "payment": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+    "sourceDocumentLocation": "https://health-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+    "_self": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
   }
 }

--- a/health-api-library/library/src/androidTest/assets/payment-requests.json
+++ b/health-api-library/library/src/androidTest/assets/payment-requests.json
@@ -8,10 +8,10 @@
     "purpose": "ReNr AZ356789Z",
     "status": "paid",
     "_links": {
-      "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-      "payment": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-      "sourceDocumentLocation": "https://pay-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-      "self": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
+      "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+      "payment": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+      "sourceDocumentLocation": "https://health-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+      "self": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
     }
   },
   {
@@ -23,10 +23,10 @@
     "purpose": "ReNr BZ056789",
     "status": "paid",
     "_links": {
-      "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-      "payment": "https://pay-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-      "sourceDocumentLocation": "https://pay-api.gini.net/documents/48090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-      "self": "https://pay-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000"
+      "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+      "payment": "https://health-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+      "sourceDocumentLocation": "https://health-api.gini.net/documents/48090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+      "self": "https://health-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000"
     }
   }
 ]

--- a/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiCommunicatorTest.java
+++ b/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiCommunicatorTest.java
@@ -56,7 +56,7 @@ public class HealthApiCommunicatorTest {
         System.setProperty("dexmaker.dexcache", getApplicationContext().getCacheDir().getPath());
         retryPolicyFactory = new DefaultRetryPolicyFactory();
         mRequestQueue = Mockito.mock(RequestQueue.class);
-        mApiCommunicator = new HealthApiCommunicator("https://pay-api.gini.net/", new GiniHealthApiType(3), mRequestQueue, retryPolicyFactory);
+        mApiCommunicator = new HealthApiCommunicator("https://health-api.gini.net/", new GiniHealthApiType(3), mRequestQueue, retryPolicyFactory);
     }
 
     public byte[] createUploadData() {
@@ -107,7 +107,7 @@ public class HealthApiCommunicatorTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
         final Request request = requestCaptor.getValue();
-        assertEquals("https://pay-api.gini.net/documents/1234-1234/extractions", request.getUrl());
+        assertEquals("https://health-api.gini.net/documents/1234-1234/extractions", request.getUrl());
         assertEquals(POST, request.getMethod());
     }
 
@@ -167,7 +167,7 @@ public class HealthApiCommunicatorTest {
         verify(mRequestQueue).add(requestCaptor.capture());
         final Request request = requestCaptor.getValue();
 
-        assertEquals("https://pay-api.gini.net/documents/aa9a4630-8e05-11eb-ad19-3bfb1a96d239/pages", request.getUrl());
+        assertEquals("https://health-api.gini.net/documents/aa9a4630-8e05-11eb-ad19-3bfb1a96d239/pages", request.getUrl());
     }
 
 }

--- a/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiDocumentTaskManagerTest.java
+++ b/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiDocumentTaskManagerTest.java
@@ -280,7 +280,7 @@ public class HealthApiDocumentTaskManagerTest {
     @Test
     public void testCreatePaymentRequest() throws Exception {
         when(mApiCommunicator.postPaymentRequests(any(JSONObject.class), any(Session.class)))
-                .thenReturn(createLocationHeaderJSONTask("https://pay-api.gini.net/paymentRequests/7b5a7f79-ae7c-4040-b6cf-25cde58ad937"));
+                .thenReturn(createLocationHeaderJSONTask("https://health-api.gini.net/paymentRequests/7b5a7f79-ae7c-4040-b6cf-25cde58ad937"));
 
         Task<String> paymentRequestTask = mDocumentTaskManager.createPaymentRequest(new PaymentRequestInput("", "", "", "", "", null, ""));
         paymentRequestTask.waitForCompletion();

--- a/health-api-library/library/src/doc/source/guides/common-tasks.rst
+++ b/health-api-library/library/src/doc/source/guides/common-tasks.rst
@@ -62,7 +62,7 @@ Setting the document type hint
 To easily set the document type hint we introduced the ``DocumentType`` enum. It is safer and easier
 to use than a ``String``. For more details about the document type hints see the `Document Type
 Hints in the Gini API documentation
-<https://pay-api.gini.net/documentation/#document-types>`_.
+<https://health-api.gini.net/documentation/v3/#document-types>`_.
 
 .. _getting-extractions:
 

--- a/health-api-library/library/src/doc/source/guides/getting-started.rst
+++ b/health-api-library/library/src/doc/source/guides/getting-started.rst
@@ -77,7 +77,7 @@ Configure Pinning
 -----------------
 
 The following sample configuration shows how to set the public key pin for the two domains. The Gini
-Health API Library uses by default (``pay-api.gini.net`` and ``user.gini.net``). It should be saved under
+Health API Library uses by default (``health-api.gini.net`` and ``user.gini.net``). It should be saved under
 ``res/xml/network_security_config.xml``:
 
 .. code-block:: xml
@@ -88,7 +88,7 @@ Health API Library uses by default (``pay-api.gini.net`` and ``user.gini.net``).
             <trustkit-config
                 disableDefaultReportUri="true"
                 enforcePinning="true" />
-            <domain includeSubdomains="false">pay-api.gini.net</domain>
+            <domain includeSubdomains="false">health-api.gini.net</domain>
             <pin-set>
                 <!-- old *.gini.net public key-->
                 <pin digest="SHA-256">yGLLyvZLo2NNXeBNKJwx1PlCtm+YEVU6h2hxVpRa4l4=</pin>

--- a/health-api-library/library/src/doc/source/see_also.rst
+++ b/health-api-library/library/src/doc/source/see_also.rst
@@ -7,5 +7,5 @@ See also
 This section collects useful resources around Gini Health API Library for Android.
 
 * `Gini Health API Library for Android reference docs <https://developer.gini.net/gini-mobile-android/health-api-library/library/dokka/index.html>`_
-* `Gini Pay API Documentation <https://pay-api.gini.net/documentation/>`_
+* `Gini Health API Documentation <https://health-api.gini.net/documentation/v3/#gini-health-api-documentation-v3-0>`_
 * `Bolts framework <https://github.com/BoltsFramework/Bolts-Android/#tasks>`_.

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
@@ -18,7 +18,11 @@ import net.gini.android.health.sdk.requirement.AtLeastOneInstalledBankAppRequire
 import net.gini.android.health.sdk.requirement.Requirement
 import net.gini.android.health.sdk.requirement.RequirementsChecker
 import net.gini.android.health.sdk.review.ReviewFragment
-import net.gini.android.health.sdk.review.model.*
+import net.gini.android.health.sdk.review.model.PaymentDetails
+import net.gini.android.health.sdk.review.model.PaymentRequest
+import net.gini.android.health.sdk.review.model.ResultWrapper
+import net.gini.android.health.sdk.review.model.toPaymentDetails
+import net.gini.android.health.sdk.review.model.wrapToResult
 import java.lang.ref.WeakReference
 
 /**
@@ -157,7 +161,8 @@ class GiniHealth(
     suspend fun checkIfDocumentIsPayable(documentId: String): Boolean =
         with(documentManager) {
             getExtractions(getDocument(documentId))
-                .specificExtractions["iban"]?.value?.isNotEmpty() ?: false
+                .compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value?.isNotEmpty()
+                ?: false
         }
 
     internal fun setOpenBankState(state: PaymentState) {

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
@@ -21,6 +21,7 @@ import net.gini.android.health.sdk.review.ReviewFragment
 import net.gini.android.health.sdk.review.model.PaymentDetails
 import net.gini.android.health.sdk.review.model.PaymentRequest
 import net.gini.android.health.sdk.review.model.ResultWrapper
+import net.gini.android.health.sdk.review.model.getPaymentExtraction
 import net.gini.android.health.sdk.review.model.toPaymentDetails
 import net.gini.android.health.sdk.review.model.wrapToResult
 import java.lang.ref.WeakReference
@@ -161,7 +162,7 @@ class GiniHealth(
     suspend fun checkIfDocumentIsPayable(documentId: String): Boolean =
         with(documentManager) {
             getExtractions(getDocument(documentId))
-                .compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value?.isNotEmpty()
+                .compoundExtractions.getPaymentExtraction("iban")?.value?.isNotEmpty()
                 ?: false
         }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewViewModel.kt
@@ -198,8 +198,8 @@ internal class ReviewViewModel(internal val giniHealth: GiniHealth) : ViewModel(
                     is ResultWrapper.Success -> paymentDetails.value.extractions?.let { extractionsContainer ->
                         giniHealth.giniHealthAPI.documentManager.sendFeedback(
                             documentResult.value,
-                            extractionsContainer.specificExtractions.withFeedback(paymentDetails.value),
-                            extractionsContainer.compoundExtractions
+                            extractionsContainer.specificExtractions,
+                            extractionsContainer.compoundExtractions.withFeedback(paymentDetails.value)
                         )
                     }
                 }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
 import net.gini.android.core.api.models.Document
-import net.gini.android.core.api.models.PaymentRequestInput
+import net.gini.android.health.api.models.PaymentRequestInput
 import net.gini.android.health.sdk.GiniHealth
 import net.gini.android.health.sdk.preferences.UserPreference.PreferredBankApp
 import net.gini.android.health.sdk.preferences.UserPreferences

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/bank/Bank.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/bank/Bank.kt
@@ -11,7 +11,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.annotation.ColorInt
-import net.gini.android.core.api.models.PaymentProvider
+import net.gini.android.health.api.models.PaymentProvider
 
 internal const val Scheme = "ginipay" // It has to match the scheme in query tag in manifest
 private const val PaymentPath = "payment"

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/error/Errors.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/error/Errors.kt
@@ -1,8 +1,11 @@
 package net.gini.android.health.sdk.review.error
 
+/**
+ * Thrown when a bank was needed but none had been selected.
+ */
 class NoBankSelected : Throwable("No Bank Selected")
 
 /**
- * Thrown when there's no Payment Provider for the package name of the selected bank app.
+ * Thrown when there was no payment data in the document extractions.
  */
-class NoProviderForPackageName(packageName: String) : Throwable("No Provide for package $packageName")
+class NoPaymentDataExtracted : Throwable("No payment data extracted.")

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
@@ -15,10 +15,10 @@ data class PaymentDetails(
 ): Parcelable
 
 internal fun ExtractionsContainer.toPaymentDetails() = PaymentDetails(
-    recipient = specificExtractions["paymentRecipient"]?.value ?: "",
-    iban = specificExtractions["iban"]?.value ?: "",
-    amount = specificExtractions["amountToPay"]?.value?.toAmount() ?: "",
-    purpose = specificExtractions["paymentPurpose"]?.value ?: "",
+    recipient = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_recipient")?.value ?: "",
+    iban = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value ?: "",
+    amount = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("amount_to_pay")?.value?.toAmount() ?: "",
+    purpose = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_purpose")?.value ?: "",
     extractions = this
 )
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
@@ -2,9 +2,11 @@ package net.gini.android.health.sdk.review.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import net.gini.android.core.api.models.CompoundExtraction
 import net.gini.android.core.api.models.ExtractionsContainer
 import net.gini.android.core.api.models.SpecificExtraction
 import net.gini.android.health.sdk.review.error.NoPaymentDataExtracted
+import net.gini.android.health.sdk.util.toBackendFormat
 
 @Parcelize
 data class PaymentDetails(
@@ -20,12 +22,12 @@ internal fun ExtractionsContainer.toPaymentDetails(): PaymentDetails {
         throw NoPaymentDataExtracted()
     }
     return PaymentDetails(
-        recipient = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_recipient")?.value
+        recipient = compoundExtractions.getPaymentExtraction("payment_recipient")?.value
             ?: "",
-        iban = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value ?: "",
-        amount = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("amount_to_pay")?.value?.toAmount()
+        iban = compoundExtractions.getPaymentExtraction("iban")?.value ?: "",
+        amount = compoundExtractions.getPaymentExtraction("amount_to_pay")?.value?.toAmount()
             ?: "",
-        purpose = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_purpose")?.value ?: "",
+        purpose = compoundExtractions.getPaymentExtraction("payment_purpose")?.value ?: "",
         extractions = this
     )
 }
@@ -44,42 +46,56 @@ internal fun String.toAmount(): String {
  */
 val PaymentDetails.isPayable get() = iban.isNotEmpty()
 
-internal fun MutableMap<String, SpecificExtraction>.withFeedback(paymentDetails: PaymentDetails): Map<String, SpecificExtraction> {
-    this["paymentRecipient"] = this["paymentRecipient"].let { extraction ->
-        SpecificExtraction(
-            extraction?.name ?: "paymentRecipient",
-            paymentDetails.recipient,
-            extraction?.entity,
-            extraction?.box,
-            extraction?.candidate
-        )
-    }
-    this["iban"] = this["iban"].let { extraction ->
-        SpecificExtraction(
-            extraction?.name ?: "iban",
-            paymentDetails.iban,
-            extraction?.entity,
-            extraction?.box,
-            extraction?.candidate
-        )
-    }
-    this["amountToPay"] = this["amountToPay"].let { extraction ->
-        SpecificExtraction(
-            extraction?.name ?: "amountToPay",
-            paymentDetails.amount,
-            extraction?.entity,
-            extraction?.box,
-            extraction?.candidate
-        )
-    }
-    this["paymentPurpose"] = this["paymentPurpose"].let { extraction ->
-        SpecificExtraction(
-            extraction?.name ?: "paymentPurpose",
-            paymentDetails.purpose,
-            extraction?.entity,
-            extraction?.box,
-            extraction?.candidate
+internal fun MutableMap<String, CompoundExtraction>.withFeedback(paymentDetails: PaymentDetails): Map<String, CompoundExtraction> {
+    this["payment"] = this["payment"].let { payment ->
+        CompoundExtraction(
+            payment?.name ?: "payment",
+            payment?.specificExtractionMaps?.mapIndexed { index, specificExtractions ->
+                if (index > 0) return@mapIndexed specificExtractions
+
+                mutableMapOf<String, SpecificExtraction>().also { extractions ->
+                    extractions.putAll(specificExtractions)
+                    extractions["payment_recipient"] = extractions["payment_recipient"].let { extraction ->
+                        SpecificExtraction(
+                            extraction?.name ?: "payment_recipient",
+                            paymentDetails.recipient,
+                            extraction?.entity ?: "",
+                            extraction?.box,
+                            extraction?.candidate ?: emptyList()
+                        )
+                    }
+                    extractions["iban"] = extractions["iban"].let { extraction ->
+                        SpecificExtraction(
+                            extraction?.name ?: "iban",
+                            paymentDetails.iban,
+                            extraction?.entity ?: "",
+                            extraction?.box,
+                            extraction?.candidate ?: emptyList()
+                        )
+                    }
+                    extractions["amount_to_pay"] = extractions["amount_to_pay"].let { extraction ->
+                        SpecificExtraction(
+                            extraction?.name ?: "amount_to_pay",
+                            "${paymentDetails.amount.toBackendFormat()}:EUR",
+                            extraction?.entity ?: "",
+                            extraction?.box,
+                            extraction?.candidate ?: emptyList()
+                        )
+                    }
+                    extractions["payment_purpose"] = extractions["payment_purpose"].let { extraction ->
+                        SpecificExtraction(
+                            extraction?.name ?: "payment_purpose",
+                            paymentDetails.purpose,
+                            extraction?.entity ?: "",
+                            extraction?.box,
+                            extraction?.candidate ?: emptyList()
+                        )
+                    }
+                }
+            } ?: listOf()
         )
     }
     return this
 }
+
+internal fun MutableMap<String, CompoundExtraction>.getPaymentExtraction(name: String) = this["payment"]?.specificExtractionMaps?.get(0)?.get(name)

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import net.gini.android.core.api.models.ExtractionsContainer
 import net.gini.android.core.api.models.SpecificExtraction
+import net.gini.android.health.sdk.review.error.NoPaymentDataExtracted
 
 @Parcelize
 data class PaymentDetails(
@@ -14,13 +15,20 @@ data class PaymentDetails(
     internal val extractions: ExtractionsContainer? = null
 ): Parcelable
 
-internal fun ExtractionsContainer.toPaymentDetails() = PaymentDetails(
-    recipient = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_recipient")?.value ?: "",
-    iban = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value ?: "",
-    amount = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("amount_to_pay")?.value?.toAmount() ?: "",
-    purpose = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_purpose")?.value ?: "",
-    extractions = this
-)
+internal fun ExtractionsContainer.toPaymentDetails(): PaymentDetails {
+    if (!compoundExtractions.containsKey("payment")) {
+        throw NoPaymentDataExtracted()
+    }
+    return PaymentDetails(
+        recipient = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_recipient")?.value
+            ?: "",
+        iban = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")?.value ?: "",
+        amount = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("amount_to_pay")?.value?.toAmount()
+            ?: "",
+        purpose = compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_purpose")?.value ?: "",
+        extractions = this
+    )
+}
 
 internal fun String.toAmount(): String {
     val delimiterIndex = this.indexOf(":")

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/GiniHealthTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/GiniHealthTest.kt
@@ -32,15 +32,14 @@ val extractions = ExtractionsContainer(
             "amount_to_pay" to SpecificExtraction("amount_tp_pay", "123.56", "", null, listOf()),
             "payment_purpose" to SpecificExtraction("payment_purpose", "purpose", "", null, listOf()),
         )))
-    ), emptyList()
+    )
 )
 
 fun copyExtractions(extractions: ExtractionsContainer) = ExtractionsContainer(
     extractions.specificExtractions.toMap(),
     extractions.compoundExtractions.map { (name, compoundExtraction) ->
         name to CompoundExtraction(name, compoundExtraction.specificExtractionMaps.map { it.toMap() })
-    }.toMap(),
-    extractions.returnReasons.toList()
+    }.toMap()
 )
 
 @ExperimentalCoroutinesApi

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/requirement/RequirementsTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/requirement/RequirementsTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import net.gini.android.core.api.DocumentManager
 import net.gini.android.health.api.GiniHealthAPI
+import net.gini.android.health.api.HealthApiDocumentManager
 import net.gini.android.health.sdk.GiniHealth
 import net.gini.android.health.sdk.review.bank.packageInfosFixture
 import net.gini.android.health.sdk.review.bank.paymentProvidersFixture
@@ -32,7 +33,7 @@ class RequirementsTest {
     private var packageManager: PackageManager? = null
     private var giniHealth: GiniHealth? = null
     private var giniHealthAPI: GiniHealthAPI? = null
-    private var documentManager: DocumentManager? = null
+    private var documentManager: HealthApiDocumentManager? = null
 
     @Before
     fun setup() {

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/bank/BankTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/bank/BankTest.kt
@@ -10,7 +10,7 @@ import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import net.gini.android.core.api.models.PaymentProvider
+import net.gini.android.health.api.models.PaymentProvider
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
@@ -1,0 +1,154 @@
+package net.gini.android.health.sdk.review.model
+
+import net.gini.android.core.api.models.CompoundExtraction
+import net.gini.android.core.api.models.ExtractionsContainer
+import net.gini.android.core.api.models.SpecificExtraction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Created by Alpár Szotyori on 01.02.22.
+ *
+ * Copyright (c) 2022 Gini GmbH.
+ */
+class PaymentDetailsTest {
+
+    @Test
+    fun `Updates payment extractions with payment detail values for feedback`() {
+        // Given
+        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
+            "payment",
+            listOf(mapOf(
+                "payment_recipient" to SpecificExtraction(
+                    "payment_recipient",
+                    "John Doe",
+                    "", null, emptyList()
+                ),
+                "iban" to SpecificExtraction(
+                    "iban",
+                    "DE123456789",
+                    "", null, emptyList()
+                ),
+                "amount_to_pay" to SpecificExtraction(
+                    "amount_to_pay",
+                    "1.11:EUR",
+                    "", null, emptyList()
+                ),
+                "payment_purpose" to SpecificExtraction(
+                    "payment_purpose",
+                    "Testing",
+                    "", null, emptyList()
+                )
+            ))
+        ))
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99:EUR",
+            purpose = "Still testing"
+        )
+
+        // When
+        compoundExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals(paymentDetails.recipient, compoundExtractions.getPaymentExtraction("payment_recipient")?.value)
+        assertEquals(paymentDetails.iban, compoundExtractions.getPaymentExtraction("iban")?.value)
+        assertEquals(paymentDetails.amount, compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
+        assertEquals(paymentDetails.purpose, compoundExtractions.getPaymentExtraction("payment_purpose")?.value)
+    }
+
+    @Test
+    fun `Adds missing payment extraction when updating payment detail values for feedback`() {
+        // Given
+        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
+            "payment",
+            listOf(mapOf(
+                "iban" to SpecificExtraction(
+                    "iban",
+                    "DE123456789",
+                    "", null, emptyList()
+                ),
+                "amount_to_pay" to SpecificExtraction(
+                    "amount_to_pay",
+                    "1.11:EUR",
+                    "", null, emptyList()
+                ),
+                "payment_purpose" to SpecificExtraction(
+                    "payment_purpose",
+                    "Testing",
+                    "", null, emptyList()
+                )
+            ))
+        ))
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99:EUR",
+            purpose = "Still testing"
+        )
+
+        // When
+        compoundExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals(paymentDetails.recipient, compoundExtractions.getPaymentExtraction("payment_recipient")?.value)
+        assertEquals(paymentDetails.iban, compoundExtractions.getPaymentExtraction("iban")?.value)
+        assertEquals(paymentDetails.amount, compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
+        assertEquals(paymentDetails.purpose, compoundExtractions.getPaymentExtraction("payment_purpose")?.value)
+    }
+
+    @Test
+    fun `Converts amount_to_pay to backend format when updating payment detail values for feedback`() {
+        // Given
+        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
+            "payment",
+            listOf(mapOf(
+                "amount_to_pay" to SpecificExtraction(
+                    "amount_to_pay",
+                    "1.11:EUR",
+                    "", null, emptyList()
+                )
+            ))
+        ))
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99",
+            purpose = "Still testing"
+        )
+
+        // When
+        compoundExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals("9.99:EUR", compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
+    }
+
+    @Test
+    fun `Converts amount_to_pay extraction value to number`() {
+        // Given
+        val extractionsContainer = ExtractionsContainer(
+            emptyMap(),
+            mutableMapOf("payment" to CompoundExtraction(
+                "payment",
+                listOf(mapOf(
+                    "amount_to_pay" to SpecificExtraction(
+                        "amount_to_pay",
+                        "1.11:EUR",
+                        "", null, emptyList()
+                    )
+                ))
+            ))
+        )
+
+        // When
+        val paymentDetails = extractionsContainer.toPaymentDetails()
+
+        // Then
+        assertEquals("1.11", paymentDetails.amount)
+    }
+}


### PR DESCRIPTION
* Changes for working with the Health API.
* Throw `NoPaymentDataExtracted` when the extractions have no `payment` compound extraction.
* Update feedback sending to work with the Health API.