### PR TITLE
fix: Add proguard rule to libraries to preserve all retrofit service interface methods

### DIFF
--- a/bank-api-library/library/build.gradle.kts
+++ b/bank-api-library/library/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            consumerProguardFile("proguard-rules.pro")
         }
     }
     compileOptions {

--- a/bank-api-library/library/proguard-rules.pro
+++ b/bank-api-library/library/proguard-rules.pro
@@ -15,3 +15,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Retain Retrofit service methods
+-keep,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}

--- a/core-api-library/library/build.gradle.kts
+++ b/core-api-library/library/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            consumerProguardFile("proguard-rules.pro")
         }
     }
     compileOptions {

--- a/core-api-library/library/proguard-rules.pro
+++ b/core-api-library/library/proguard-rules.pro
@@ -15,3 +15,19 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Retain Retrofit service methods
+-keep,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore these missing classes related to okhttp3 as they are not used on Android
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/health-api-library/library/build.gradle.kts
+++ b/health-api-library/library/build.gradle.kts
@@ -33,7 +33,7 @@ android {
         }
         getByName("release") {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            consumerProguardFile("proguard-rules.pro")
         }
     }
     compileOptions {

--- a/health-api-library/library/proguard-rules.pro
+++ b/health-api-library/library/proguard-rules.pro
@@ -15,3 +15,8 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Retain Retrofit service methods
+-keep,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}


### PR DESCRIPTION
Affects: core-api-library, bank-api-library, health-api-library

PIA-3387