### PR TITLE
fix(capture-sdk): Fix showing/hiding "back to camera" button on No Results Screen

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragmentImpl.java
@@ -67,8 +67,7 @@ class NoResultsFragmentImpl {
     }
 
     private boolean isDocumentFromCameraScreen() {
-        final Intent intent = mDocument.getIntent();
-        return intent == null || intent.getAction() == null;
+        return mDocument.getImportMethod() != Document.ImportMethod.OPEN_WITH;
     }
 
 }


### PR DESCRIPTION
Using the document's intent was not working when multi-page was enabled.

Testing instructions: https://ginis.atlassian.net/browse/PIA-3093?focusedCommentId=19163