### PR TITLE
Pia 2656 support predictive back gesture

### DIFF
--- a/bank-sdk/component-api-example-app/src/main/AndroidManifest.xml
+++ b/bank-sdk/component-api-example-app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="net.gini.android.bank.sdk.componentapiexample">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>

--- a/bank-sdk/component-api-example-app/src/main/java/net/gini/android/bank/sdk/componentapiexample/camera/CameraExampleActivity.kt
+++ b/bank-sdk/component-api-example-app/src/main/java/net/gini/android/bank/sdk/componentapiexample/camera/CameraExampleActivity.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.os.BuildCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import net.gini.android.capture.AsyncCallback
@@ -67,6 +69,18 @@ class CameraExampleActivity : AppCompatActivity(), CameraFragmentListener, Onboa
         } else {
             mCameraFragmentInterface = retrieveCameraFragment()
         }
+
+        this.onBackPressedDispatcher.addCallback(this, object: OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (isOnboardingVisible()) {
+                    removeOnboarding()
+                } else {
+                    isEnabled = false
+                    onBackPressed()
+                }
+            }
+
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -87,6 +101,7 @@ class CameraExampleActivity : AppCompatActivity(), CameraFragmentListener, Onboa
         else -> false
     }
 
+    // TODO: back pressed override
     override fun onBackPressed() {
         if (isOnboardingVisible()) {
             removeOnboarding()

--- a/bank-sdk/screen-api-example-app/src/main/AndroidManifest.xml
+++ b/bank-sdk/screen-api-example-app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="net.gini.android.bank.sdk.screenapiexample">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/LineItemsAdapter.kt
@@ -288,7 +288,7 @@ internal sealed class ViewHolder<in T>(itemView: View, val viewType: ViewType) :
                 .setDuration(300)
 
             animator.addListener(object : Animator.AnimatorListener {
-                override fun onAnimationStart(animation: Animator?) {
+                override fun onAnimationStart(animation: Animator) {
                     if (!isExpandingAnimation) {
                         binding.headerText1.isVisible = false
                         binding.headerText2.isVisible = false
@@ -297,7 +297,7 @@ internal sealed class ViewHolder<in T>(itemView: View, val viewType: ViewType) :
                     }
                 }
 
-                override fun onAnimationEnd(animation: Animator?) {
+                override fun onAnimationEnd(animation: Animator) {
                     if (isExpandingAnimation) {
                         binding.headerText1.isVisible = true
                         binding.headerText2.isVisible = true
@@ -306,16 +306,16 @@ internal sealed class ViewHolder<in T>(itemView: View, val viewType: ViewType) :
                     }
                 }
 
-                override fun onAnimationCancel(animation: Animator?) {
+                override fun onAnimationCancel(animation: Animator) {
                 }
 
-                override fun onAnimationRepeat(animation: Animator?) {
+                override fun onAnimationRepeat(animation: Animator) {
                 }
 
             })
 
             animator.addUpdateListener(object : ValueAnimator.AnimatorUpdateListener {
-                override fun onAnimationUpdate(animation: ValueAnimator?) {
+                override fun onAnimationUpdate(animation: ValueAnimator) {
                     val updateVal = (animation?.animatedValue as? Float)?.let {
                         if (!isExpandingAnimation) 1 - it else it
                     } ?: return

--- a/capture-sdk/component-api-example-app/src/main/AndroidManifest.xml
+++ b/capture-sdk/component-api-example-app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="net.gini.android.capture.component">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>

--- a/capture-sdk/component-api-example-app/src/main/java/net/gini/android/capture/component/camera/CameraExampleAppCompatActivity.java
+++ b/capture-sdk/component-api-example-app/src/main/java/net/gini/android/capture/component/camera/CameraExampleAppCompatActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
@@ -74,14 +75,6 @@ public class CameraExampleAppCompatActivity extends AppCompatActivity implements
             new CaptureComponentContract(), activityResultCallback);
 
     @Override
-    public void onBackPressed() {
-        if (mCameraScreenHandler.onBackPressed()) {
-            return;
-        }
-        super.onBackPressed();
-    }
-
-    @Override
     protected void onNewIntent(final Intent intent) {
         super.onNewIntent(intent);
         mCameraScreenHandler.onNewIntent(intent);
@@ -98,6 +91,16 @@ public class CameraExampleAppCompatActivity extends AppCompatActivity implements
         setContentView(R.layout.activity_camera_compat);
         mCameraScreenHandler = new CameraScreenHandler(this, mStartReview, mStartMultiPageReview, mStartAnalysis);
         mCameraScreenHandler.onCreate(savedInstanceState);
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (mCameraScreenHandler.onBackPressed()) {
+                    return;
+                }
+                setEnabled(false);
+                onBackPressed();
+            }
+        });
     }
 
     @Override

--- a/capture-sdk/screen-api-example-app/src/main/AndroidManifest.xml
+++ b/capture-sdk/screen-api-example-app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="net.gini.android.capture.screen">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <queries>

--- a/capture-sdk/sdk/src/doc/source/features.rst
+++ b/capture-sdk/sdk/src/doc/source/features.rst
@@ -130,6 +130,17 @@ You need to declare the ``READ_EXTERNAL_STORAGE`` permission in your app's ``And
 
     </manifest>
 
+When targeting Android 13 and later you will also have to declare the ``READ_MEDIA_IMAGES`` permission:
+
+.. code-block:: xml
+
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="...">
+
+        <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
+    </manifest>
+
 If the permission has not been granted the Gini Capture SDK will prompt the user to grant the permission when they use
 the document import feature.
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.AppCompatActivity;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static net.gini.android.capture.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPressed;
 import static net.gini.android.capture.tracking.EventTrackingHelper.trackAnalysisScreenEvent;
 
 /**
@@ -231,6 +233,16 @@ public class AnalysisActivity extends AppCompatActivity implements
             retainFragment();
         }
         enableHomeAsUp(this);
+        handleOnBackPressed();
+    }
+
+    private void handleOnBackPressed() {
+        interceptOnBackPressed(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                trackAnalysisScreenEvent(AnalysisScreenEvent.CANCEL);
+            }
+        });
     }
 
     @Override
@@ -254,12 +266,6 @@ public class AnalysisActivity extends AppCompatActivity implements
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        trackAnalysisScreenEvent(AnalysisScreenEvent.CANCEL);
     }
 
     @Override

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -31,9 +32,11 @@ import net.gini.android.capture.tracking.CameraScreenEvent;
 import java.util.Map;
 
 import static net.gini.android.capture.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPressed;
 import static net.gini.android.capture.internal.util.FeatureConfiguration.shouldShowOnboarding;
 import static net.gini.android.capture.internal.util.FeatureConfiguration.shouldShowOnboardingAtFirstRun;
 import static net.gini.android.capture.review.ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY;
+import static net.gini.android.capture.tracking.EventTrackingHelper.trackAnalysisScreenEvent;
 import static net.gini.android.capture.tracking.EventTrackingHelper.trackCameraScreenEvent;
 
 /**
@@ -360,6 +363,16 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         }
         showOnboardingIfRequested();
         setupHomeButton();
+        handleOnBackPressed();
+    }
+
+    private void handleOnBackPressed() {
+        interceptOnBackPressed(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                trackCameraScreenEvent(CameraScreenEvent.EXIT);
+            }
+        });
     }
 
     private void setupHomeButton() {
@@ -471,12 +484,6 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        trackCameraScreenEvent(CameraScreenEvent.EXIT);
     }
 
     private void startHelpActivity() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/fileimport/FileChooserActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/fileimport/FileChooserActivity.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
@@ -124,6 +125,30 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
         readExtras();
         setupFileProvidersView();
         overridePendingTransition(0, 0);
+        handleOnBackPressed();
+    }
+
+    private void handleOnBackPressed() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (mFileProvidersView.getTag() == null) {
+                    return;
+                }
+                final boolean isShown = (boolean) mFileProvidersView.getTag();
+                if (!isShown) {
+                    return;
+                }
+                overridePendingTransition(0, 0);
+                hideFileProviders(new TransitionListenerAdapter() {
+                    @Override
+                    public void onTransitionEnd(@NonNull final Transition transition) {
+                        setEnabled(false);
+                        onBackPressed();
+                    }
+                });
+            }
+        });
     }
 
     @Override
@@ -230,21 +255,6 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
                 mFileProvidersView.setTag(true);
             }
         }, SHOW_ANIM_DELAY);
-    }
-
-    @Override
-    public void onBackPressed() {
-        final boolean isShown = (boolean) mFileProvidersView.getTag();
-        if (!isShown) {
-            return;
-        }
-        overridePendingTransition(0, 0);
-        hideFileProviders(new TransitionListenerAdapter() {
-            @Override
-            public void onTransitionEnd(@NonNull final Transition transition) {
-                FileChooserActivity.super.onBackPressed();
-            }
-        });
     }
 
     private void hideFileProviders(

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/ActivityHelper.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/ActivityHelper.java
@@ -1,6 +1,7 @@
 package net.gini.android.capture.internal.util;
 
 import static net.gini.android.capture.internal.util.ContextHelper.isTablet;
+import static net.gini.android.capture.tracking.EventTrackingHelper.trackAnalysisScreenEvent;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -8,9 +9,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 
+import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+
+import net.gini.android.capture.tracking.AnalysisScreenEvent;
 
 /**
  * Internal use only.
@@ -47,6 +52,29 @@ public final class ActivityHelper {
         if (!isTablet(activity)) {
             lockToPortraitOrientation(activity);
         }
+    }
+
+    /**
+     * Intercepts the back button pressed event once and then disables the {@link OnBackPressedCallback}.
+     *
+     * Always calls {@link Activity#onBackPressed()} after disabling the {@link OnBackPressedCallback}.
+     *
+     * @param activity
+     * @param callback
+     */
+    public static void interceptOnBackPressed(@Nullable final AppCompatActivity activity, @NonNull final OnBackPressedCallback callback) {
+        if (activity == null) {
+            return;
+        }
+        activity.getOnBackPressedDispatcher().addCallback(activity, new OnBackPressedCallback(callback.isEnabled()) {
+            @Override
+            public void handleOnBackPressed() {
+                callback.handleOnBackPressed();
+                callback.setEnabled(false);
+                setEnabled(false);
+                activity.onBackPressed();
+            }
+        });
     }
 
     private ActivityHelper() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/AndroidHelper.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/AndroidHelper.java
@@ -1,6 +1,9 @@
 package net.gini.android.capture.internal.util;
 
+import android.Manifest;
 import android.os.Build;
+
+import java.lang.reflect.Field;
 
 /**
  * Internal use only.
@@ -16,6 +19,69 @@ public final class AndroidHelper {
      */
     public static boolean isMarshmallowOrLater() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
+
+    /**
+     * Internal use only
+     *
+     * Checks whether the current android version is Tiramisu (Android 13, API Level 33) or later using reflection
+     * to enable forward compatibility.
+     *
+     * This method helps you prepare for changes that need to be activated on Android 13 and later without
+     * having to set the compile sdk to android api level 33.
+     *
+     * @return true, if the current android version is Tiramisu (Android 13) or later
+     */
+    public static boolean isTiramisuOrLater() {
+        try {
+            final Field tiramisu = Build.VERSION_CODES.class.getField("TIRAMISU");
+            final int tiramisuVersionCode = tiramisu.getInt(null);
+            return Build.VERSION.SDK_INT >= tiramisuVersionCode;
+        } catch (NoSuchFieldException | IllegalAccessException | SecurityException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Internal use only.
+     *
+     * Checks whether a permission is available using reflection to enable forward compatibility.
+     *
+     * This methods helps you handle permissions that will be available in a later android sdk version without
+     * having to bump the compile sdk and target sdk versions in the build.gradle file. Once you are ready to
+     * target the newer android sdk no more code changes will be needed.
+     *
+     * @param permissionName name of the permission as found in the Manifest.permission static class
+     * @return true, if the permission is available
+     */
+    public static boolean isPermissionAvailableOnCurrentAndroidVersion(String permissionName) {
+        try {
+            Manifest.permission.class.getField(permissionName);
+            return true;
+        } catch (NoSuchFieldException | SecurityException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Internal use only.
+     *
+     * Gets the fully qualified permission name using reflection to enable forward compatibility.
+     *
+     * This methods helps you handle permissions that will be available in a later android sdk version without
+     * having to bump the compile sdk and target sdk versions in the build.gradle file. Once your app is ready to
+     * target the newer android sdk no more code changes will be needed.
+     *
+     * @param permissionName name of the permission as found in the Manifest.permission static class
+     * @return fully qualified permission name or an empty string
+     */
+    public static String getFullyQualifiedPermissionName(String permissionName) {
+        try {
+            final Field readMediaImages = Manifest.permission.class.getField(permissionName);
+            return (String) readMediaImages.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException | SecurityException e) {
+            return "";
+        }
     }
 
     private AndroidHelper() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/ReviewActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/ReviewActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -24,6 +25,7 @@ import net.gini.android.capture.onboarding.OnboardingActivity;
 import net.gini.android.capture.tracking.ReviewScreenEvent;
 
 import static net.gini.android.capture.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPressed;
 import static net.gini.android.capture.tracking.EventTrackingHelper.trackReviewScreenEvent;
 
 /**
@@ -193,6 +195,16 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
             retainFragment();
         }
         enableHomeAsUp(this);
+        handleOnBackPressed();
+    }
+
+    private void handleOnBackPressed() {
+        interceptOnBackPressed(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                trackReviewScreenEvent(ReviewScreenEvent.BACK);
+            }
+        });
     }
 
     private void restoreSavedState(@Nullable final Bundle savedInstanceState) {
@@ -209,12 +221,6 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        trackReviewScreenEvent(ReviewScreenEvent.BACK);
     }
 
     @Override

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewActivity.java
@@ -2,6 +2,8 @@ package net.gini.android.capture.review.multipage;
 
 import static net.gini.android.capture.analysis.AnalysisActivity.RESULT_NO_EXTRACTIONS;
 import static net.gini.android.capture.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPressed;
+import static net.gini.android.capture.tracking.EventTrackingHelper.trackCameraScreenEvent;
 import static net.gini.android.capture.tracking.EventTrackingHelper.trackReviewScreenEvent;
 
 import android.app.Activity;
@@ -22,10 +24,9 @@ import net.gini.android.capture.tracking.ReviewScreenEvent;
 
 import java.util.List;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Created by Alpar Szotyori on 16.02.2018.
@@ -243,6 +244,16 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
             retainFragment();
         }
         enableHomeAsUp(this);
+        handleOnBackPressed();
+    }
+
+    private void handleOnBackPressed() {
+        interceptOnBackPressed(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                trackReviewScreenEvent(ReviewScreenEvent.BACK);
+            }
+        });
     }
 
     private void initFragment() {
@@ -279,12 +290,6 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        trackReviewScreenEvent(ReviewScreenEvent.BACK);
     }
 
     @Override


### PR DESCRIPTION
Note: please review only the commits [ed57c9f](https://github.com/gini/gini-mobile-android/pull/84/commits/ed57c9f1481c136fced8b739eae6cc707734c0d8) and newer.

I replaced all `onBackPressed()` overrides with AndroidX's `OnBackPressedCallbacks`.

The changes have no visible effect. Every back button press or back swipe gesture should work as usual even on Android 13.

The predictive back gesture feature is disabled in Android 13 and can be enabled for testing purposes in the developer tools only. 

It's been a while since android recommends using `OnBackPressedCallbacks` so even though these changes won't have any effect now we are reducing future technical debt.

https://developer.android.com/guide/navigation/predictive-back-gesture
https://android-developers.googleblog.com/2022/07/prepare-your-app-to-support-predictive-back-gestures.html