### PR TITLE
Pia 2780 disable pay button if total is zero

### DIFF
--- a/bank-sdk/sdk/src/doc/source/customization-guide.rst
+++ b/bank-sdk/sdk/src/doc/source/customization-guide.rst
@@ -463,6 +463,10 @@ Digital Invoice Screen
 
   Via the string resource named ``gbs_digital_invoice_pay_other_charges``.
 
+- **Title (disabled)**
+
+  Via the string resource named ``gbs_digital_invoice_pay_disabled``.
+
 - **Button Style**
 
   Via overriding the style named ``GiniCaptureTheme.DigitalInvoice.Pay.Button`` (with

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceScreenPresenter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceScreenPresenter.kt
@@ -177,7 +177,7 @@ internal class DigitalInvoiceScreenPresenter(
                 footerDetails = footerDetails
                     .copy(
                         totalGrossPriceIntegralAndFractionalParts = digitalInvoice.totalPriceIntegralAndFractionalParts(),
-                        buttonEnabled = selected > 0 || digitalInvoice.totalPrice() > BigDecimal.ZERO,
+                        buttonEnabled = digitalInvoice.totalPrice() > BigDecimal.ZERO,
                         count = selected,
                         total = total
                     )

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
@@ -557,12 +557,16 @@ internal sealed class ViewHolder<in T>(itemView: View, val viewType: ViewType) :
             binding.skipButton.isEnabled = data.buttonEnabled
             binding.skipButton.isVisible = data.inaccurateExtraction
             binding.payButton.isEnabled = data.buttonEnabled
-            binding.payButton.text = if (data.count > 0) {
-                binding.payButton.resources.getString(
-                    R.string.gbs_digital_invoice_pay,
-                    data.count,
-                    data.total
-                )
+            binding.payButton.text = if (data.buttonEnabled) {
+                if (data.count > 0) {
+                    binding.payButton.resources.getString(
+                        R.string.gbs_digital_invoice_pay,
+                        data.count,
+                        data.total
+                    )
+                } else {
+                    binding.payButton.resources.getString(R.string.gbs_digital_invoice_pay_other_charges)
+                }
             } else {
                 binding.payButton.resources.getString(R.string.gbs_digital_invoice_pay_other_charges)
             }

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
@@ -568,7 +568,7 @@ internal sealed class ViewHolder<in T>(itemView: View, val viewType: ViewType) :
                     binding.payButton.resources.getString(R.string.gbs_digital_invoice_pay_other_charges)
                 }
             } else {
-                binding.payButton.resources.getString(R.string.gbs_digital_invoice_pay_other_charges)
+                binding.payButton.resources.getString(R.string.gbs_digital_invoice_pay_disabled)
             }
             val (integral, fractional) = data.totalGrossPriceIntegralAndFractionalParts
             binding.grossPriceTotalIntegralPart.text = integral

--- a/bank-sdk/sdk/src/main/res/values-en/strings.xml
+++ b/bank-sdk/sdk/src/main/res/values-en/strings.xml
@@ -16,6 +16,7 @@
     <string name="gbs_digital_invoice_footer_notice">Please double check if the amount is correct and add further articles if necessary.</string>
     <string name="gbs_digital_invoice_pay">Pay %1$d/%2$d</string>
     <string name="gbs_digital_invoice_pay_other_charges">Pay</string>
+    <string name="gbs_digital_invoice_pay_disabled">Pay</string>
     <string name="gbs_digital_invoice_line_item_details_description_label">Item Name</string>
     <string name="gbs_digital_invoice_line_item_details_quantity_label">Quantity</string>
     <string name="gbs_digital_invoice_line_item_details_gross_price_label">Item price</string>

--- a/bank-sdk/sdk/src/main/res/values/strings.xml
+++ b/bank-sdk/sdk/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="gbs_digital_invoice_footer_notice">Bitte überprüfe vor der Zahlung, ob alles in Ordnung ist und füge eventuell fehlende Artikel hinzu.</string>
     <string name="gbs_digital_invoice_pay">Bezahlen %1$d/%2$d</string>
     <string name="gbs_digital_invoice_pay_other_charges">Bezahlen</string>
+    <string name="gbs_digital_invoice_pay_disabled">Bezahlen</string>
     <string name="gbs_digital_invoice_return_reason_dialog_title">Der Grund der Rücksendung</string>
     <string name="gbs_digital_invoice_what_is_this_dialog_title">Was ist das?</string>
     <string name="gbs_digital_invoice_what_is_this_dialog_message">Wir haben die Artikel aus deiner Rechnung extrahiert. Wenn du einige Artikel zurückschicken oder du deine Rechnung nur teilweise bezahlen möchtest, kannst du einzelne Artikel abwählen und der zu bezahlende Betrag wird automatisch neu berechnet.</string>


### PR DESCRIPTION
* Pay button is disabled when total amount is 0 irrelevant of how many items are selected.
* If button is disabled the label is just “Pay”. 
* Added a dedicated string for the disabled pay button title: gbs_digital_invoice_pay_disabled.