### PR TITLE
Pia 2845 fix text alignment

### DIFF
--- a/bank-sdk/sdk/src/main/res/layout/gbs_fragment_line_item_details.xml
+++ b/bank-sdk/sdk/src/main/res/layout/gbs_fragment_line_item_details.xml
@@ -205,7 +205,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toStartOf="@+id/gross_price_total_fractional_part"
-        android:includeFontPadding="false"
         android:textAppearance="@style/GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Integral.TextStyle"
         app:layout_constraintEnd_toStartOf="@id/gross_price_total_fractional_part"
         app:layout_constraintTop_toTopOf="@id/gross_price_total_fractional_part"

--- a/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_addon.xml
+++ b/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_addon.xml
@@ -28,7 +28,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_toStartOf="@+id/gbs_addon_price_total_fractional_part"
-        android:includeFontPadding="false"
         android:textAppearance="@style/GiniCaptureTheme.DigitalInvoice.Addon.Price.Integral.TextStyle"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="@id/gbs_addon_price_total_fractional_part"

--- a/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_addon.xml
+++ b/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_addon.xml
@@ -18,9 +18,9 @@
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="@dimen/gbs_digital_invoice_addon_name_margin_right"
         android:textAppearance="@style/GiniCaptureTheme.DigitalInvoice.Addon.Name.TextStyle"
+        app:layout_constraintBaseline_toBaselineOf="@+id/gbs_addon_price_total_integral_part"
         app:layout_constraintEnd_toStartOf="@id/gbs_addon_price_total_integral_part"
-        app:layout_constraintBottom_toBottomOf="@id/gbs_addon_price_total_integral_part"
-        tools:text="Discount:"/>
+        tools:text="Discount:" />
 
     <TextView
         android:id="@+id/gbs_addon_price_total_integral_part"

--- a/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_footer.xml
+++ b/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_footer.xml
@@ -25,7 +25,6 @@
         android:id="@+id/gross_price_total_integral_part"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:includeFontPadding="false"
         android:textAppearance="@style/GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Integral.TextStyle"
         app:layout_constraintStart_toEndOf="@id/total_label"
         app:layout_constraintEnd_toStartOf="@id/gross_price_total_fractional_part"

--- a/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_line_item.xml
+++ b/bank-sdk/sdk/src/main/res/layout/gbs_item_digital_invoice_line_item.xml
@@ -112,7 +112,6 @@
         android:id="@+id/gross_price_integral_part"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:includeFontPadding="false"
         android:textAppearance="@style/GiniCaptureTheme.DigitalInvoice.LineItem.GrossPrice.Integral.TextStyle"
         app:layout_constraintEnd_toStartOf="@id/gross_price_fractional_part"
         app:layout_constraintTop_toBottomOf="@id/description"


### PR DESCRIPTION
To test it please add the following to `bank-sdk/screen-api-example-app/src/main/res/values/themes.xml`. It will make both the integral and fractional parts of prices have the same font size:
```
    <style name="GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Integral.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Integral.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>

    <style name="GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Fractional.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.TotalGrossPrice.Fractional.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>

    <style name="GiniCaptureTheme.DigitalInvoice.LineItem.GrossPrice.Integral.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.LineItem.GrossPrice.Integral.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>

    <style name="GiniCaptureTheme.DigitalInvoice.LineItem.GrossPrice.Fractional.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.LineItem.GrossPrice.Fractional.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>

    <style name="GiniCaptureTheme.DigitalInvoice.Addon.Price.Integral.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.Addon.Price.Integral.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>

    <style name="GiniCaptureTheme.DigitalInvoice.Addon.Price.Fractional.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.Addon.Price.Fractional.TextStyle">
        <item name="android:textSize">24sp</item>
    </style>
```