### PR TITLE
Pia 2179 pia 2022 fixes for pay api

### DIFF
--- a/bank-api-library/README.md
+++ b/bank-api-library/README.md
@@ -3,8 +3,6 @@
 Gini Bank API Library for Android
 ===================================
 
-TODO: replace https://pay-api.gini.net links with the one for the Bank API once it's available
-
 A library for communicating with the [Gini Bank API](https://pay-api.gini.net/documentation/). It allows you to easily add
 [payment information extraction](https://pay-api.gini.net/documentation/#document-extractions-for-payment) capabilities
 to your app. It also enables your app to create or resolve [payment requests](https://pay-api.gini.net/documentation/#payments).

--- a/bank-api-library/library/src/doc/source/see_also.rst
+++ b/bank-api-library/library/src/doc/source/see_also.rst
@@ -7,5 +7,5 @@ See also
 This section collects useful resources around the Gini Bank API Library for Android.
 
 * `Gini Bank API Library for Android reference docs <https://developer.gini.net/gini-mobile-android/bank-api-library/library/dokka/index.html>`_
-* `Gini Pay API Documentation <https://pay-api.gini.net/documentation/>`_
+* `Gini Bank API Documentation <https://pay-api.gini.net/documentation/>`_
 * `Bolts framework <https://github.com/BoltsFramework/Bolts-Android/#tasks>`_.

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayActivity.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayActivity.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import net.gini.android.core.api.models.PaymentRequest
-import net.gini.android.core.api.models.ResolvePaymentInput
+import net.gini.android.bank.api.models.ResolvePaymentInput
 import net.gini.android.bank.sdk.screenapiexample.databinding.ActivityPayBinding
 import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper
 import net.gini.android.bank.sdk.pay.getRequestId

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelInterface.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelInterface.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import kotlinx.coroutines.flow.StateFlow
 import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper
 import net.gini.android.core.api.models.PaymentRequest
-import net.gini.android.core.api.models.ResolvePaymentInput
-import net.gini.android.core.api.models.ResolvedPayment
+import net.gini.android.bank.api.models.ResolvePaymentInput
+import net.gini.android.bank.api.models.ResolvedPayment
 
 /**
  * Created by Alpár Szotyori on 19.01.22.

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelJava.java
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelJava.java
@@ -9,8 +9,8 @@ import net.gini.android.bank.sdk.GiniBank;
 import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper;
 import net.gini.android.bank.sdk.util.CoroutineContinuationHelper;
 import net.gini.android.core.api.models.PaymentRequest;
-import net.gini.android.core.api.models.ResolvePaymentInput;
-import net.gini.android.core.api.models.ResolvedPayment;
+import net.gini.android.bank.api.models.ResolvePaymentInput;
+import net.gini.android.bank.api.models.ResolvedPayment;
 
 import kotlinx.coroutines.flow.MutableStateFlow;
 import kotlinx.coroutines.flow.StateFlow;

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelKotlin.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/pay/PayViewModelKotlin.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import net.gini.android.core.api.models.PaymentRequest
-import net.gini.android.core.api.models.ResolvePaymentInput
-import net.gini.android.core.api.models.ResolvedPayment
+import net.gini.android.bank.api.models.ResolvePaymentInput
+import net.gini.android.bank.api.models.ResolvedPayment
 import net.gini.android.bank.sdk.screenapiexample.util.ResultWrapper
 import net.gini.android.bank.sdk.screenapiexample.util.wrapToResult
 import net.gini.android.bank.sdk.GiniBank

--- a/bank-sdk/sdk/src/doc/source/capture-features.rst
+++ b/bank-sdk/sdk/src/doc/source/capture-features.rst
@@ -138,8 +138,6 @@ to your app according to the user's changes.
 The ``amountToPay`` extraction is updated to be the sum of items the user decided to pay. It includes discounts and
 additional charges that might be present on the invoice.
 
-// TODO: update links after Bank API is available
-
 The extractions related to the return assistant are stored in the ``compoundExtractions`` field of the
 ``CaptureResult``. See the Gini Bank API's `documentation
 <https://pay-api.gini.net/documentation/#return-assistant-extractions>`_ to learn about the return assistant's compound
@@ -261,8 +259,6 @@ data extractions as described in the `Sending Feedback <integration.html#sending
 
 Custom Networking Implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-// TODO: update links after Bank API is available
 
 If you use your own networking implementation and directly communicate with the Gini Bank API then see `this section
 <https://pay-api.gini.net/documentation/#submitting-feedback-on-extractions>`_ in its documentation on how to send

--- a/bank-sdk/sdk/src/doc/source/integration.rst
+++ b/bank-sdk/sdk/src/doc/source/integration.rst
@@ -101,7 +101,7 @@ Networking
 ~~~~~~~~~~
 
 The Gini Bank SDK allows you to use the default networking implementation of our Gini Capture SDK to communicate with the Gini
-Pay API. You may also implement your own networking layer.
+Bank API. You may also implement your own networking layer.
 
 .. note::
 
@@ -168,8 +168,6 @@ Sending Feedback
 Your app should send feedback for the extractions the Gini Bank API delivered. Feedback should be sent *only* for the
 extractions the user has seen and accepted (or corrected).
 
-// TODO: update links after Bank API is available
-
 For addition information about feedback see the `Gini Bank API documentation
 <https://pay-api.gini.net/documentation/#send-feedback-and-get-even-better-extractions-next-time>`_.
 
@@ -223,8 +221,6 @@ The example below shows how to correct extractions and send feedback using the d
 
 Custom Implementation
 +++++++++++++++++++++
-
-// TODO: update links after Bank API is available
 
 If you use your own networking implementation and directly communicate with the Gini Bank API then see `this section
 <https://pay-api.gini.net/documentation/#submitting-feedback-on-extractions>`_ in its documentation on how to send

--- a/bank-sdk/sdk/src/doc/source/migrating-from-gvl.rst
+++ b/bank-sdk/sdk/src/doc/source/migrating-from-gvl.rst
@@ -22,8 +22,6 @@ the Gini Vision Library did.
 Gini Bank API Library
 --------------------
 
-// TODO: update links after Bank API is available
-
 The `Gini Bank API Library <https://github.com/gini/gini-mobile-android/tree/main/bank-api-library>`_ supersedes the Gini API SDK and is used
 to communicate with the `Gini Bank API <https://pay-api.gini.net/documentation/#gini-pay-api-documentation-v1-0>`_.
 

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
@@ -12,8 +12,8 @@ import net.gini.android.capture.requirements.GiniCaptureRequirements
 import net.gini.android.capture.requirements.RequirementsReport
 import net.gini.android.capture.util.CancellationToken
 import net.gini.android.core.api.models.PaymentRequest
-import net.gini.android.core.api.models.ResolvePaymentInput
-import net.gini.android.core.api.models.ResolvedPayment
+import net.gini.android.bank.api.models.ResolvePaymentInput
+import net.gini.android.bank.api.models.ResolvedPayment
 import net.gini.android.bank.sdk.GiniBank.releaseCapture
 import net.gini.android.bank.sdk.GiniBank.setCaptureConfiguration
 import net.gini.android.bank.sdk.GiniBank.startCaptureFlow

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/pay/PaymentRequestIntent.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/pay/PaymentRequestIntent.kt
@@ -2,7 +2,7 @@ package net.gini.android.bank.sdk.pay
 
 import android.content.Intent
 import android.net.Uri
-import net.gini.android.core.api.models.ResolvedPayment
+import net.gini.android.bank.api.models.ResolvedPayment
 
 internal const val Scheme = "ginipay" // It has to match the scheme in query tag in manifest
 private const val PaymentPath = "payment"

--- a/capture-sdk/component-api-example-app/src/main/java/net/gini/android/capture/component/MainActivity.java
+++ b/capture-sdk/component-api-example-app/src/main/java/net/gini/android/capture/component/MainActivity.java
@@ -44,8 +44,6 @@ public class MainActivity extends AppCompatActivity {
     private RuntimePermissionHandler mRuntimePermissionHandler;
     private TextView mTextAppVersion;
     private TextView mTextGiniCaptureSdkVersion;
-    private Spinner mGiniApiTypeSpinner;
-    private GiniApiType mGiniApiType = GiniApiType.BANK;
 
     public static final int RESULT_ERROR = RESULT_FIRST_USER + 1;
     public static final String EXTRA_OUT_ERROR = "EXTRA_OUT_ERROR";
@@ -101,15 +99,12 @@ public class MainActivity extends AppCompatActivity {
         app.clearGiniCaptureNetworkInstances();
         final GiniCapture.Builder builder = GiniCapture.newInstance()
                 .setGiniCaptureNetworkService(
-                        app.getGiniCaptureNetworkService("ComponentAPI",
-                                mGiniApiType)
+                        app.getGiniCaptureNetworkService("ComponentAPI")
                 ).setGiniCaptureNetworkApi(app.getGiniCaptureNetworkApi());
-        if (mGiniApiType == GiniApiType.BANK) {
-            builder.setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
-                    .setFileImportEnabled(true)
-                    .setQRCodeScanningEnabled(true)
-                    .setMultiPageEnabled(true);
-        }
+        builder.setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
+                .setFileImportEnabled(true)
+                .setQRCodeScanningEnabled(true)
+                .setMultiPageEnabled(true);
         builder.setFlashButtonEnabled(true);
         // Uncomment to turn off the camera flash by default
 //        builder.setFlashOnByDefault(false);
@@ -156,18 +151,6 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(final View v) {
                 startGiniCapture();
-            }
-        });
-        mGiniApiTypeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(final AdapterView<?> parent, final View view,
-                    final int position, final long id) {
-                mGiniApiType = GiniApiType.valueOf(mGiniApiTypeSpinner.getSelectedItem().toString());
-            }
-
-            @Override
-            public void onNothingSelected(final AdapterView<?> parent) {
-
             }
         });
     }
@@ -220,7 +203,6 @@ public class MainActivity extends AppCompatActivity {
         mButtonStartGiniCapture = findViewById(R.id.button_start_gini_capture);
         mTextGiniCaptureSdkVersion = findViewById(R.id.text_gini_capture_version);
         mTextAppVersion = findViewById(R.id.text_app_version);
-        mGiniApiTypeSpinner = findViewById(R.id.gini_api_type_spinner);
     }
 
     private void createRuntimePermissionsHandler() {

--- a/capture-sdk/component-api-example-app/src/main/res/layout/activity_main.xml
+++ b/capture-sdk/component-api-example-app/src/main/res/layout/activity_main.xml
@@ -9,26 +9,6 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="net.gini.android.capture.component.MainActivity">
 
-    <Spinner
-        android:id="@+id/gini_api_type_spinner"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/button_start_gini_capture"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="24dp"
-        android:entries="@array/gini_api_types" />
-
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/gini_api_type_spinner"
-        android:layout_alignEnd="@+id/gini_api_type_spinner"
-        android:layout_alignStart="@+id/gini_api_type_spinner"
-        android:layout_marginBottom="8dp"
-        android:gravity="center"
-        android:text="@string/gini_api_type_label" />
-
     <Button
         android:id="@+id/button_start_gini_capture"
         android:layout_width="match_parent"

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
@@ -75,7 +75,7 @@ public class GiniCaptureDefaultNetworkApi implements GiniCaptureNetworkApi {
                 .getDocumentTaskManager();
         final net.gini.android.core.api.models.Document document =
                 mDefaultNetworkService.getAnalyzedGiniApiDocument();
-        // We require the Gini Bank API lib's net.gini.android.models.Document for sending the feedback
+        // We require the Gini Bank API lib's net.gini.android.core.api.models.Document for sending the feedback
         if (document != null) {
             LOG.debug("Send feedback for api document {} using extractions {}", document.getId(),
                     extractions);

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
 
 import com.android.volley.VolleyError;
 
-import net.gini.android.core.api.DocumentTaskManager;
+import net.gini.android.bank.api.BankApiDocumentTaskManager;
 import net.gini.android.capture.GiniCapture;
 import net.gini.android.capture.internal.camera.api.UIExecutor;
 import net.gini.android.capture.logging.ErrorLog;
@@ -71,7 +71,7 @@ public class GiniCaptureDefaultNetworkApi implements GiniCaptureNetworkApi {
     @Override
     public void sendFeedback(@NonNull final Map<String, GiniCaptureSpecificExtraction> extractions,
                              @NonNull final GiniCaptureNetworkCallback<Void, Error> callback) {
-        final DocumentTaskManager documentTaskManager = mDefaultNetworkService.getGiniApi()
+        final BankApiDocumentTaskManager documentTaskManager = mDefaultNetworkService.getGiniApi()
                 .getDocumentTaskManager();
         final net.gini.android.core.api.models.Document document =
                 mDefaultNetworkService.getAnalyzedGiniApiDocument();

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -33,7 +33,7 @@ import net.gini.android.capture.network.model.ReturnReasonsMapper;
 import net.gini.android.capture.network.model.SpecificExtractionMapper;
 import net.gini.android.capture.util.CancellationToken;
 import net.gini.android.capture.util.NoOpCancellationToken;
-import net.gini.android.core.api.models.ExtractionsContainer;
+import net.gini.android.bank.api.models.ExtractionsContainer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
@@ -3,7 +3,7 @@ package net.gini.android.capture.network.logging
 import com.android.volley.VolleyError
 import net.gini.android.bank.api.BuildConfig
 import net.gini.android.capture.logging.ErrorLog
-import net.gini.android.core.api.requests.ErrorEvent
+import net.gini.android.bank.api.requests.ErrorEvent
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.nio.charset.Charset

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/model/ReturnReasonsMapper.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/model/ReturnReasonsMapper.java
@@ -1,6 +1,6 @@
 package net.gini.android.capture.network.model;
 
-import net.gini.android.core.api.models.ReturnReason;
+import net.gini.android.bank.api.models.ReturnReason;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 
 /**
- * Helper class to map the {@link net.gini.android.models.ReturnReason} from the Gini API SDK to the Gini Capture
+ * Helper class to map the {@link net.gini.android.bank.api.models.ReturnReason} from the Gini API SDK to the Gini Capture
  * Library's {@link GiniCaptureReturnReason} and vice versa.
  */
 public class ReturnReasonsMapper {

--- a/capture-sdk/example-app-shared-code/src/main/java/net/gini/android/capture/example/shared/BaseExampleApp.java
+++ b/capture-sdk/example-app-shared-code/src/main/java/net/gini/android/capture/example/shared/BaseExampleApp.java
@@ -73,8 +73,7 @@ public abstract class BaseExampleApp extends MultiDexApplication {
     }
 
     @NonNull
-    public GiniCaptureNetworkService getGiniCaptureNetworkService(@NonNull final String appFlowApiType,
-                                                                  @NonNull final GiniApiType giniApiType) {
+    public GiniCaptureNetworkService getGiniCaptureNetworkService(@NonNull final String appFlowApiType) {
         final String clientId = getClientId();
         final String clientSecret = getClientSecret();
         if (TextUtils.isEmpty(clientId) || TextUtils.isEmpty(clientSecret)) {
@@ -87,14 +86,10 @@ public abstract class BaseExampleApp extends MultiDexApplication {
             final DocumentMetadata documentMetadata = new DocumentMetadata();
             documentMetadata.setBranchId("GCSExampleAndroid");
             documentMetadata.add("AppFlow", appFlowApiType);
-            if (giniApiType == GiniApiType.BANK) {
-                mGiniCaptureNetworkService = GiniCaptureDefaultNetworkService.builder(this)
-                        .setClientCredentials(clientId, clientSecret, "example.com")
-                        .setDocumentMetadata(documentMetadata)
+            mGiniCaptureNetworkService = GiniCaptureDefaultNetworkService.builder(this)
+                    .setClientCredentials(clientId, clientSecret, "example.com")
+                    .setDocumentMetadata(documentMetadata)
                         .build();
-            } else {
-                throw new UnsupportedOperationException("Unknown Gini API type: " + giniApiType);
-            }
         }
         return mGiniCaptureNetworkService;
     }

--- a/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/MainActivity.java
+++ b/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/MainActivity.java
@@ -73,9 +73,7 @@ public class MainActivity extends AppCompatActivity {
     private RuntimePermissionHandler mRuntimePermissionHandler;
     private TextView mTextGiniCaptureSdkVersion;
     private TextView mTextAppVersion;
-    private Spinner mGiniApiTypeSpinner;
     private CancellationToken mFileImportCancellationToken;
-    private GiniApiType mGiniApiType = GiniApiType.BANK;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -232,18 +230,6 @@ public class MainActivity extends AppCompatActivity {
                 startGiniCaptureSdk();
             }
         });
-        mGiniApiTypeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(final AdapterView<?> parent, final View view,
-                    final int position, final long id) {
-                mGiniApiType = GiniApiType.valueOf(mGiniApiTypeSpinner.getSelectedItem().toString());
-            }
-
-            @Override
-            public void onNothingSelected(final AdapterView<?> parent) {
-
-            }
-        });
     }
 
     private void startGiniCaptureSdk() {
@@ -317,15 +303,12 @@ public class MainActivity extends AppCompatActivity {
         app.clearGiniCaptureNetworkInstances();
         final GiniCapture.Builder builder = GiniCapture.newInstance()
                 .setGiniCaptureNetworkService(
-                        app.getGiniCaptureNetworkService("ScreenAPI",
-                                mGiniApiType)
+                        app.getGiniCaptureNetworkService("ScreenAPI")
                 ).setGiniCaptureNetworkApi(app.getGiniCaptureNetworkApi());
-        if (mGiniApiType == GiniApiType.BANK) {
-            builder.setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
-                    .setFileImportEnabled(true)
-                    .setQRCodeScanningEnabled(true)
-                    .setMultiPageEnabled(true);
-        }
+        builder.setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
+                .setFileImportEnabled(true)
+                .setQRCodeScanningEnabled(true)
+                .setMultiPageEnabled(true);
         builder.setFlashButtonEnabled(true);
         builder.setEventTracker(new GiniCaptureEventTracker());
         builder.setCustomErrorLoggerListener(new CustomErrorLoggerListener());
@@ -378,7 +361,6 @@ public class MainActivity extends AppCompatActivity {
         mButtonStartScanner = (Button) findViewById(R.id.button_start_scanner);
         mTextGiniCaptureSdkVersion = (TextView) findViewById(R.id.text_gini_capture_version);
         mTextAppVersion = (TextView) findViewById(R.id.text_app_version);
-        mGiniApiTypeSpinner = findViewById(R.id.gini_api_type_spinner);
     }
 
     private ArrayList<OnboardingPage> getOnboardingPages() {

--- a/capture-sdk/screen-api-example-app/src/main/res/layout/activity_main.xml
+++ b/capture-sdk/screen-api-example-app/src/main/res/layout/activity_main.xml
@@ -36,24 +36,4 @@
         android:layout_alignParentBottom="true"
         tools:text="v1.0.0" />
 
-    <Spinner
-        android:id="@+id/gini_api_type_spinner"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/button_start_scanner"
-        android:layout_centerHorizontal="true"
-        android:layout_marginBottom="24dp"
-        android:entries="@array/gini_api_types" />
-
-    <TextView
-        android:id="@+id/textView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_above="@+id/gini_api_type_spinner"
-        android:layout_alignEnd="@+id/gini_api_type_spinner"
-        android:layout_alignStart="@+id/gini_api_type_spinner"
-        android:layout_marginBottom="8dp"
-        android:gravity="center"
-        android:text="@string/gini_api_type_label" />
-
 </RelativeLayout>

--- a/capture-sdk/sdk/src/doc/source/integration.rst
+++ b/capture-sdk/sdk/src/doc/source/integration.rst
@@ -166,8 +166,6 @@ Sending Feedback
 Your app should send feedback for the extractions the Gini Bank API delivered. Feedback should be sent *only* for the
 extractions the user has seen and accepted (or corrected).
 
-// TODO: update links after Bank API is available
-
 For additional information about feedback see the `Gini Bank API documentation
 <https://pay-api.gini.net/documentation/#send-feedback-and-get-even-better-extractions-next-time>`_.
 
@@ -223,8 +221,6 @@ The example below shows how to correct extractions and send feedback using the d
 
 Custom Implementation
 ^^^^^^^^^^^^^^^^^^^^^
-
-// TODO: update links after Bank API is available
 
 If you use your own networking implementation and directly communicate with the Gini Bank API then see `this section
 <https://pay-api.gini.net/documentation/#submitting-feedback-on-extractions>`_ in its documentation on how to send

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/PaymentRequest.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/PaymentRequest.kt
@@ -4,7 +4,7 @@ import java.util.*
 import net.gini.android.core.api.response.PaymentRequestResponse
 
 data class PaymentRequest(
-    val paymentProviderId: String,
+    val paymentProviderId: String?,
     val requesterUri: String?,
     val recipient: String,
     val iban: String,

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/response/PaymentRequestResponse.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/response/PaymentRequestResponse.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class PaymentRequestResponse(
-    @Json(name = "paymentProvider") val paymentProvider: String,
+    @Json(name = "paymentProvider") val paymentProvider: String?,
     @Json(name = "requesterUri") val requesterUri: String?,
     @Json(name = "recipient") val recipient: String,
     @Json(name = "iban") val iban: String,


### PR DESCRIPTION
* Fix Capture SDK and Bank SDK to work with the updated Bank API Library.
* Fix payment request parsing in the Core API Library when `paymentProvider` is not available. 
  This happens when using the Pay API in the Bank API Library. The Health API Library was not affected.