### PR TITLE
fix(capture-sdk): Reduce minimum aspect ratio back to 4:3

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/CameraResolutionRequirement.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/CameraResolutionRequirement.java
@@ -19,8 +19,8 @@ public class CameraResolutionRequirement implements Requirement {
     public static final int MIN_PICTURE_AREA = 7_900_000;
     // We allow up to 13MP picture resolutions
     public static final int MAX_PICTURE_AREA = 13_000_000;
-    // We require an aspect ratio of at least 16:9
-    public static final float MIN_ASPECT_RATIO = 1.77f;
+    // We require an aspect ratio of at least 4:3
+    public static final float MIN_ASPECT_RATIO = 1.33f;
 
     private final CameraHolder mCameraHolder;
 


### PR DESCRIPTION
With the minimum set to 16:9 we excluded devices that we supported before. These devices are still popular (like Galaxy Tab S2) so we need to reduce the minimum back to 4:3.

PIA-3248