### PR TITLE
fix(bank-sdk): Don't handle input in `CaptureFlowActivity` on activity restart

### DIFF
--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowActivity.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowActivity.kt
@@ -21,7 +21,9 @@ internal class CaptureFlowActivity : AppCompatActivity(), CaptureFlowImportContr
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        handleInput()
+        if (savedInstanceState == null) {
+            handleInput()
+        }
     }
 
     private fun handleInput() {


### PR DESCRIPTION
Handling the input on activity restarts caused the camera activity to be launched again when the
digital invoice activity returned with a result.

PIA-2785