### PR TITLE
Pia 2805 input field colors

### DIFF
--- a/bank-sdk/sdk/src/doc/source/customization-guide.rst
+++ b/bank-sdk/sdk/src/doc/source/customization-guide.rst
@@ -705,6 +705,14 @@ All Action Bar customizations except the title are global to all Activities.
   Via overriding the style named ``GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.TextStyle`` (with
   parent style ``Root.GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.TextStyle``).
 
+- **Input Field Cursor Color**
+
+  Via the color resource named ``gbs_digital_invoice_line_item_details_input_field_cursor``.
+
+- **Input Field Text Selection Highlight Color**
+
+  Via the color resource named ``gbs_digital_invoice_line_item_details_input_field_selection_highlight``.
+
 :ref:`Back to screenshot. <edit-line-item>`
 
 7. Multiplication Symbol

--- a/bank-sdk/sdk/src/main/res/values/colors.xml
+++ b/bank-sdk/sdk/src/main/res/values/colors.xml
@@ -49,6 +49,8 @@
     <color name="gbs_digital_invoice_line_item_details_checkbox_label">#9B9B9B</color>
     <color name="gbs_digital_invoice_line_item_details_input_field_text">#222222</color>
     <color name="gbs_digital_invoice_line_item_details_input_field_hint_text">#9B9B9B</color>
+    <color name="gbs_digital_invoice_line_item_details_input_field_cursor">#009EDC</color>
+    <color name="gbs_digital_invoice_line_item_details_input_field_selection_highlight">#009EDC</color>
     <color name="gbs_digital_invoice_line_item_details_input_line">#F1F2F4</color>
     <color name="gbs_digital_invoice_line_item_details_multiplication_symbol">#9B9B9B</color>
     <color name="gbs_digital_invoice_line_item_details_total_label">#000</color>

--- a/bank-sdk/sdk/src/main/res/values/styles.xml
+++ b/bank-sdk/sdk/src/main/res/values/styles.xml
@@ -120,7 +120,7 @@
 
     <style name="Root.GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.Style" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
         <item name="materialThemeOverlay">
-            @style/Root.GiniCaptureTheme.ThemeOverlay.App.TextInputLayout
+            @style/GiniCaptureTheme.ThemeOverlay.App.TextInputLayout
         </item>
         <item name="shapeAppearance">@style/ShapeAppearance.MaterialComponents.SmallComponent</item>
         <item name="hintTextColor">
@@ -389,6 +389,8 @@
     <style name="GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.TextStyle" />
 
     <style name="GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.Style" parent="Root.GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.Style" />
+
+    <style name="GiniCaptureTheme.ThemeOverlay.App.TextInputLayout" parent="Root.GiniCaptureTheme.ThemeOverlay.App.TextInputLayout" />
 
     <style name="GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.Hint.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.LineItemDetails.InputField.Hint.TextStyle" />
 

--- a/bank-sdk/sdk/src/main/res/values/styles.xml
+++ b/bank-sdk/sdk/src/main/res/values/styles.xml
@@ -140,7 +140,10 @@
 
     <style name="Root.GiniCaptureTheme.ThemeOverlay.App.TextInputLayout" parent="">
         <item name="colorPrimary">
-            @color/gbs_digital_invoice_line_item_details_input_field_hint_text
+            @color/gbs_digital_invoice_line_item_details_input_field_cursor
+        </item>
+        <item name="colorAccent">
+            @color/gbs_digital_invoice_line_item_details_input_field_selection_highlight
         </item>
         <item name="colorOnSurface">
             @color/gbs_digital_invoice_line_item_details_input_field_hint_text


### PR DESCRIPTION
To test it add these lines to `bank-sdk/screen-api-example-app/src/main/res/values/colors.xml`:
```
<color name="gbs_digital_invoice_line_item_details_input_field_cursor">#f00</color>
<color name="gbs_digital_invoice_line_item_details_input_field_selection_highlight">#f0f</color>
```