### PR TITLE
chore: Update okhttp3 to 4.10.0

### DIFF
--- a/bank-api-library/library/build.gradle.kts
+++ b/bank-api-library/library/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.moshi.core)
-    implementation(libs.retrofit)
     implementation(libs.retrofit.moshi.converter)
     kapt(libs.moshi.codegen)
 

--- a/core-api-library/library/build.gradle.kts
+++ b/core-api-library/library/build.gradle.kts
@@ -45,6 +45,7 @@ android {
 
 dependencies {
     api(libs.retrofit)
+    implementation(libs.okhttp3)
     implementation(libs.trustkit)
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.core)

--- a/core-api-library/shared-tests/build.gradle.kts
+++ b/core-api-library/shared-tests/build.gradle.kts
@@ -40,7 +40,6 @@ android {
 dependencies {
     implementation(project(":core-api-library:library"))
     implementation(libs.trustkit)
-    implementation(libs.retrofit)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,7 @@ benManesVersions-gradle = "com.github.ben-manes:gradle-versions-plugin:0.39.0"
 trustkit = "com.datatheorem.android.trustkit:trustkit:1.1.5"
 jUnitParams = "pl.pragmatists:JUnitParams:1.1.1"
 retrofit = "com.squareup.retrofit2:retrofit:2.9.0"
+okhttp3 = "com.squareup.okhttp3:okhttp:4.10.0"
 retrofit-moshi-converter = "com.squareup.retrofit2:converter-moshi:2.4.0"
 okhttp3-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:4.2.1"
 

--- a/health-api-library/library/build.gradle.kts
+++ b/health-api-library/library/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.moshi.core)
-    implementation(libs.retrofit)
     implementation(libs.retrofit.moshi.converter)
     kapt(libs.moshi.codegen)
 


### PR DESCRIPTION
Fixes security vulnerabilities detected in 3.14.9.

Affects: core-api-library, bank-api-library, health-api-library

PIA-3350