### PR TITLE
Pia 3234 camera injected loading indicator

### DIFF
--- a/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/MainActivity.java
+++ b/capture-sdk/screen-api-example-app/src/main/java/net/gini/android/capture/screen/MainActivity.java
@@ -43,6 +43,7 @@ import net.gini.android.capture.tracking.EventTracker;
 import net.gini.android.capture.tracking.OnboardingScreenEvent;
 import net.gini.android.capture.tracking.ReviewScreenEvent;
 import net.gini.android.capture.util.CancellationToken;
+import net.gini.android.capture.view.DefaultLoadingIndicatorAdapter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -321,7 +322,7 @@ public class MainActivity extends AppCompatActivity {
         builder.setFlashButtonEnabled(true);
         builder.setEventTracker(new GiniCaptureEventTracker());
         builder.setCustomErrorLoggerListener(new CustomErrorLoggerListener());
-
+        builder.setLoadingIndicatorAdapter(new DefaultLoadingIndicatorAdapter());
         // Uncomment to disable sending errors to Gini
 //        builder.setGiniErrorLoggerIsOn(false);
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -612,7 +612,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mImageFrame = view.findViewById(R.id.gc_camera_frame);
         mCameraFrameWrapper = view.findViewById(R.id.gc_camera_frame_wrapper);
         mPaneWrapper = view.findViewById(R.id.gc_pane_wrapper);
-        mLoadingIndicator = view.findViewById(R.id.gc_injected_loading_indicator);
+        mLoadingIndicator = view.findViewById(R.id.gc_injected_loading_indicator_container);
     }
 
     private void setTopBarInjectedViewContainer() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -13,13 +13,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.widget.Button;
-import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -337,7 +335,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                         });
 
         mUnsupportedQRCodePopup =
-                new QRCodePopup<>(mFragment, mCameraFrameWrapper, mActivityIndicatorBackground,
+                new QRCodePopup<>(mFragment, mCameraFrameWrapper, mActivityIndicatorBackground, null,
                         getHideQRCodeDetectedPopupDelayMs(), false, null, () -> {
                             mQRCodeContent = null;
                             return null;

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -34,7 +34,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
     private var qrStatusTxt: TextView = popupView.findViewById(R.id.gc_qr_code_status)
     private var qrImageFrame: ImageView = popupView.findViewById(R.id.gc_camera_frame)
     private var qrCheckImage: ImageView = popupView.findViewById(R.id.gc_qr_code_check)
-    private var mLoadingIndicatorAdapter: InjectedViewContainer<CustomLoadingIndicatorAdapter> = popupView.findViewById(R.id.gc_injected_loading_indicator)
+    private var mLoadingIndicatorAdapter: InjectedViewContainer<CustomLoadingIndicatorAdapter> = popupView.findViewById(R.id.gc_injected_loading_indicator_container)
     private var mInvoiceTxt: TextView = popupView.findViewById(R.id.gc_retrieving_invoice)
 
     private val hideRunnable: Runnable = Runnable {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -13,6 +13,9 @@ import androidx.core.view.ViewPropertyAnimatorListener
 import androidx.core.view.ViewPropertyAnimatorListenerAdapter
 import net.gini.android.capture.R
 import net.gini.android.capture.internal.ui.FragmentImplCallback
+import net.gini.android.capture.view.CustomLoadingIndicatorAdapter
+import net.gini.android.capture.view.InjectedViewAdapter
+import net.gini.android.capture.view.InjectedViewContainer
 
 /**
  * Internal use only.
@@ -31,7 +34,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
     private var qrStatusTxt: TextView = popupView.findViewById(R.id.gc_qr_code_status)
     private var qrImageFrame: ImageView = popupView.findViewById(R.id.gc_camera_frame)
     private var qrCheckImage: ImageView = popupView.findViewById(R.id.gc_qr_code_check)
-    private var mProgressBar: ProgressBar = popupView.findViewById(R.id.gc_activity_indicator)
+    private var mLoadingIndicatorAdapter: InjectedViewContainer<CustomLoadingIndicatorAdapter> = popupView.findViewById(R.id.gc_injected_loading_indicator)
     private var mInvoiceTxt: TextView = popupView.findViewById(R.id.gc_retrieving_invoice)
 
     private val hideRunnable: Runnable = Runnable {
@@ -119,7 +122,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
 
         qrCheckImage.visibility = View.GONE
         qrImageFrame.visibility = View.INVISIBLE
-        mProgressBar.visibility = View.VISIBLE
+        mLoadingIndicatorAdapter.injectedViewAdapter?.onVisible()
         mInvoiceTxt.visibility = View.VISIBLE
         supportedBackgroundView?.visibility = View.VISIBLE
     }
@@ -131,7 +134,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
         qrImageFrame.visibility = View.VISIBLE
         qrImageFrame.imageTintList =
             ColorStateList.valueOf(ContextCompat.getColor(popupView.context, R.color.Light_01))
-        mProgressBar.visibility = View.GONE
+        mLoadingIndicatorAdapter.injectedViewAdapter?.onHidden()
         mInvoiceTxt.visibility = View.GONE
         supportedBackgroundView?.visibility = View.GONE
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -26,6 +26,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
     private val fragmentImplCallback: FragmentImplCallback,
     private val popupView: View,
     private val supportedBackgroundView: View? = null,
+    private val loadingIndicatorAdapter: CustomLoadingIndicatorAdapter?,
     private val hideDelayMs: Long,
     private val supported: Boolean,
     private val onClicked: (T?) -> Unit = {}
@@ -34,7 +35,6 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
     private var qrStatusTxt: TextView = popupView.findViewById(R.id.gc_qr_code_status)
     private var qrImageFrame: ImageView = popupView.findViewById(R.id.gc_camera_frame)
     private var qrCheckImage: ImageView = popupView.findViewById(R.id.gc_qr_code_check)
-    private var mLoadingIndicatorAdapter: InjectedViewContainer<CustomLoadingIndicatorAdapter> = popupView.findViewById(R.id.gc_injected_loading_indicator_container)
     private var mInvoiceTxt: TextView = popupView.findViewById(R.id.gc_retrieving_invoice)
 
     private val hideRunnable: Runnable = Runnable {
@@ -122,7 +122,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
 
         qrCheckImage.visibility = View.GONE
         qrImageFrame.visibility = View.INVISIBLE
-        mLoadingIndicatorAdapter.injectedViewAdapter?.onVisible()
+        loadingIndicatorAdapter?.onVisible()
         mInvoiceTxt.visibility = View.VISIBLE
         supportedBackgroundView?.visibility = View.VISIBLE
     }
@@ -134,7 +134,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
         qrImageFrame.visibility = View.VISIBLE
         qrImageFrame.imageTintList =
             ColorStateList.valueOf(ContextCompat.getColor(popupView.context, R.color.Light_01))
-        mLoadingIndicatorAdapter.injectedViewAdapter?.onHidden()
+        loadingIndicatorAdapter?.onHidden()
         mInvoiceTxt.visibility = View.GONE
         supportedBackgroundView?.visibility = View.GONE
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
@@ -16,6 +16,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -248,22 +248,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ProgressBar
-            android:id="@+id/gc_activity_indicator"
+        <net.gini.android.capture.view.InjectedViewContainer
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:indeterminateOnly="true"
-            android:indeterminateTint="@color/gc_analysis_activity_indicator"
-            android:indeterminateTintMode="src_in"
-            android:padding="@dimen/gc_camera_activity_indicator_padding"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/gc_camera_frame"
             app:layout_constraintEnd_toEndOf="@+id/gc_qr_code_check"
             app:layout_constraintStart_toStartOf="@+id/gc_qr_code_check"
-            app:layout_constraintTop_toTopOf="@+id/gc_camera_frame"
-            tools:targetApi="lollipop"
-            tools:visibility="gone" />
+            app:layout_constraintTop_toTopOf="@+id/gc_camera_frame" />
 
         <TextView
             android:id="@+id/gc_retrieving_invoice"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -249,7 +249,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator"
+            android:id="@+id/gc_injected_loading_indicator_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -249,10 +249,9 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator_container"
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/gc_camera_frame"
             app:layout_constraintEnd_toEndOf="@+id/gc_qr_code_check"
             app:layout_constraintStart_toStartOf="@+id/gc_qr_code_check"
@@ -266,9 +265,9 @@
             android:text="Retrieving invoice"
             android:textColor="@color/Light_01"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@+id/gc_activity_indicator"
-            app:layout_constraintStart_toStartOf="@+id/gc_activity_indicator"
-            app:layout_constraintTop_toBottomOf="@+id/gc_activity_indicator" />
+            app:layout_constraintEnd_toEndOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintStart_toStartOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintTop_toBottomOf="@+id/gc_injected_loading_indicator" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -249,7 +249,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator"
+            android:id="@+id/gc_injected_loading_indicator_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -249,10 +249,9 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator_container"
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/gc_camera_frame"
             app:layout_constraintEnd_toEndOf="@+id/gc_qr_code_check"
             app:layout_constraintStart_toStartOf="@+id/gc_qr_code_check"
@@ -266,9 +265,9 @@
             android:textColor="@color/Light_01"
             android:id="@+id/gc_retrieving_invoice"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@+id/gc_activity_indicator"
-            app:layout_constraintStart_toStartOf="@+id/gc_activity_indicator"
-            app:layout_constraintTop_toBottomOf="@+id/gc_activity_indicator" />
+            app:layout_constraintEnd_toEndOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintStart_toStartOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintTop_toBottomOf="@+id/gc_injected_loading_indicator" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -248,22 +248,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ProgressBar
-            android:id="@+id/gc_activity_indicator"
+        <net.gini.android.capture.view.InjectedViewContainer
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:indeterminateOnly="true"
-            android:indeterminateTint="@color/gc_analysis_activity_indicator"
-            android:indeterminateTintMode="src_in"
-            android:padding="@dimen/gc_camera_activity_indicator_padding"
-            android:visibility="invisible"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="@+id/gc_camera_frame"
             app:layout_constraintEnd_toEndOf="@+id/gc_qr_code_check"
             app:layout_constraintStart_toStartOf="@+id/gc_qr_code_check"
-            app:layout_constraintTop_toTopOf="@+id/gc_camera_frame"
-            tools:targetApi="lollipop"
-            tools:visibility="gone" />
+            app:layout_constraintTop_toTopOf="@+id/gc_camera_frame" />
 
         <TextView
             style="@style/GiniCaptureTheme.Typography.Body2"

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -263,20 +263,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ProgressBar
-            android:id="@+id/gc_activity_indicator"
+        <net.gini.android.capture.view.InjectedViewContainer
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:indeterminateOnly="true"
-            android:indeterminateTint="@color/gc_analysis_activity_indicator"
-            android:indeterminateTintMode="src_in"
-            android:padding="@dimen/large"
-            android:visibility="gone"
-            tools:targetApi="lollipop" />
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <TextView
             style="@style/GiniCaptureTheme.Typography.Body2"

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -1,6 +1,6 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/gc_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -31,10 +31,10 @@
         android:id="@+id/gc_camera_focus_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         android:alpha="0"
-        android:src="@drawable/gc_camera_focus_indicator" />
+        android:src="@drawable/gc_camera_focus_indicator"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <FrameLayout
         android:id="@+id/gc_camera_pane_background"
@@ -193,11 +193,11 @@
         android:id="@+id/gc_stub_camera_no_permission"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
+        android:layout="@layout/gc_layout_camera_no_permission"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout="@layout/gc_layout_camera_no_permission" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
     <View
@@ -208,9 +208,9 @@
         android:visibility="gone" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/gc_camera_frame_wrapper"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:id="@+id/gc_camera_frame_wrapper"
         app:layout_constraintBottom_toTopOf="@+id/gc_pane_wrapper"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -263,27 +263,28 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator_container"
+            android:id="@+id/gc_injected_loading_indicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintTop_toTopOf="parent" />
+
 
         <TextView
+            android:id="@+id/gc_retrieving_invoice"
             style="@style/GiniCaptureTheme.Typography.Body2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/gc_retrieving_invoice"
             android:textColor="@color/Light_01"
-            android:id="@+id/gc_retrieving_invoice"
             android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@+id/gc_activity_indicator"
-            app:layout_constraintStart_toStartOf="@+id/gc_activity_indicator"
-            app:layout_constraintTop_toBottomOf="@+id/gc_activity_indicator" />
+            app:layout_constraintEnd_toEndOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintStart_toStartOf="@+id/gc_injected_loading_indicator"
+            app:layout_constraintTop_toBottomOf="@+id/gc_injected_loading_indicator" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -264,7 +264,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <net.gini.android.capture.view.InjectedViewContainer
-            android:id="@+id/gc_injected_loading_indicator"
+            android:id="@+id/gc_injected_loading_indicator_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"


### PR DESCRIPTION
Pia 3234

Custom loading indicator injected in the camera. There was a possible issue with an injected view not working properly, with the progress bar showing only on the first shot, workaround is to inflate the view again in onResume 