### PR TITLE
docs(health-api-library): Replace Pay API doc links with links to the Health API docs

### DIFF
--- a/health-api-library/README.md
+++ b/health-api-library/README.md
@@ -3,11 +3,9 @@
 Gini Health API Library for Android
 ===================================
 
-TODO: replace https://pay-api.gini.net links with the one for the Health API once it's available
-
-A library for communicating with the [Gini Health API](https://pay-api.gini.net/documentation/). It allows you to easily add
-[payment information extraction](https://pay-api.gini.net/documentation/#document-extractions-for-payment) capabilities
-to your app. It also enables your app to create or resolve [payment requests](https://pay-api.gini.net/documentation/#payments).
+A library for communicating with the [Gini Health API](https://health-api.gini.net/documentation/v3/#gini-health-api-documentation-v3-0).
+It allows you to easily add payment information extraction ([see "payment" compound extraction](https://health-api.gini.net/documentation/v3/#available-compound-extractions))
+capabilities to your app. It also enables your app to create payment requests and retrieve payment providers.
 
 The Gini Health API provides an information extraction service for analyzing invoices. Specifically it extracts information
 such as the document sender or the payment relevant information (amount to pay, IBAN, BIC, payment reference, etc.).

--- a/health-api-library/library/src/androidTest/assets/payment-provider.json
+++ b/health-api-library/library/src/androidTest/assets/payment-provider.json
@@ -11,5 +11,5 @@
     "background": "112233",
     "text": "44AAFF"
   },
-  "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+  "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
 }

--- a/health-api-library/library/src/androidTest/assets/payment-providers.json
+++ b/health-api-library/library/src/androidTest/assets/payment-providers.json
@@ -12,7 +12,7 @@
       "background": "112233",
       "text": "44AAFF"
     },
-    "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+    "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
   },
   {
     "id": "9a9b41f2-32f8-11eb-9fb5-e378350b0392",
@@ -27,6 +27,6 @@
       "background": "557788",
       "text": "00DDEE"
     },
-    "iconLocation": "https://pay-api.pia.stage.gini.net/paymentProviders/icon"
+    "iconLocation": "https://health-api.pia.stage.gini.net/paymentProviders/icon"
   }
 ]

--- a/health-api-library/library/src/androidTest/assets/payment-request.json
+++ b/health-api-library/library/src/androidTest/assets/payment-request.json
@@ -7,9 +7,9 @@
   "purpose": "ReNr AZ356789Z",
   "status": "paid",
   "_links": {
-    "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-    "payment": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-    "sourceDocumentLocation": "https://pay-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-    "_self": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
+    "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+    "payment": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+    "sourceDocumentLocation": "https://health-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+    "_self": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
   }
 }

--- a/health-api-library/library/src/androidTest/assets/payment-requests.json
+++ b/health-api-library/library/src/androidTest/assets/payment-requests.json
@@ -8,10 +8,10 @@
     "purpose": "ReNr AZ356789Z",
     "status": "paid",
     "_links": {
-      "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-      "payment": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-      "sourceDocumentLocation": "https://pay-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-      "self": "https://pay-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
+      "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+      "payment": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+      "sourceDocumentLocation": "https://health-api.gini.net/documents/88090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+      "self": "https://health-api.gini.net/paymentRequests/b4bd3e80-7bd1-11e4-95ab-000000000000"
     }
   },
   {
@@ -23,10 +23,10 @@
     "purpose": "ReNr BZ056789",
     "status": "paid",
     "_links": {
-      "paymentProvider": "https://pay-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
-      "payment": "https://pay-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000/payment",
-      "sourceDocumentLocation": "https://pay-api.gini.net/documents/48090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
-      "self": "https://pay-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000"
+      "paymentProvider": "https://health-api.gini.net/paymentProviders/7e72441c-32f8-11eb-b611-c3190574373c",
+      "payment": "https://health-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000/payment",
+      "sourceDocumentLocation": "https://health-api.gini.net/documents/48090c5a-32ed-11eb-9e1a-9f2bc4656a7d",
+      "self": "https://health-api.gini.net/paymentRequests/d4bd3e80-7bd1-11e4-95ab-000000000000"
     }
   }
 ]

--- a/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiCommunicatorTest.java
+++ b/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiCommunicatorTest.java
@@ -56,7 +56,7 @@ public class HealthApiCommunicatorTest {
         System.setProperty("dexmaker.dexcache", getApplicationContext().getCacheDir().getPath());
         retryPolicyFactory = new DefaultRetryPolicyFactory();
         mRequestQueue = Mockito.mock(RequestQueue.class);
-        mApiCommunicator = new HealthApiCommunicator("https://pay-api.gini.net/", new GiniHealthApiType(3), mRequestQueue, retryPolicyFactory);
+        mApiCommunicator = new HealthApiCommunicator("https://health-api.gini.net/", new GiniHealthApiType(3), mRequestQueue, retryPolicyFactory);
     }
 
     public byte[] createUploadData() {
@@ -107,7 +107,7 @@ public class HealthApiCommunicatorTest {
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mRequestQueue).add(requestCaptor.capture());
         final Request request = requestCaptor.getValue();
-        assertEquals("https://pay-api.gini.net/documents/1234-1234/extractions", request.getUrl());
+        assertEquals("https://health-api.gini.net/documents/1234-1234/extractions", request.getUrl());
         assertEquals(POST, request.getMethod());
     }
 
@@ -167,7 +167,7 @@ public class HealthApiCommunicatorTest {
         verify(mRequestQueue).add(requestCaptor.capture());
         final Request request = requestCaptor.getValue();
 
-        assertEquals("https://pay-api.gini.net/documents/aa9a4630-8e05-11eb-ad19-3bfb1a96d239/pages", request.getUrl());
+        assertEquals("https://health-api.gini.net/documents/aa9a4630-8e05-11eb-ad19-3bfb1a96d239/pages", request.getUrl());
     }
 
 }

--- a/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiDocumentTaskManagerTest.java
+++ b/health-api-library/library/src/androidTest/java/net/gini/android/health/api/HealthApiDocumentTaskManagerTest.java
@@ -280,7 +280,7 @@ public class HealthApiDocumentTaskManagerTest {
     @Test
     public void testCreatePaymentRequest() throws Exception {
         when(mApiCommunicator.postPaymentRequests(any(JSONObject.class), any(Session.class)))
-                .thenReturn(createLocationHeaderJSONTask("https://pay-api.gini.net/paymentRequests/7b5a7f79-ae7c-4040-b6cf-25cde58ad937"));
+                .thenReturn(createLocationHeaderJSONTask("https://health-api.gini.net/paymentRequests/7b5a7f79-ae7c-4040-b6cf-25cde58ad937"));
 
         Task<String> paymentRequestTask = mDocumentTaskManager.createPaymentRequest(new PaymentRequestInput("", "", "", "", "", null, ""));
         paymentRequestTask.waitForCompletion();

--- a/health-api-library/library/src/doc/source/guides/common-tasks.rst
+++ b/health-api-library/library/src/doc/source/guides/common-tasks.rst
@@ -62,7 +62,7 @@ Setting the document type hint
 To easily set the document type hint we introduced the ``DocumentType`` enum. It is safer and easier
 to use than a ``String``. For more details about the document type hints see the `Document Type
 Hints in the Gini API documentation
-<https://pay-api.gini.net/documentation/#document-types>`_.
+<https://health-api.gini.net/documentation/v3/#document-types>`_.
 
 .. _getting-extractions:
 

--- a/health-api-library/library/src/doc/source/guides/getting-started.rst
+++ b/health-api-library/library/src/doc/source/guides/getting-started.rst
@@ -77,7 +77,7 @@ Configure Pinning
 -----------------
 
 The following sample configuration shows how to set the public key pin for the two domains. The Gini
-Health API Library uses by default (``pay-api.gini.net`` and ``user.gini.net``). It should be saved under
+Health API Library uses by default (``health-api.gini.net`` and ``user.gini.net``). It should be saved under
 ``res/xml/network_security_config.xml``:
 
 .. code-block:: xml
@@ -88,7 +88,7 @@ Health API Library uses by default (``pay-api.gini.net`` and ``user.gini.net``).
             <trustkit-config
                 disableDefaultReportUri="true"
                 enforcePinning="true" />
-            <domain includeSubdomains="false">pay-api.gini.net</domain>
+            <domain includeSubdomains="false">health-api.gini.net</domain>
             <pin-set>
                 <!-- old *.gini.net public key-->
                 <pin digest="SHA-256">yGLLyvZLo2NNXeBNKJwx1PlCtm+YEVU6h2hxVpRa4l4=</pin>

--- a/health-api-library/library/src/doc/source/see_also.rst
+++ b/health-api-library/library/src/doc/source/see_also.rst
@@ -7,5 +7,5 @@ See also
 This section collects useful resources around Gini Health API Library for Android.
 
 * `Gini Health API Library for Android reference docs <https://developer.gini.net/gini-mobile-android/health-api-library/library/dokka/index.html>`_
-* `Gini Pay API Documentation <https://pay-api.gini.net/documentation/>`_
+* `Gini Health API Documentation <https://health-api.gini.net/documentation/v3/#gini-health-api-documentation-v3-0>`_
 * `Bolts framework <https://github.com/BoltsFramework/Bolts-Android/#tasks>`_.


### PR DESCRIPTION
I will add the following migration note to the release notes of Health API Library:

# Migrate from previous version

It was necessary to reorganise some classes. You only need to replace `core` with `health` for the following classes:
* Replace `net.gini.android.core.api.models.PaymentRequestInput` with `net.gini.android.health.api.models.PaymentRequestInput`.
* Replace `net.gini.android.core.api.models.PaymentProvider`with `net.gini.android.health.api.models.PaymentProvider`.
* Replace `net.gini.android.core.api.DocumentTaskManager`with `net.gini.android.health.api.HealthApiDocumentTaskManager`.
* Replace `net.gini.android.core.api.DocumentManager`
with `net.gini.android.health.api.HealthApiDocumentManager`.

The location of the payment extractions have moved to the compound extractions. Also the label names are now in snake case ([see "payment" compound extraction in the Health API docs](https://health-api.gini.net/documentation/v3/#available-compound-extractions)):
* Replace `extractionsContainer.specificExtractions["paymentRecipient"]` with `compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_recipient")`.
* Replace `extractionsContainer.specificExtractions["iban"]` with `compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("iban")`.
* Replace `extractionsContainer.specificExtractions["amountToPay"]` with `compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("amount_to_pay")`.
* Replace `extractionsContainer.specificExtractions["paymentPurpose"]` with `compoundExtractions["payment"]?.specificExtractionMaps?.get(0)?.get("payment_purpose")`.

