### PR TITLE
fix(capture-sdk): Fix ImageDiskStore generating the same filename twice

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/storage/ImageDiskStore.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/storage/ImageDiskStore.java
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.UUID;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -89,7 +90,7 @@ public class ImageDiskStore {
     @NonNull
     private Uri generateUri(@NonNull final Context context, @Nullable final String extension) {
         final String filename =
-                System.currentTimeMillis() + (extension != null ? "." + extension : "");
+                UUID.randomUUID() + (extension != null ? "." + extension : "");
         final String storePath = getStoreDir(context).getAbsolutePath();
         return new Uri.Builder().scheme("file").path(storePath).appendPath(filename).build();
     }

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/internal/storage/ImageDiskStoreTest.java
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/internal/storage/ImageDiskStoreTest.java
@@ -27,7 +27,7 @@ import org.robolectric.shadows.ShadowContentResolver;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.Calendar;
+import java.util.UUID;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -146,7 +146,7 @@ public class ImageDiskStoreTest {
     }
 
     @Test
-    public void should_generateFilenames_basedOnTheCurrentTime_inMilliseconds() throws Exception {
+    public void should_generateFilenames_withUUID() throws Exception {
         // Given
         final ImageDiskStore imageDiskStore = new ImageDiskStore();
         final Application appContext = getApplicationContext();
@@ -158,22 +158,9 @@ public class ImageDiskStoreTest {
         final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
         final String fileName = storeDir.listFiles()[0].getName();
 
-        final Calendar calendarFileNameDate = Calendar.getInstance();
-        calendarFileNameDate.setTimeInMillis(Long.parseLong(fileName));
+        final UUID uuid = UUID.fromString(fileName);
 
-        final Calendar calendarNow = Calendar.getInstance();
-        calendarNow.get(Calendar.YEAR);
-
-        assertThat(calendarFileNameDate.get(Calendar.YEAR)).isEqualTo(
-                calendarNow.get(Calendar.YEAR));
-        assertThat(calendarFileNameDate.get(Calendar.MONTH)).isEqualTo(
-                calendarNow.get(Calendar.MONTH));
-        assertThat(calendarFileNameDate.get(Calendar.DAY_OF_MONTH)).isEqualTo(
-                calendarNow.get(Calendar.DAY_OF_MONTH));
-        assertThat(calendarFileNameDate.get(Calendar.HOUR)).isEqualTo(
-                calendarNow.get(Calendar.HOUR));
-        assertThat(calendarFileNameDate.get(Calendar.MINUTE)).isEqualTo(
-                calendarNow.get(Calendar.MINUTE));
+        assertThat(uuid).isNotNull();
     }
 
     @Test
@@ -240,6 +227,26 @@ public class ImageDiskStoreTest {
         // Then
         final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
         assertThat(storeDir.listFiles()).hasLength(1);
+    }
+
+    @Test
+    public void should_generateDifferentFileNames() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+        copyAssetToStorage("invoice.jpg", appContext.getFilesDir().getPath());
+
+        // When
+        int c = 1;
+        int times = 100;
+        while (c <= times) {
+            final Uri uri = imageDiskStore.save(appContext, getTestJpeg());
+            final Uri uri2 = imageDiskStore.save(appContext, getTestJpeg());
+
+            // Then
+            assertThat(uri).isNotEqualTo(uri2);
+            c++;
+        }
     }
 
     @Test


### PR DESCRIPTION
Filenames were generated using `System.currentTimeMillis()` which could return the same value, if called quickly twice.

Switched to using UUIDs for filenames instead.

PIA-3169