### PR TITLE
Pia 3447 fix analysis screen error handling

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
@@ -18,6 +18,7 @@ import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction;
 import net.gini.android.capture.noresults.NoResultsActivity;
 import net.gini.android.capture.onboarding.OnboardingActivity;
 import net.gini.android.capture.review.ReviewActivity;
+import net.gini.android.capture.review.multipage.MultiPageReviewActivity;
 import net.gini.android.capture.tracking.AnalysisScreenEvent;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import static net.gini.android.capture.camera.CameraActivity.RESULT_CAMERA_SCREEN;
 import static net.gini.android.capture.camera.CameraActivity.RESULT_ENTER_MANUALLY;
+import static net.gini.android.capture.error.ErrorActivity.ERROR_SCREEN_REQUEST;
 import static net.gini.android.capture.internal.util.ActivityHelper.enableHomeAsUp;
 import static net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPressed;
 import static net.gini.android.capture.noresults.NoResultsActivity.NO_RESULT_CANCEL_KEY;
@@ -399,8 +401,11 @@ public class AnalysisActivity extends AppCompatActivity implements
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-        if (requestCode == NO_RESULT_REQUEST &&
+        if ((requestCode == NO_RESULT_REQUEST || requestCode == ERROR_SCREEN_REQUEST) &&
                 ((resultCode == RESULT_CANCELED && data != null && data.hasExtra(NO_RESULT_CANCEL_KEY)) || resultCode == RESULT_ENTER_MANUALLY || resultCode == RESULT_CAMERA_SCREEN)) {
+            if (resultCode == RESULT_CAMERA_SCREEN) {
+                GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+            }
             setResult(resultCode, data);
         }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisActivity.java
@@ -386,7 +386,9 @@ public class AnalysisActivity extends AppCompatActivity implements
             noResultsActivity.setExtrasClassLoader(AnalysisActivity.class.getClassLoader());
             startActivityForResult(noResultsActivity, NO_RESULT_REQUEST);
             setResult(RESULT_NO_EXTRACTIONS);
-            GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+            if (GiniCapture.hasInstance()) {
+                GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+            }
         } else {
             final Intent result = new Intent();
             setResult(RESULT_OK, result);
@@ -404,7 +406,9 @@ public class AnalysisActivity extends AppCompatActivity implements
         if ((requestCode == NO_RESULT_REQUEST || requestCode == ERROR_SCREEN_REQUEST) &&
                 ((resultCode == RESULT_CANCELED && data != null && data.hasExtra(NO_RESULT_CANCEL_KEY)) || resultCode == RESULT_ENTER_MANUALLY || resultCode == RESULT_CAMERA_SCREEN)) {
             if (resultCode == RESULT_CAMERA_SCREEN) {
-                GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+                if (GiniCapture.hasInstance()) {
+                    GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+                }
             }
             setResult(resultCode, data);
         }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisInteractor.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisInteractor.java
@@ -66,7 +66,11 @@ public class AnalysisInteractor {
                                             requestResult,
                                     final Throwable throwable) {
                                 if (throwable != null && !isCancellation(throwable)) {
-                                    throw new RuntimeException(throwable); // NOPMD
+                                    if (throwable instanceof FailureException) {
+                                        throw new FailureException(((FailureException) throwable).errorType);
+                                    } else {
+                                        throw new RuntimeException(throwable); // NOPMD
+                                    }
                                 } else if (requestResult != null) {
                                     final Map<String, GiniCaptureSpecificExtraction> extractions =
                                             requestResult.getAnalysisResult().getExtractions();

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
@@ -21,6 +21,7 @@ import net.gini.android.capture.document.GiniCaptureDocumentError;
 import net.gini.android.capture.document.GiniCaptureMultiPageDocument;
 import net.gini.android.capture.document.PdfDocument;
 import net.gini.android.capture.error.ErrorActivity;
+import net.gini.android.capture.error.ErrorType;
 import net.gini.android.capture.internal.camera.photo.ParcelableMemoryCache;
 import net.gini.android.capture.internal.document.DocumentRenderer;
 import net.gini.android.capture.internal.document.DocumentRendererFactory;
@@ -495,7 +496,16 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
         errorDetails.put(ERROR_DETAILS_MAP_KEY.ERROR_OBJECT, throwable);
         trackAnalysisScreenEvent(AnalysisScreenEvent.ERROR, errorDetails);
 
-        FailureException exception = (FailureException) throwable;
-        ErrorActivity.startErrorActivity(getActivity(), exception.errorType, mMultiPageDocument);
+        final ErrorType errorType;
+        if (throwable instanceof FailureException) {
+            FailureException exception = (FailureException) throwable;
+            errorType = exception.errorType;
+        } else if (throwable.getCause() instanceof FailureException) {
+            FailureException exception = (FailureException) throwable.getCause();
+            errorType = exception.errorType;
+        } else {
+            errorType = ErrorType.GENERAL;
+        }
+        ErrorActivity.startErrorActivity(getActivity(), errorType, mMultiPageDocument);
     }
 }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -915,8 +915,12 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         if (mFragment.getActivity() == null)
             return;
 
-        FailureException exception = (FailureException) throwable;
-        ErrorActivity.startErrorActivity(mFragment.getActivity(), exception.errorType, document);
+        if (throwable instanceof FailureException) {
+            FailureException exception = (FailureException) throwable;
+            ErrorActivity.startErrorActivity(mFragment.getActivity(), exception.errorType, document);
+        } else {
+            ErrorActivity.startErrorActivity(mFragment.getActivity(), ErrorType.GENERAL, document);
+        }
     }
 
     private void showFileChooser() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/error/ErrorType.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/error/ErrorType.kt
@@ -60,7 +60,7 @@ enum class ErrorType(@DrawableRes val drawableResource: Int,
                     FileImportValidator.Error.TOO_MANY_PDF_PAGES -> FILE_IMPORT_PAGE_COUNT
                     FileImportValidator.Error.TOO_MANY_DOCUMENT_PAGES -> FILE_IMPORT_PAGE_COUNT
                     else -> {
-                        NO_CONNECTION
+                        GENERAL
                     }
                 }
             }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
@@ -269,9 +269,8 @@ public class NetworkRequestsManager {
                                         "Document deletion failed for {}: {}",
                                         document.getId(),
                                         error.getMessage());
-                                future.completeExceptionally(
-                                        new RuntimeException(
-                                                error.getMessage(), error.getCause()));
+                                ErrorType errorType = ErrorType.typeFromError(error);
+                                future.completeExceptionally(new FailureException(errorType));
                             }
 
                             @Override
@@ -384,8 +383,8 @@ public class NetworkRequestsManager {
                             public void failure(final Error error) {
                                 LOG.error("Document analysis failed for {}: {}",
                                         multiPageDocument.getId(), error.getMessage());
-                                future.completeExceptionally(
-                                        new RuntimeException(error.getMessage(), error.getCause()));
+                                ErrorType errorType = ErrorType.typeFromError(error);
+                                future.completeExceptionally(new FailureException(errorType));
                             }
 
                             @Override

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/network/FailureException.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/network/FailureException.java
@@ -2,7 +2,7 @@ package net.gini.android.capture.network;
 
 import net.gini.android.capture.error.ErrorType;
 
-public class FailureException extends Exception {
+public class FailureException extends RuntimeException {
 
     public final ErrorType errorType;
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/ReviewFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/ReviewFragmentImpl.java
@@ -35,6 +35,7 @@ import net.gini.android.capture.document.DocumentFactory;
 import net.gini.android.capture.document.GiniCaptureDocument;
 import net.gini.android.capture.document.ImageDocument;
 import net.gini.android.capture.error.ErrorActivity;
+import net.gini.android.capture.error.ErrorType;
 import net.gini.android.capture.internal.cache.PhotoMemoryCache;
 import net.gini.android.capture.internal.camera.photo.ParcelableMemoryCache;
 import net.gini.android.capture.internal.camera.photo.Photo;
@@ -258,8 +259,12 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
             return;
         }
 
-        FailureException exception = (FailureException) throwable;
-        ErrorActivity.startErrorActivity(activity, exception.errorType, document);
+        if (throwable instanceof FailureException) {
+            FailureException exception = (FailureException) throwable;
+            ErrorActivity.startErrorActivity(activity, exception.errorType, document);
+        } else {
+            ErrorActivity.startErrorActivity(activity, ErrorType.GENERAL, document);
+        }
 
         if (GiniCapture.hasInstance()) {
             GiniCapture.getInstance().internal().setReviewScreenAnalysisError(throwable);

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewActivity.java
@@ -364,7 +364,9 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
 
         if (requestCode == ERROR_SCREEN_REQUEST) {
             if (resultCode == RESULT_CAMERA_SCREEN) {
-                GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+                if (GiniCapture.hasInstance()) {
+                    GiniCapture.getInstance().internal().getImageMultiPageDocumentMemoryStore().clear();
+                }
                 startActivity(CameraActivity.createIntent(MultiPageReviewActivity.this, false));
             }
             if (resultCode == RESULT_ENTER_MANUALLY) {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
@@ -764,8 +764,12 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
    private void handleError(Throwable throwable, Document document) {
        if (getActivity() != null) {
-           FailureException exception = (FailureException) throwable;
-           ErrorActivity.startErrorActivity(requireActivity(), exception.errorType, document);
+           if (throwable instanceof FailureException) {
+               FailureException exception = (FailureException) throwable;
+               ErrorActivity.startErrorActivity(requireActivity(), exception.errorType, document);
+           } else {
+               ErrorActivity.startErrorActivity(requireActivity(), ErrorType.GENERAL, document);
+           }
        }
    }
 


### PR DESCRIPTION
While testing with our partially restored backend I found a few issues with our error handling in the analysis screen:
* Errors were lost due to a casting exception from Throwable to FailureException. I made sure that the FailureException is forwarded through the AnalysisInteractor without wrapping it into a RuntimeException. Also I made the casting to fail gracefully and as a fallback show the GENERAL error type.
* The error screen results were not properly handled by the AnalysisActivity. I added the same logic we have in the MultiPageReviewActivity.
* In case of polling timeout we showed NO_CONNECTION error and I replaced it with GENERAL as the general fallback error type.

@llevente Please apply any changes you see fit and merge it afterwards. Thank you!