### PR TITLE
Pia 2278 expose document

### DIFF
--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -54,6 +54,39 @@ jobs:
           name: capture-sdk-unit-test-coverage
           path: capture-sdk/sdk/build/jacoco/jacocoHtml
 
+  default-network-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: run unit tests
+        run: ./gradlew capture-sdk:default-network:testDebugUnitTest
+
+      - name: archive unit test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: capture-sdk-default-network-unit-test-results
+          path: capture-sdk/default-network/build/reports/tests
+
+      - name: create unit test coverage report
+        run: ./gradlew capture-sdk:default-network:jacocoTestDebugUnitTestReport
+
+      - name: archive unit test coverage report
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: capture-sdk-default-network-unit-test-coverage
+          path: capture-sdk/default-network/build/jacoco/jacocoHtml
+
   default-network-instrumented-test:
     runs-on: macos-latest
     steps:

--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/ExtractionsActivity.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/ExtractionsActivity.kt
@@ -16,6 +16,10 @@ import net.gini.android.capture.network.GiniCaptureNetworkCallback
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
 import net.gini.android.bank.sdk.screenapiexample.R
 import net.gini.android.bank.sdk.screenapiexample.databinding.ActivityExtractionsBinding
+import net.gini.android.capture.network.GiniCaptureDefaultNetworkApi
+import net.gini.android.capture.network.GiniCaptureDefaultNetworkService
+import net.gini.android.capture.network.GiniCaptureNetworkService
+import org.koin.android.ext.android.inject
 
 /**
  * Displays the Pay5 extractions: paymentRecipient, iban, bic, amount and paymentReference.
@@ -28,13 +32,20 @@ class ExtractionsActivity : AppCompatActivity() {
 
     private var mExtractions: MutableMap<String, GiniCaptureSpecificExtraction> = hashMapOf()
     private lateinit var mExtractionsAdapter: ExtractionsAdapter
+    private val defaultNetworkService: GiniCaptureDefaultNetworkService by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityExtractionsBinding.inflate(layoutInflater)
         setContentView(binding.root)
         readExtras()
+        showAnalyzedDocumentId()
         setUpRecyclerView(binding)
+    }
+
+    private fun showAnalyzedDocumentId() {
+        val documentId = defaultNetworkService.analyzedGiniApiDocument?.id ?: ""
+        binding.textDocumentId.text = getString(R.string.analyzed_document_id, documentId)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/bank-sdk/screen-api-example-app/src/main/res/layout/activity_extractions.xml
+++ b/bank-sdk/screen-api-example-app/src/main/res/layout/activity_extractions.xml
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="net.gini.android.bank.sdk.screenapiexample.ExtractionsActivity">
+
+    <TextView
+        android:id="@+id/text_document_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
+        android:paddingTop="10dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        tools:text="Analyzed Gini Bank API Document ID: asdadsasd-asdadsasd-asdadsasd-asdadsasd-asdadsasd"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview_extractions"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
-        tools:listitem="@layout/item_extraction" />
+        tools:listitem="@layout/item_extraction"
+        android:layout_below="@id/text_document_id"/>
 
     <LinearLayout
         android:id="@+id/layout_progress"
@@ -19,7 +32,8 @@
         android:layout_gravity="center"
         android:orientation="vertical"
         android:visibility="gone"
-        tools:visibility="visible">
+        tools:visibility="visible"
+        android:layout_centerInParent="true">
 
         <ProgressBar
             android:layout_width="wrap_content"
@@ -39,4 +53,4 @@
             android:textSize="18sp"
             android:textStyle="bold" />
     </LinearLayout>
-</FrameLayout>
+</RelativeLayout>

--- a/bank-sdk/screen-api-example-app/src/main/res/values/strings.xml
+++ b/bank-sdk/screen-api-example-app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="custom_help_screen_title">Custom Help Screen</string>
     <string name="custom_help_screen_greeting">This is a custom help screen.</string>
 
+    <string name="analyzed_document_id">Analyzed Gini Bank API Document ID: %s</string>
+
     <!-- String customization examples -->
 
     <!--<string name="gc_title_camera">Dokument fotografieren</string>-->

--- a/bank-sdk/sdk/src/doc/source/integration.rst
+++ b/bank-sdk/sdk/src/doc/source/integration.rst
@@ -149,6 +149,9 @@ You can call ``GiniCaptureDefaultNetworkService.getAnalyzedGiniApiDocument()`` a
 extractions to your application. It returns the Gini Bank API document which was created when the user uploaded an
 image or pdf for analysis.
 
+When extractions were retrieved without using the Gini Bank API, then it will return ``null``. For example when the
+extractions came from an EPS QR Code.
+
 .. note::
 
     Make sure to call it before calling ``GiniCaptureDefaultNetworkService.cleanup()`` or ``GiniBank.releaseCapture()``.

--- a/bank-sdk/sdk/src/doc/source/integration.rst
+++ b/bank-sdk/sdk/src/doc/source/integration.rst
@@ -142,6 +142,18 @@ For all configuration options of the default networking implementation see the d
 and `GiniCaptureDefaultNetworkApi.Builder
 <https://developer.gini.net/gini-mobile-android/capture-sdk/default-network/dokka/default-network/net.gini.android.capture.network/-gini-capture-default-network-api/-builder/index.html>`_.
 
+Retrieve the Analyzed Document
+++++++++++++++++++++++++++++++
+
+You can call ``GiniCaptureDefaultNetworkService.getAnalyzedGiniApiDocument()`` after the Gini Bank SDK has returned
+extractions to your application. It returns the Gini Bank API document which was created when the user uploaded an
+image or pdf for analysis.
+
+.. note::
+
+    Make sure to call it before calling ``GiniCaptureDefaultNetworkService.cleanup()`` or ``GiniBank.releaseCapture()``.
+    Otherwise the analyzed document won't be available anymore.
+
 Custom Implementation
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/capture-sdk/default-network/build.gradle.kts
+++ b/capture-sdk/default-network/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
     id("com.android.library")
     kotlin("android")
     kotlin("kapt")
+    id("com.hiya.jacoco-android")
+}
+
+jacoco {
+    toolVersion = libs.versions.jacoco.get()
 }
 
 android {

--- a/capture-sdk/default-network/build.gradle.kts
+++ b/capture-sdk/default-network/build.gradle.kts
@@ -48,8 +48,12 @@ dependencies {
     implementation(libs.androidx.annotation)
 
     testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.turbine)
+    testImplementation(libs.androidx.test.junit)
+    testImplementation(libs.robolectric)
     testImplementation(libs.truth)
-    testImplementation(libs.mockito.core)
 
     androidTestImplementation(libs.moshi.core)
     kaptAndroidTest(libs.moshi.codegen)

--- a/capture-sdk/default-network/build.gradle.kts
+++ b/capture-sdk/default-network/build.gradle.kts
@@ -87,7 +87,7 @@ tasks.register<CreatePropertiesTask>("injectTestProperties") {
 }
 
 afterEvaluate {
-    tasks.filter { it.name.endsWith("test", ignoreCase = true) }.forEach {
+    tasks.filter { it.name.endsWith("androidTest", ignoreCase = true) }.forEach {
         it.dependsOn(tasks.getByName("injectTestProperties"))
     }
 }

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -346,8 +346,17 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
         return true;
     }
 
+    /**
+     * Call this method to retrieve the document which was created when the user uploaded an image or a pdf for
+     * analysis.
+     * <p>
+     * You should call this method only after the Gini Capture SDK returned the extraction results and before
+     * you call {@link GiniCaptureDefaultNetworkService#cleanup()} or {@link GiniCapture#cleanup(Context)}.
+     *
+     * @return the last analyzed Gini Bank API {@link net.gini.android.core.api.models.Document}
+     */
     @Nullable
-    net.gini.android.core.api.models.Document getAnalyzedGiniApiDocument() {
+    public net.gini.android.core.api.models.Document getAnalyzedGiniApiDocument() {
         return mAnalyzedGiniApiDocument;
     }
 

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -350,6 +350,9 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
      * Call this method to retrieve the document which was created when the user uploaded an image or a pdf for
      * analysis.
      * <p>
+     * It returns `null` when extractions were retrieved without using the Gini Bank API.
+     * For example when the extractions came from an EPS QR code.
+     * <p>
      * You should call this method only after the Gini Capture SDK returned the extraction results and before
      * you call {@link GiniCaptureDefaultNetworkService#cleanup()} or {@link GiniCapture#cleanup(Context)}.
      *

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -60,8 +60,8 @@ import bolts.Task;
 /**
  * Default implementation of the network related tasks required by the Gini Capture SDK.
  *
- * <p> Relies on the <a href="http://developer.gini.net/gini-pay-api-lib-android/">Gini Bank API lib</a> for
- * executing the requests, which implements communication with the Gini API using generated
+ * <p> Relies on the <a href="https://developer.gini.net/gini-mobile-android/bank-api-library/library/html/">Gini Bank API Library</a> for
+ * executing the requests, which implements communication with the Gini Bank API using generated
  * anonymous Gini users.
  *
  * <p><b>Important:</b> Access to the Gini User Center API is required which is restricted to

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -14,8 +14,8 @@ import androidx.annotation.XmlRes;
 import com.android.volley.Cache;
 import com.android.volley.VolleyError;
 
+import net.gini.android.bank.api.BankApiDocumentTaskManager;
 import net.gini.android.core.api.DocumentMetadata;
-import net.gini.android.core.api.DocumentTaskManager;
 import net.gini.android.bank.api.GiniBankAPI;
 import net.gini.android.bank.api.GiniBankAPIBuilder;
 import net.gini.android.core.api.authorization.CredentialsStore;
@@ -119,7 +119,7 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
             callback.failure(error);
             return new NoOpCancellationToken();
         }
-        final DocumentTaskManager documentTaskManager = mGiniApi.getDocumentTaskManager();
+        final BankApiDocumentTaskManager documentTaskManager = mGiniApi.getDocumentTaskManager();
         final Task<net.gini.android.core.api.models.Document> createDocumentTask;
         if (mDocumentMetadata != null) {
             createDocumentTask = documentTaskManager.createPartialDocument(document.getData(),

--- a/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
+++ b/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
@@ -1,0 +1,101 @@
+package net.gini.android.capture.network
+
+import android.net.Uri
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import bolts.Task
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import net.gini.android.bank.api.BankApiDocumentTaskManager
+import net.gini.android.bank.api.GiniBankAPI
+import net.gini.android.capture.Document
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import java.lang.Thread.sleep
+import java.text.DateFormat
+import java.util.*
+import kotlin.collections.LinkedHashMap
+
+/**
+ * Created by Alpár Szotyori on 25.02.22.
+ *
+ * Copyright (c) 2022 Gini GmbH.
+ */
+
+@RunWith(AndroidJUnit4::class)
+class GiniCaptureDefaultNetworkServiceTest {
+
+    @Test
+    fun `allows retrieving the analyzed Gini Bank API document after analysis`() {
+        // Given
+        // Mock Gini Bank API documents
+        val partialDocument = net.gini.android.core.api.models.Document(
+            "id1",
+            net.gini.android.core.api.models.Document.ProcessingState.COMPLETED,
+            "filename1",
+            1,
+            Date(),
+            net.gini.android.core.api.models.Document.SourceClassification.SCANNED,
+            Uri.EMPTY,
+            listOf(),
+            listOf()
+        )
+
+        val compositeDocument = net.gini.android.core.api.models.Document(
+            "id2",
+            net.gini.android.core.api.models.Document.ProcessingState.COMPLETED,
+            "filename2",
+            1,
+            Date(),
+            net.gini.android.core.api.models.Document.SourceClassification.COMPOSITE,
+            Uri.EMPTY,
+            listOf(),
+            listOf()
+        )
+
+        // Mock DocumentTaskManager returning the mock documents
+        val documentTaskManager = mockk<BankApiDocumentTaskManager>()
+        every { documentTaskManager.createPartialDocument(any(), any(), null, null) }
+            .returns(
+                Task.forResult(
+                    partialDocument
+                )
+            )
+        every { documentTaskManager.createCompositeDocument(any<LinkedHashMap<net.gini.android.core.api.models.Document, Int>>(), any()) }
+            .returns(
+                Task.forResult(
+                    compositeDocument
+                )
+            )
+        every { documentTaskManager.pollDocument(any()) } returns Task.forResult(compositeDocument)
+        every { documentTaskManager.getAllExtractions(any()) } returns Task.forResult(mockk())
+
+        // Mock GiniBankAPI
+        val bankApi = mockk<GiniBankAPI>()
+        every { bankApi.documentTaskManager } returns documentTaskManager
+
+        val networkService = GiniCaptureDefaultNetworkService(bankApi, null)
+
+        // Mock Gini Capture SDK document
+        val captureDocument = mockk<Document>()
+        every { captureDocument.id } returns "id"
+        every { captureDocument.data } returns byteArrayOf()
+        every { captureDocument.mimeType } returns "image/jpeg"
+
+        // When
+        networkService.upload(captureDocument, mockk(relaxed = true))
+
+        // Wait for queued runnables to execute
+        shadowOf(Looper.getMainLooper()).idle()
+
+        networkService.analyze(linkedMapOf(partialDocument.id to 0), mockk(relaxed = true))
+
+        // Wait for queued runnables to execute
+        shadowOf(Looper.getMainLooper()).idle()
+
+        // Then
+        assertThat(networkService.analyzedGiniApiDocument).isEqualTo(compositeDocument)
+    }
+}

--- a/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/ExtractionsActivity.kt
+++ b/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/ExtractionsActivity.kt
@@ -1,8 +1,13 @@
 package net.gini.android.capture.screen
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -12,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.example.shared.BaseExampleApp
 import net.gini.android.capture.network.Error
+import net.gini.android.capture.network.GiniCaptureDefaultNetworkService
 import net.gini.android.capture.network.GiniCaptureNetworkCallback
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
@@ -37,6 +43,7 @@ class ExtractionsActivity : AppCompatActivity() {
     private var mCompoundExtractions: Map<String, GiniCaptureCompoundExtraction> = HashMap()
     private val mLegacyExtractions: MutableMap<String, SpecificExtraction> = HashMap()
     private var mExtractionsAdapter: ExtractionsAdapter<Any>? = null
+    private lateinit var defaultNetworkService: GiniCaptureDefaultNetworkService
 
     companion object {
         private val LOG = LoggerFactory.getLogger(ExtractionsActivity::class.java)
@@ -47,9 +54,16 @@ class ExtractionsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityExtractionsBinding.inflate(layoutInflater)
+        defaultNetworkService = ((application as BaseExampleApp).getGiniCaptureNetworkService("ScreenAPI") as GiniCaptureDefaultNetworkService)
         setContentView(binding.root)
         readExtras()
+        showAnalyzedDocumentId()
         setUpRecyclerView(binding)
+    }
+
+    private fun showAnalyzedDocumentId() {
+        val documentId = defaultNetworkService.analyzedGiniApiDocument?.id ?: ""
+        binding.textDocumentId.text = getString(R.string.analyzed_document_id, documentId)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/capture-sdk/screen-api-example-app/src/main/res/layout/activity_extractions.xml
+++ b/capture-sdk/screen-api-example-app/src/main/res/layout/activity_extractions.xml
@@ -5,12 +5,25 @@
     android:layout_height="match_parent"
     tools:context="net.gini.android.capture.screen.ExtractionsActivity">
 
+    <TextView
+        android:id="@+id/text_document_id"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
+        android:paddingTop="10dp"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
+        tools:text="Analyzed Gini Bank API Document ID: asdadsasd-asdadsasd-asdadsasd-asdadsasd-asdadsasd"/>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview_extractions"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
-        tools:listitem="@layout/item_extraction" />
+        tools:listitem="@layout/item_extraction"
+        android:layout_below="@id/text_document_id"/>
 
     <LinearLayout
         android:id="@+id/layout_progress"

--- a/capture-sdk/screen-api-example-app/src/main/res/values/strings.xml
+++ b/capture-sdk/screen-api-example-app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="custom_help_screen_title">Custom Help Screen</string>
     <string name="custom_help_screen_greeting">This is a custom help screen.</string>
 
+    <string name="analyzed_document_id">Analyzed Gini Bank API Document ID: %s</string>
+
     <!-- String customization examples -->
 
     <!--<string name="gc_title_camera">Dokument fotografieren</string>-->

--- a/capture-sdk/sdk/src/doc/source/integration.rst
+++ b/capture-sdk/sdk/src/doc/source/integration.rst
@@ -150,6 +150,19 @@ and `GiniCaptureDefaultNetworkApi.Builder
 <https://developer.gini.net/gini-mobile-android/capture-sdk/default-network/dokka/default-network/net.gini.android.capture.network/-gini-capture-default-network-api/-builder/index.html>`_
 for configuration options.
 
+Retrieve the Analyzed Document
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can call ``GiniCaptureDefaultNetworkService.getAnalyzedGiniApiDocument()`` after the Gini Capture SDK has returned
+extractions to your application. It returns the Gini Bank API document which was created when the user uploaded an
+image or pdf for analysis.
+
+.. note::
+
+    Make sure to call it before calling ``GiniCaptureDefaultNetworkService.cleanup()`` or ``GiniCapture.cleanup()``.
+    Otherwise the analyzed document won't be available anymore.
+
+
 Custom Implementation
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/capture-sdk/sdk/src/doc/source/integration.rst
+++ b/capture-sdk/sdk/src/doc/source/integration.rst
@@ -157,6 +157,9 @@ You can call ``GiniCaptureDefaultNetworkService.getAnalyzedGiniApiDocument()`` a
 extractions to your application. It returns the Gini Bank API document which was created when the user uploaded an
 image or pdf for analysis.
 
+When extractions were retrieved without using the Gini Bank API, then it will return ``null``. For example when the
+extractions came from an EPS QR Code.
+
 .. note::
 
     Make sure to call it before calling ``GiniCaptureDefaultNetworkService.cleanup()`` or ``GiniCapture.cleanup()``.


### PR DESCRIPTION
Let clients access the analyzed Gini Bank API document when using the default networking implementation.