### PR TITLE
fix(capture-sdk): Fix analysis cancellation handling

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
@@ -334,6 +334,9 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
                     public Void apply(final AnalysisInteractor.ResultHolder resultHolder,
                                       final Throwable throwable) {
                         stopScanAnimation();
+                        if (isStopped()) {
+                            return null;
+                        }
                         if (throwable != null) {
                             handleAnalysisError(throwable);
                             return null;

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
@@ -8,17 +8,20 @@ package net.gini.android.capture.internal.network;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import net.gini.android.capture.AsyncCallback;
 import net.gini.android.capture.GiniCaptureDebug;
 import net.gini.android.capture.document.GiniCaptureDocument;
 import net.gini.android.capture.document.GiniCaptureMultiPageDocument;
 import net.gini.android.capture.document.ImageDocument;
+import net.gini.android.capture.error.ErrorType;
 import net.gini.android.capture.internal.cache.DocumentDataMemoryCache;
 import net.gini.android.capture.logging.ErrorLog;
 import net.gini.android.capture.logging.ErrorLogger;
 import net.gini.android.capture.network.AnalysisResult;
 import net.gini.android.capture.network.Error;
-import net.gini.android.capture.error.ErrorType;
 import net.gini.android.capture.network.GiniCaptureNetworkCallback;
 import net.gini.android.capture.network.GiniCaptureNetworkService;
 import net.gini.android.capture.network.Result;
@@ -34,8 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import jersey.repackaged.jsr166e.CompletableFuture;
 
 /**
@@ -158,7 +159,8 @@ public class NetworkRequestsManager {
     }
 
     public static boolean isCancellation(@NonNull final Throwable throwable) {
-        return throwable instanceof CancellationException;
+        return throwable instanceof CancellationException ||
+                (throwable.getCause() != null && throwable.getCause() instanceof CancellationException);
     }
 
     public CompletableFuture<NetworkRequestResult<GiniCaptureDocument>> delete(


### PR DESCRIPTION
Don't show the error screen when analysis was cancelled.

PIA-3666