### PR TITLE
Pia 3799 fix crash when closing camera screen

### DIFF
--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
@@ -35,6 +35,7 @@ import net.gini.android.capture.requirements.GiniCaptureRequirements
 import net.gini.android.capture.requirements.RequirementsReport
 import net.gini.android.capture.util.CancellationToken
 import net.gini.android.capture.view.DefaultNavigationBarTopAdapter
+import net.gini.android.capture.view.InjectedViewAdapterInstance
 import net.gini.android.capture.view.NavigationBarTopAdapter
 import net.gini.android.core.api.Resource
 import net.gini.android.core.api.models.PaymentRequest
@@ -67,13 +68,37 @@ object GiniBank {
     /**
      * Bottom navigation bar adapters. Could be changed to custom ones.
      */
-    var digitalInvoiceOnboardingNavigationBarBottomAdapter: DigitalInvoiceOnboardingNavigationBarBottomAdapter = DefaultDigitalInvoiceOnboardingNavigationBarBottomAdapter()
-    var digitalInvoiceHelpNavigationBarBottomAdapter: DigitalInvoiceHelpNavigationBarBottomAdapter = DefaultDigitalInvoiceHelpNavigationBarBottomAdapter()
+    internal var digitalInvoiceOnboardingNavigationBarBottomAdapterInstance: InjectedViewAdapterInstance<DigitalInvoiceOnboardingNavigationBarBottomAdapter> =
+        InjectedViewAdapterInstance(DefaultDigitalInvoiceOnboardingNavigationBarBottomAdapter())
+    var digitalInvoiceOnboardingNavigationBarBottomAdapter: DigitalInvoiceOnboardingNavigationBarBottomAdapter
+        set(value) {
+            digitalInvoiceOnboardingNavigationBarBottomAdapterInstance = InjectedViewAdapterInstance(value)
+        }
+        get() = digitalInvoiceOnboardingNavigationBarBottomAdapterInstance.viewAdapter
 
-    var digitalInvoiceOnboardingIllustrationAdapter: OnboardingIllustrationAdapter = ImageOnboardingIllustrationAdapter(R.drawable.gbs_digital_invoice_list_image,
-        R.string.gbs_digital_invoice_illustration)
+    internal var digitalInvoiceHelpNavigationBarBottomAdapterInstance: InjectedViewAdapterInstance<DigitalInvoiceHelpNavigationBarBottomAdapter> =
+        InjectedViewAdapterInstance(DefaultDigitalInvoiceHelpNavigationBarBottomAdapter())
+    var digitalInvoiceHelpNavigationBarBottomAdapter: DigitalInvoiceHelpNavigationBarBottomAdapter
+        set(value) {
+            digitalInvoiceHelpNavigationBarBottomAdapterInstance = InjectedViewAdapterInstance(value)
+        }
+        get() = digitalInvoiceHelpNavigationBarBottomAdapterInstance.viewAdapter
 
-    var digitalInvoiceNavigationBarBottomAdapter: DigitalInvoiceNavigationBarBottomAdapter = DefaultDigitalInvoiceNavigationBarBottomAdapter()
+    internal var digitalInvoiceOnboardingIllustrationAdapterInstance: InjectedViewAdapterInstance<OnboardingIllustrationAdapter> =
+        InjectedViewAdapterInstance(ImageOnboardingIllustrationAdapter(R.drawable.gbs_digital_invoice_list_image, R.string.gbs_digital_invoice_illustration))
+    var digitalInvoiceOnboardingIllustrationAdapter: OnboardingIllustrationAdapter
+        set(value) {
+            digitalInvoiceOnboardingIllustrationAdapterInstance = InjectedViewAdapterInstance(value)
+        }
+        get() = digitalInvoiceOnboardingIllustrationAdapterInstance.viewAdapter
+
+    internal var digitalInvoiceNavigationBarBottomAdapterInstance: InjectedViewAdapterInstance<DigitalInvoiceNavigationBarBottomAdapter> =
+        InjectedViewAdapterInstance(DefaultDigitalInvoiceNavigationBarBottomAdapter())
+    var digitalInvoiceNavigationBarBottomAdapter: DigitalInvoiceNavigationBarBottomAdapter
+        set(value) {
+            digitalInvoiceNavigationBarBottomAdapterInstance = InjectedViewAdapterInstance(value)
+        }
+        get() = digitalInvoiceNavigationBarBottomAdapterInstance.viewAdapter
 
     internal fun getCaptureConfiguration() = captureConfiguration
 

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/help/HelpActivity.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/help/HelpActivity.kt
@@ -12,6 +12,7 @@ import net.gini.android.bank.sdk.capture.digitalinvoice.help.view.DigitalInvoice
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.internal.ui.IntervalClickListener
 import net.gini.android.capture.internal.util.ActivityHelper
+import net.gini.android.capture.view.InjectedViewAdapterHolder
 import net.gini.android.capture.view.InjectedViewContainer
 import net.gini.android.capture.view.NavButtonType
 import net.gini.android.capture.view.NavigationBarTopAdapter
@@ -57,20 +58,19 @@ class HelpActivity : AppCompatActivity() {
             findViewById<InjectedViewContainer<NavigationBarTopAdapter>>(R.id.gbs_injected_navigation_bar_container_top)
         if (GiniCapture.hasInstance()) {
 
-            topBarInjectedViewContainer.injectedViewAdapter =
-                GiniCapture.getInstance().navigationBarTopAdapter
+            topBarInjectedViewContainer.injectedViewAdapterHolder = InjectedViewAdapterHolder(
+                GiniCapture.getInstance().internal().navigationBarTopAdapterInstance
+            ) { injectedAdapterView ->
+                val navType = if (GiniCapture.getInstance().isBottomNavigationBarEnabled)
+                    NavButtonType.NONE else NavButtonType.BACK
+                injectedAdapterView.setNavButtonType(navType)
 
-            val topBarAdapter = topBarInjectedViewContainer?.injectedViewAdapter
+                injectedAdapterView.setTitle(getString(net.gini.android.capture.R.string.gc_title_help))
 
-            val navType = if (GiniCapture.getInstance().isBottomNavigationBarEnabled)
-                NavButtonType.NONE else NavButtonType.BACK
-            topBarAdapter?.setNavButtonType(navType)
-
-            topBarAdapter?.setTitle(getString(net.gini.android.capture.R.string.gc_title_help))
-
-            topBarAdapter?.setOnNavButtonClickListener(IntervalClickListener {
-                onBackPressed()
-            })
+                injectedAdapterView.setOnNavButtonClickListener(IntervalClickListener {
+                    onBackPressed()
+                })
+            }
         }
     }
 
@@ -78,11 +78,12 @@ class HelpActivity : AppCompatActivity() {
         if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled) {
             val injectedViewContainer =
                 findViewById<InjectedViewContainer<DigitalInvoiceHelpNavigationBarBottomAdapter>>(R.id.gbs_injected_navigation_bar_container_bottom)
-            val adapter = GiniBank.digitalInvoiceHelpNavigationBarBottomAdapter
-            injectedViewContainer.injectedViewAdapter = adapter
-            adapter.setOnBackButtonClickListener(IntervalClickListener {
-                onBackPressed()
-            })
+            injectedViewContainer.injectedViewAdapterHolder =
+                InjectedViewAdapterHolder(GiniBank.digitalInvoiceHelpNavigationBarBottomAdapterInstance) { injectedViewAdapter ->
+                    injectedViewAdapter.setOnBackButtonClickListener(IntervalClickListener {
+                        onBackPressed()
+                    })
+                }
         }
     }
 }

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/onboarding/DigitalInvoiceOnboardingFragment.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/onboarding/DigitalInvoiceOnboardingFragment.kt
@@ -13,6 +13,8 @@ import net.gini.android.bank.sdk.capture.util.autoCleared
 import net.gini.android.bank.sdk.databinding.GbsFragmentDigitalInvoiceOnboardingBinding
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.internal.ui.IntervalClickListener
+import net.gini.android.capture.onboarding.view.OnboardingIllustrationAdapter
+import net.gini.android.capture.view.InjectedViewAdapterHolder
 
 /**
  * Created by Alpar Szotyori on 14.10.2020.
@@ -109,6 +111,7 @@ class DigitalInvoiceOnboardingFragment : Fragment(), DigitalOnboardingScreenCont
      */
     override fun onStart() {
         super.onStart()
+        binding.digitalInvoiceImageContainer.modifyAdapterIfOwned { (it as OnboardingIllustrationAdapter).onVisible() }
         presenter?.start()
     }
 
@@ -119,6 +122,7 @@ class DigitalInvoiceOnboardingFragment : Fragment(), DigitalOnboardingScreenCont
      */
     override fun onStop() {
         super.onStop()
+        binding.digitalInvoiceImageContainer.modifyAdapterIfOwned { (it as OnboardingIllustrationAdapter).onHidden() }
         presenter?.stop()
     }
 
@@ -138,10 +142,8 @@ class DigitalInvoiceOnboardingFragment : Fragment(), DigitalOnboardingScreenCont
 
     private fun setupImageIllustrationAdapter() {
         if (GiniCapture.hasInstance()) {
-            binding.digitalInvoiceImageContainer.injectedViewAdapter =
-                GiniBank.digitalInvoiceOnboardingIllustrationAdapter
-
-            GiniBank.digitalInvoiceOnboardingIllustrationAdapter.onVisible()
+            binding.digitalInvoiceImageContainer.injectedViewAdapterHolder =
+                InjectedViewAdapterHolder(GiniBank.digitalInvoiceOnboardingIllustrationAdapterInstance) { it.onVisible() }
         }
     }
 
@@ -151,13 +153,16 @@ class DigitalInvoiceOnboardingFragment : Fragment(), DigitalOnboardingScreenCont
             binding.doneButton.visibility = View.INVISIBLE
             binding.doneButton.isEnabled = false
 
-            binding.gbsInjectedNavigationBarContainerBottom.injectedViewAdapter =
-                GiniBank.digitalInvoiceOnboardingNavigationBarBottomAdapter
-            GiniBank.digitalInvoiceOnboardingNavigationBarBottomAdapter.setGetStartedButtonClickListener(
-                IntervalClickListener {
-                    presenter?.dismisOnboarding(false)
+            binding.gbsInjectedNavigationBarContainerBottom.injectedViewAdapterHolder =
+                InjectedViewAdapterHolder(
+                    GiniBank.digitalInvoiceOnboardingNavigationBarBottomAdapterInstance
+                ) { injectedViewAdapter ->
+                    injectedViewAdapter.setGetStartedButtonClickListener(
+                        IntervalClickListener {
+                            presenter?.dismisOnboarding(false)
+                        }
+                    )
                 }
-            )
         }
     }
 
@@ -168,7 +173,6 @@ class DigitalInvoiceOnboardingFragment : Fragment(), DigitalOnboardingScreenCont
      */
     override fun onDestroyView() {
         listener = null
-        GiniBank.digitalInvoiceOnboardingIllustrationAdapter.onHidden()
         super.onDestroyView()
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
@@ -7,8 +7,6 @@ import static java.util.Collections.emptyMap;
 
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
-import android.widget.Toast;
 
 import net.gini.android.capture.analysis.AnalysisActivity;
 import net.gini.android.capture.camera.view.CameraNavigationBarBottomAdapter;
@@ -38,13 +36,13 @@ import net.gini.android.capture.review.multipage.view.ReviewNavigationBarBottomA
 import net.gini.android.capture.view.CustomLoadingIndicatorAdapter;
 import net.gini.android.capture.view.DefaultLoadingIndicatorAdapter;
 import net.gini.android.capture.view.DefaultOnButtonLoadingIndicatorAdapter;
+import net.gini.android.capture.view.InjectedViewAdapterInstance;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
 import net.gini.android.capture.view.DefaultNavigationBarTopAdapter;
 import net.gini.android.capture.network.GiniCaptureNetworkService;
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction;
 import net.gini.android.capture.onboarding.OnboardingPage;
 import net.gini.android.capture.review.ReviewActivity;
-import net.gini.android.capture.review.multipage.MultiPageReviewFragment;
 import net.gini.android.capture.tracking.AnalysisScreenEvent;
 import net.gini.android.capture.tracking.CameraScreenEvent;
 import net.gini.android.capture.tracking.Event;
@@ -55,7 +53,6 @@ import net.gini.android.capture.util.CancellationToken;
 import net.gini.android.capture.view.OnButtonLoadingIndicatorAdapter;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +60,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -117,20 +112,20 @@ public class GiniCapture {
     private final List<HelpItem.Custom> mCustomHelpItems;
     private final ErrorLogger mErrorLogger;
     private final int mImportedFileSizeBytesLimit;
-    private final NavigationBarTopAdapter navigationBarTopAdapter;
-    private final OnboardingNavigationBarBottomAdapter onboardingNavigationBarBottomAdapter;
-    private final HelpNavigationBarBottomAdapter helpNavigationBarBottomAdapter;
-    private final CameraNavigationBarBottomAdapter cameraNavigationBarBottomAdapter;
+    private final InjectedViewAdapterInstance<NavigationBarTopAdapter> navigationBarTopAdapterInstance;
+    private final InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> onboardingNavigationBarBottomAdapterInstance;
+    private final InjectedViewAdapterInstance<HelpNavigationBarBottomAdapter> helpNavigationBarBottomAdapterInstance;
+    private final InjectedViewAdapterInstance<CameraNavigationBarBottomAdapter> cameraNavigationBarBottomAdapterInstance;
     private final NoResultsNavigationBarBottomAdapter noResultsNavigationBarBottomAdapter;
     private final ErrorNavigationBarBottomAdapter errorNavigationBarBottomAdapter;
     private final boolean isBottomNavigationBarEnabled;
-    private final OnboardingIllustrationAdapter onboardingAlignCornersIllustrationAdapter;
-    private final OnboardingIllustrationAdapter onboardingLightingIllustrationAdapter;
-    private final OnboardingIllustrationAdapter onboardingMultiPageIllustrationAdapter;
-    private final OnboardingIllustrationAdapter onboardingQRCodeIllustrationAdapter;
-    private final CustomLoadingIndicatorAdapter loadingIndicatorAdapter;
-    private final ReviewNavigationBarBottomAdapter reviewNavigationBarBottomAdapter;
-    private final OnButtonLoadingIndicatorAdapter onButtonLoadingIndicatorAdapter;
+    private final InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingAlignCornersIllustrationAdapterInstance;
+    private final InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingLightingIllustrationAdapterInstance;
+    private final InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingMultiPageIllustrationAdapterInstance;
+    private final InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingQRCodeIllustrationAdapterInstance;
+    private final InjectedViewAdapterInstance<CustomLoadingIndicatorAdapter> loadingIndicatorAdapterInstance;
+    private final InjectedViewAdapterInstance<ReviewNavigationBarBottomAdapter> reviewNavigationBarBottomAdapterInstance;
+    private final InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> onButtonLoadingIndicatorAdapterInstance;
 
     /**
      * Retrieve the current instance.
@@ -293,20 +288,20 @@ public class GiniCapture {
                 builder.getGiniCaptureNetworkService(),
                 builder.getCustomErrorLoggerListener());
         mImportedFileSizeBytesLimit = builder.getImportedFileSizeBytesLimit();
-        navigationBarTopAdapter = builder.getNavigationBarTopAdapter();
-        onboardingNavigationBarBottomAdapter = builder.getOnboardingNavigationBarBottomAdapter();
-        helpNavigationBarBottomAdapter = builder.getHelpNavigationBarBottomAdapter();
+        navigationBarTopAdapterInstance = builder.getNavigationBarTopAdapterInstance();
+        onboardingNavigationBarBottomAdapterInstance = builder.getOnboardingNavigationBarBottomAdapterInstance();
+        helpNavigationBarBottomAdapterInstance = builder.getHelpNavigationBarBottomAdapterInstance();
         isBottomNavigationBarEnabled = builder.isBottomNavigationBarEnabled();
-        onboardingAlignCornersIllustrationAdapter = builder.getOnboardingAlignCornersIllustrationAdapter();
-        onboardingLightingIllustrationAdapter = builder.getOnboardingLightingIllustrationAdapter();
-        onboardingMultiPageIllustrationAdapter = builder.getOnboardingMultiPageIllustrationAdapter();
-        onboardingQRCodeIllustrationAdapter = builder.getOnboardingQRCodeIllustrationAdapter();
-        cameraNavigationBarBottomAdapter = builder.getCameraNavigationBarBottomAdapter();
+        onboardingAlignCornersIllustrationAdapterInstance = builder.getOnboardingAlignCornersIllustrationAdapterInstance();
+        onboardingLightingIllustrationAdapterInstance = builder.getOnboardingLightingIllustrationAdapterInstance();
+        onboardingMultiPageIllustrationAdapterInstance = builder.getOnboardingMultiPageIllustrationAdapterInstance();
+        onboardingQRCodeIllustrationAdapterInstance = builder.getOnboardingQRCodeIllustrationAdapterInstance();
+        cameraNavigationBarBottomAdapterInstance = builder.getCameraNavigationBarBottomAdapterInstance();
         noResultsNavigationBarBottomAdapter = builder.getNoResultsNavigationBarBottomAdapter();
         errorNavigationBarBottomAdapter = builder.getErrorNavigationBarBottomAdapter();
-        loadingIndicatorAdapter = builder.getLoadingIndicatorAdapter();
-        reviewNavigationBarBottomAdapter = builder.getReviewNavigationBarBottomAdapter();
-        onButtonLoadingIndicatorAdapter = builder.getOnButtonLoadingIndicatorAdapter();
+        loadingIndicatorAdapterInstance = builder.getLoadingIndicatorAdapterInstance();
+        reviewNavigationBarBottomAdapterInstance = builder.getReviewNavigationBarBottomAdapterInstance();
+        onButtonLoadingIndicatorAdapterInstance = builder.getOnButtonLoadingIndicatorAdapterInstance();
     }
 
     /**
@@ -568,22 +563,22 @@ public class GiniCapture {
 
     @NonNull
     public NavigationBarTopAdapter getNavigationBarTopAdapter() {
-        return navigationBarTopAdapter;
+        return navigationBarTopAdapterInstance.getViewAdapter();
     }
 
     @NonNull
     public OnboardingNavigationBarBottomAdapter getOnboardingNavigationBarBottomAdapter() {
-        return onboardingNavigationBarBottomAdapter;
+        return onboardingNavigationBarBottomAdapterInstance.getViewAdapter();
     }
 
     @NonNull
     public HelpNavigationBarBottomAdapter getHelpNavigationBarBottomAdapter() {
-        return helpNavigationBarBottomAdapter;
+        return helpNavigationBarBottomAdapterInstance.getViewAdapter();
     }
 
     @NonNull
     public CameraNavigationBarBottomAdapter getCameraNavigationBarBottomAdapter() {
-        return cameraNavigationBarBottomAdapter;
+        return cameraNavigationBarBottomAdapterInstance.getViewAdapter();
     }
 
     @NonNull
@@ -602,37 +597,49 @@ public class GiniCapture {
 
     @Nullable
     public OnboardingIllustrationAdapter getOnboardingAlignCornersIllustrationAdapter() {
-        return onboardingAlignCornersIllustrationAdapter;
+        if (onboardingAlignCornersIllustrationAdapterInstance == null) {
+            return null;
+        }
+        return onboardingAlignCornersIllustrationAdapterInstance.getViewAdapter();
     }
 
     @Nullable
     public OnboardingIllustrationAdapter getOnboardingLightingIllustrationAdapter() {
-        return onboardingLightingIllustrationAdapter;
+        if (onboardingLightingIllustrationAdapterInstance == null) {
+            return null;
+        }
+        return onboardingLightingIllustrationAdapterInstance.getViewAdapter();
     }
 
     @Nullable
     public OnboardingIllustrationAdapter getOnboardingMultiPageIllustrationAdapter() {
-        return onboardingMultiPageIllustrationAdapter;
+        if (onboardingMultiPageIllustrationAdapterInstance == null) {
+            return null;
+        }
+        return onboardingMultiPageIllustrationAdapterInstance.getViewAdapter();
     }
 
     @Nullable
     public OnboardingIllustrationAdapter getOnboardingQRCodeIllustrationAdapter() {
-        return onboardingQRCodeIllustrationAdapter;
+        if (onboardingQRCodeIllustrationAdapterInstance == null) {
+            return null;
+        }
+        return onboardingQRCodeIllustrationAdapterInstance.getViewAdapter();
     }
 
     @Nullable
-    public CustomLoadingIndicatorAdapter getloadingIndicatorAdapter() {
-        return loadingIndicatorAdapter;
+    public CustomLoadingIndicatorAdapter getLoadingIndicatorAdapter() {
+        return loadingIndicatorAdapterInstance.getViewAdapter();
     }
 
     @NonNull
     public ReviewNavigationBarBottomAdapter getReviewNavigationBarBottomAdapter() {
-        return reviewNavigationBarBottomAdapter;
+        return reviewNavigationBarBottomAdapterInstance.getViewAdapter();
     }
 
     @Nullable
     public OnButtonLoadingIndicatorAdapter getOnButtonLoadingIndicatorAdapter() {
-        return onButtonLoadingIndicatorAdapter;
+        return onButtonLoadingIndicatorAdapterInstance.getViewAdapter();
     }
 
     /**
@@ -685,21 +692,21 @@ public class GiniCapture {
         private boolean mGiniErrorLoggerIsOn = true;
         private ErrorLoggerListener mCustomErrorLoggerListener;
         private int mImportedFileSizeBytesLimit = FILE_SIZE_LIMIT;
-        private NavigationBarTopAdapter navigationBarTopAdapter = new DefaultNavigationBarTopAdapter();
-        private OnboardingNavigationBarBottomAdapter navigationBarBottomAdapter = new DefaultOnboardingNavigationBarBottomAdapter();
-        private HelpNavigationBarBottomAdapter helpNavigationBarBottomAdapter = new DefaultHelpNavigationBarBottomAdapter();
-        private CameraNavigationBarBottomAdapter cameraNavigationBarBottomAdapter = new DefaultCameraNavigationBarBottomAdapter();
+        private InjectedViewAdapterInstance<NavigationBarTopAdapter> navigationBarTopAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultNavigationBarTopAdapter());
+        private InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> navigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultOnboardingNavigationBarBottomAdapter());
+        private InjectedViewAdapterInstance<HelpNavigationBarBottomAdapter> helpNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultHelpNavigationBarBottomAdapter());
+        private InjectedViewAdapterInstance<CameraNavigationBarBottomAdapter> cameraNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultCameraNavigationBarBottomAdapter());
         private NoResultsNavigationBarBottomAdapter noResultsNavigationBarBottomAdapter = new DefaultNoResultsNavigationBarBottomAdapter();
         private ErrorNavigationBarBottomAdapter errorNavigationBarBottomAdapter = new DefaultErrorNavigationBarBottomAdapter();
         private boolean isBottomNavigationBarEnabled = false;
-        private OnboardingIllustrationAdapter onboardingAlignCornersIllustrationAdapter;
-        private OnboardingIllustrationAdapter onboardingLightingIllustrationAdapter;
-        private OnboardingIllustrationAdapter onboardingMultiPageIllustrationAdapter;
-        private OnboardingIllustrationAdapter onboardingQRCodeIllustrationAdapter;
-        private CustomLoadingIndicatorAdapter loadingIndicatorAdapter = new DefaultLoadingIndicatorAdapter();
-        private ReviewNavigationBarBottomAdapter reviewNavigationBarBottomAdapter = new DefaultReviewNavigationBarBottomAdapter();
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingAlignCornersIllustrationAdapterInstance;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingLightingIllustrationAdapterInstance;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingMultiPageIllustrationAdapterInstance;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> onboardingQRCodeIllustrationAdapterInstance;
+        private InjectedViewAdapterInstance<CustomLoadingIndicatorAdapter> loadingIndicatorAdapter = new InjectedViewAdapterInstance<>(new DefaultLoadingIndicatorAdapter());
+        private InjectedViewAdapterInstance<ReviewNavigationBarBottomAdapter> reviewNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultReviewNavigationBarBottomAdapter());
 
-        private OnButtonLoadingIndicatorAdapter onButtonLoadingIndicatorAdapter = new DefaultOnButtonLoadingIndicatorAdapter();
+        private InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> onButtonLoadingIndicatorAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultOnButtonLoadingIndicatorAdapter());
 
         /**
          * Create a new {@link GiniCapture} instance.
@@ -1030,13 +1037,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setNavigationBarTopAdapter(@NonNull final NavigationBarTopAdapter adapter) {
-            navigationBarTopAdapter = adapter;
+            navigationBarTopAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private NavigationBarTopAdapter getNavigationBarTopAdapter() {
-            return navigationBarTopAdapter;
+        private InjectedViewAdapterInstance<NavigationBarTopAdapter> getNavigationBarTopAdapterInstance() {
+            return navigationBarTopAdapterInstance;
         }
 
         /**
@@ -1046,13 +1053,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setOnboardingNavigationBarBottomAdapter(@NonNull final OnboardingNavigationBarBottomAdapter adapter) {
-            navigationBarBottomAdapter = adapter;
+            navigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private OnboardingNavigationBarBottomAdapter getOnboardingNavigationBarBottomAdapter() {
-            return navigationBarBottomAdapter;
+        private InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> getOnboardingNavigationBarBottomAdapterInstance() {
+            return navigationBarBottomAdapterInstance;
         }
 
         /**
@@ -1062,13 +1069,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setHelpNavigationBarBottomAdapter(@NonNull final HelpNavigationBarBottomAdapter adapter) {
-            helpNavigationBarBottomAdapter = adapter;
+            helpNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private HelpNavigationBarBottomAdapter getHelpNavigationBarBottomAdapter() {
-            return helpNavigationBarBottomAdapter;
+        private InjectedViewAdapterInstance<HelpNavigationBarBottomAdapter> getHelpNavigationBarBottomAdapterInstance() {
+            return helpNavigationBarBottomAdapterInstance;
         }
 
         /**
@@ -1078,12 +1085,12 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setCameraNavigationBarBottomAdapter(@NonNull final CameraNavigationBarBottomAdapter adapter) {
-            cameraNavigationBarBottomAdapter = adapter;
+            cameraNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
-        public CameraNavigationBarBottomAdapter getCameraNavigationBarBottomAdapter() {
-            return cameraNavigationBarBottomAdapter;
+        private InjectedViewAdapterInstance<CameraNavigationBarBottomAdapter> getCameraNavigationBarBottomAdapterInstance() {
+            return cameraNavigationBarBottomAdapterInstance;
         }
 
         /**
@@ -1132,8 +1139,8 @@ public class GiniCapture {
         }
 
         @NonNull
-        private OnboardingIllustrationAdapter getOnboardingAlignCornersIllustrationAdapter() {
-            return onboardingAlignCornersIllustrationAdapter;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> getOnboardingAlignCornersIllustrationAdapterInstance() {
+            return onboardingAlignCornersIllustrationAdapterInstance;
         }
 
         /**
@@ -1143,13 +1150,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setOnboardingAlignCornersIllustrationAdapter(@NonNull final OnboardingIllustrationAdapter adapter) {
-            onboardingAlignCornersIllustrationAdapter = adapter;
+            onboardingAlignCornersIllustrationAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private OnboardingIllustrationAdapter getOnboardingLightingIllustrationAdapter() {
-            return onboardingLightingIllustrationAdapter;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> getOnboardingLightingIllustrationAdapterInstance() {
+            return onboardingLightingIllustrationAdapterInstance;
         }
 
         /**
@@ -1159,13 +1166,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setOnboardingLightingIllustrationAdapter(@NonNull final OnboardingIllustrationAdapter adapter) {
-            onboardingLightingIllustrationAdapter = adapter;
+            onboardingLightingIllustrationAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private OnboardingIllustrationAdapter getOnboardingMultiPageIllustrationAdapter() {
-            return onboardingMultiPageIllustrationAdapter;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> getOnboardingMultiPageIllustrationAdapterInstance() {
+            return onboardingMultiPageIllustrationAdapterInstance;
         }
 
         /**
@@ -1175,13 +1182,13 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setOnboardingMultiPageIllustrationAdapter(@NonNull final OnboardingIllustrationAdapter adapter) {
-            onboardingMultiPageIllustrationAdapter = adapter;
+            onboardingMultiPageIllustrationAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private OnboardingIllustrationAdapter getOnboardingQRCodeIllustrationAdapter() {
-            return onboardingQRCodeIllustrationAdapter;
+        private InjectedViewAdapterInstance<OnboardingIllustrationAdapter> getOnboardingQRCodeIllustrationAdapterInstance() {
+            return onboardingQRCodeIllustrationAdapterInstance;
         }
 
         /**
@@ -1191,12 +1198,12 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setOnboardingQRCodeIllustrationAdapter(@NonNull final OnboardingIllustrationAdapter adapter) {
-            onboardingQRCodeIllustrationAdapter = adapter;
+            onboardingQRCodeIllustrationAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private CustomLoadingIndicatorAdapter getLoadingIndicatorAdapter() {
+        private InjectedViewAdapterInstance<CustomLoadingIndicatorAdapter> getLoadingIndicatorAdapterInstance() {
             return loadingIndicatorAdapter;
         }
 
@@ -1207,17 +1214,17 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setLoadingIndicatorAdapter(@NonNull final CustomLoadingIndicatorAdapter adapter) {
-            loadingIndicatorAdapter = adapter;
+            loadingIndicatorAdapter = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
         @NonNull
-        private OnButtonLoadingIndicatorAdapter getOnButtonLoadingIndicatorAdapter() {
-            return onButtonLoadingIndicatorAdapter;
+        private InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> getOnButtonLoadingIndicatorAdapterInstance() {
+            return onButtonLoadingIndicatorAdapterInstance;
         }
 
         public Builder setOnButtonLoadingIndicatorAdapter(@NonNull final OnButtonLoadingIndicatorAdapter adapter) {
-            onButtonLoadingIndicatorAdapter = adapter;
+            onButtonLoadingIndicatorAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
@@ -1228,12 +1235,12 @@ public class GiniCapture {
          * @return the {@link Builder} instance
          */
         public Builder setReviewBottomBarNavigationAdapter(@NonNull final ReviewNavigationBarBottomAdapter adapter) {
-            reviewNavigationBarBottomAdapter = adapter;
+            reviewNavigationBarBottomAdapterInstance = new InjectedViewAdapterInstance<>(adapter);
             return this;
         }
 
-        private ReviewNavigationBarBottomAdapter getReviewNavigationBarBottomAdapter() {
-            return reviewNavigationBarBottomAdapter;
+        private InjectedViewAdapterInstance<ReviewNavigationBarBottomAdapter> getReviewNavigationBarBottomAdapterInstance() {
+            return reviewNavigationBarBottomAdapterInstance;
         }
     }
 
@@ -1306,6 +1313,34 @@ public class GiniCapture {
 
         public Map<String, GiniCaptureCompoundExtraction> getCompoundExtractions() {
             return mCompoundExtractions;
+        }
+
+        public InjectedViewAdapterInstance<NavigationBarTopAdapter> getNavigationBarTopAdapterInstance() {
+            return mGiniCapture.navigationBarTopAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<CameraNavigationBarBottomAdapter> getCameraNavigationBarBottomAdapterInstance() {
+            return mGiniCapture.cameraNavigationBarBottomAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<HelpNavigationBarBottomAdapter> getHelpNavigationBarBottomAdapterInstance() {
+            return mGiniCapture.helpNavigationBarBottomAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<CustomLoadingIndicatorAdapter> getLoadingIndicatorAdapterInstance() {
+            return mGiniCapture.loadingIndicatorAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> getOnboardingNavigationBarBottomAdapterInstance() {
+            return mGiniCapture.onboardingNavigationBarBottomAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<ReviewNavigationBarBottomAdapter> getReviewNavigationBarBottomAdapterInstance() {
+            return mGiniCapture.reviewNavigationBarBottomAdapterInstance;
+        }
+
+        public InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> getOnButtonLoadingIndicatorAdapterInstance() {
+            return mGiniCapture.onButtonLoadingIndicatorAdapterInstance;
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/error/ErrorActivity.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/error/ErrorActivity.kt
@@ -18,6 +18,7 @@ import net.gini.android.capture.noresults.NoResultsActivity.EXTRA_IN_DOCUMENT
 import net.gini.android.capture.ImageRetakeOptionsListener
 import net.gini.android.capture.error.view.ErrorNavigationBarBottomAdapter
 import net.gini.android.capture.internal.ui.IntervalClickListener
+import net.gini.android.capture.view.InjectedViewAdapterHolder
 import net.gini.android.capture.view.InjectedViewContainer
 import net.gini.android.capture.view.NavButtonType
 import net.gini.android.capture.view.NavigationBarTopAdapter
@@ -51,30 +52,33 @@ class ErrorActivity : AppCompatActivity(),
         val topBarContainer =
             findViewById<InjectedViewContainer<NavigationBarTopAdapter>>(R.id.gc_injected_navigation_bar_container_top)
         if (GiniCapture.hasInstance()) {
-            topBarContainer.injectedViewAdapter = GiniCapture.getInstance().navigationBarTopAdapter
+            topBarContainer.injectedViewAdapterHolder = InjectedViewAdapterHolder(GiniCapture.getInstance().internal().navigationBarTopAdapterInstance) { injectedViewAdapter ->
+                injectedViewAdapter.apply {
+                    setTitle(getString(R.string.gc_title_error))
 
-            topBarContainer.injectedViewAdapter?.apply {
-                setTitle(getString(R.string.gc_title_error))
-
-                if (!GiniCapture.getInstance().isBottomNavigationBarEnabled) {
-                    setNavButtonType(NavButtonType.BACK)
-                    setOnNavButtonClickListener(IntervalClickListener {
-                        onBackPressed()
-                    })
-                } else setNavButtonType(NavButtonType.NONE)
+                    if (!GiniCapture.getInstance().isBottomNavigationBarEnabled) {
+                        setNavButtonType(NavButtonType.BACK)
+                        setOnNavButtonClickListener(IntervalClickListener {
+                            onBackPressed()
+                        })
+                    } else {
+                        setNavButtonType(NavButtonType.NONE)
+                    }
+                }
             }
         }
     }
 
     private fun setBottomBarInjectedContainer() {
         if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled) {
-            val bottomBarContainer = findViewById<InjectedViewContainer<ErrorNavigationBarBottomAdapter>>(R.id.gc_injected_navigation_bar_container_bottom)
-            bottomBarContainer.injectedViewAdapter = GiniCapture.getInstance().errorNavigationBarBottomAdapter
-            bottomBarContainer.injectedViewAdapter?.apply {
-                setOnBackButtonClickListener(IntervalClickListener {
-                    onBackPressed()
-                })
-            }
+            // TODO: remove later
+//            val bottomBarContainer = findViewById<InjectedViewContainer<ErrorNavigationBarBottomAdapter>>(R.id.gc_injected_navigation_bar_container_bottom)
+//            bottomBarContainer.injectedViewAdapter = GiniCapture.getInstance().errorNavigationBarBottomAdapter
+//            bottomBarContainer.injectedViewAdapter?.apply {
+//                setOnBackButtonClickListener(IntervalClickListener {
+//                    onBackPressed()
+//                })
+//            }
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/FileImportActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/FileImportActivity.java
@@ -28,6 +28,7 @@ import net.gini.android.capture.help.view.HelpNavigationBarBottomAdapter;
 import net.gini.android.capture.internal.ui.IntervalClickListener;
 import net.gini.android.capture.noresults.NoResultsActivity;
 import net.gini.android.capture.review.ReviewActivity;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
 import net.gini.android.capture.view.NavButtonType;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
@@ -71,35 +72,30 @@ public class FileImportActivity extends AppCompatActivity {
         new Handler(Looper.getMainLooper()).postDelayed(this::showCustomSnackBar, 500);
     }
 
-    private void setupBottomBarNavigation() {
-        InjectedViewContainer<HelpNavigationBarBottomAdapter> injectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_bottom);
-        if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-
-            injectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getHelpNavigationBarBottomAdapter());
-
-            HelpNavigationBarBottomAdapter helpNavigationBarBottomAdapter = injectedViewContainer.getInjectedViewAdapter();
-            assert helpNavigationBarBottomAdapter != null;
-            helpNavigationBarBottomAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
-                onBackPressed();
-            }));
-        }
-    }
-
     private void setupTopBarNavigation() {
         InjectedViewContainer<NavigationBarTopAdapter> topBarInjectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_top);
         if (GiniCapture.hasInstance()) {
+            topBarInjectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getNavigationBarTopAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
+                        injectedViewAdapter.setTitle(getString(R.string.gc_title_supported_formats));
 
-            topBarInjectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getNavigationBarTopAdapter());
+                        injectedViewAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+                    }));
+        }
+    }
 
-            NavigationBarTopAdapter topBarAdapter = topBarInjectedViewContainer.getInjectedViewAdapter();
-            assert topBarAdapter != null;
-            topBarAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
-            topBarAdapter.setTitle(getString(R.string.gc_title_file_import));
-
-            topBarAdapter.setOnNavButtonClickListener(
-                    new IntervalClickListener(v ->
-                    onBackPressed())
-            );
+    private void setupBottomBarNavigation() {
+        InjectedViewContainer<HelpNavigationBarBottomAdapter> injectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_bottom);
+        if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
+            injectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getHelpNavigationBarBottomAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
+                            onBackPressed();
+                        }));
+                    }));
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/HelpActivity.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/HelpActivity.kt
@@ -3,7 +3,6 @@ package net.gini.android.capture.help
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -14,6 +13,7 @@ import net.gini.android.capture.help.HelpItem.PhotoTips
 import net.gini.android.capture.help.view.HelpNavigationBarBottomAdapter
 import net.gini.android.capture.internal.ui.IntervalClickListener
 import net.gini.android.capture.internal.util.ActivityHelper
+import net.gini.android.capture.view.InjectedViewAdapterHolder
 import net.gini.android.capture.view.InjectedViewContainer
 import net.gini.android.capture.view.NavButtonType
 import net.gini.android.capture.view.NavigationBarTopAdapter
@@ -43,35 +43,36 @@ class HelpActivity : AppCompatActivity() {
     }
 
     private fun setupTopBarNavigation() {
-        val topBarInjectedViewContainer = findViewById<InjectedViewContainer<NavigationBarTopAdapter>>(R.id.gc_injected_navigation_bar_container_top)
+        val topBarInjectedViewContainer =
+            findViewById<InjectedViewContainer<NavigationBarTopAdapter>>(R.id.gc_injected_navigation_bar_container_top)
         if (GiniCapture.hasInstance()) {
-
-            topBarInjectedViewContainer.injectedViewAdapter = GiniCapture.getInstance().navigationBarTopAdapter
-
-            val topBarAdapter = topBarInjectedViewContainer?.injectedViewAdapter
-
-            val navType = if (GiniCapture.getInstance().isBottomNavigationBarEnabled)
-                NavButtonType.NONE else NavButtonType.BACK
-            topBarAdapter?.setNavButtonType(navType)
-
-            topBarAdapter?.setTitle(getString(R.string.gc_title_help))
-            topBarAdapter?.setOnNavButtonClickListener(IntervalClickListener {
-                onBackPressed()
-            })
+            topBarInjectedViewContainer.injectedViewAdapterHolder =
+                InjectedViewAdapterHolder(
+                    GiniCapture.getInstance().internal().navigationBarTopAdapterInstance
+                ) { injectedViewAdapter ->
+                    val navType = if (GiniCapture.getInstance().isBottomNavigationBarEnabled)
+                        NavButtonType.NONE else NavButtonType.BACK
+                    injectedViewAdapter.setNavButtonType(navType)
+                    injectedViewAdapter.setTitle(getString(R.string.gc_title_help))
+                    injectedViewAdapter.setOnNavButtonClickListener(IntervalClickListener {
+                        onBackPressed()
+                    })
+                }
         }
     }
 
 
     private fun setupBottomBarNavigation() {
-        val injectedViewContainer: InjectedViewContainer<HelpNavigationBarBottomAdapter>? = findViewById(R.id.gc_injected_navigation_bar_container_bottom)
+        val injectedViewContainer: InjectedViewContainer<HelpNavigationBarBottomAdapter>? =
+            findViewById(R.id.gc_injected_navigation_bar_container_bottom)
         if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled) {
-
-            injectedViewContainer?.injectedViewAdapter = GiniCapture.getInstance().helpNavigationBarBottomAdapter
-
-            val helpNavigationBarBottomAdapter = injectedViewContainer?.injectedViewAdapter
-            helpNavigationBarBottomAdapter?.setOnBackClickListener(IntervalClickListener {
-                onBackPressed()
-            })
+            injectedViewContainer?.injectedViewAdapterHolder = InjectedViewAdapterHolder(
+                GiniCapture.getInstance().internal().helpNavigationBarBottomAdapterInstance
+            ) { injectedViewAdapter ->
+                injectedViewAdapter.setOnBackClickListener(IntervalClickListener {
+                    onBackPressed()
+                })
+            }
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/PhotoTipsActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/PhotoTipsActivity.java
@@ -11,6 +11,7 @@ import net.gini.android.capture.help.view.HelpNavigationBarBottomAdapter;
 import net.gini.android.capture.internal.ui.IntervalClickListener;
 import net.gini.android.capture.noresults.NoResultsActivity;
 import net.gini.android.capture.review.ReviewActivity;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
 import net.gini.android.capture.view.NavButtonType;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
@@ -45,31 +46,30 @@ public class PhotoTipsActivity extends AppCompatActivity {
         setupTopBarNavigation();
     }
 
-    private void setupBottomBarNavigation() {
-        InjectedViewContainer<HelpNavigationBarBottomAdapter> injectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_bottom);
-        if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-
-            injectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getHelpNavigationBarBottomAdapter());
-
-            HelpNavigationBarBottomAdapter helpNavigationBarBottomAdapter = GiniCapture.getInstance().getHelpNavigationBarBottomAdapter();
-            helpNavigationBarBottomAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
-                onBackPressed();
-            }));
-        }
-    }
-
     private void setupTopBarNavigation() {
         InjectedViewContainer<NavigationBarTopAdapter> topBarInjectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_top);
         if (GiniCapture.hasInstance()) {
+            topBarInjectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getNavigationBarTopAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
+                        injectedViewAdapter.setTitle(getString(R.string.gc_title_supported_formats));
 
-            topBarInjectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getNavigationBarTopAdapter());
+                        injectedViewAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+                    }));
+        }
+    }
 
-            NavigationBarTopAdapter topBarAdapter = topBarInjectedViewContainer.getInjectedViewAdapter();
-            assert topBarAdapter != null;
-            topBarAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
-            topBarAdapter.setTitle(getString(R.string.gc_title_photo_tips));
-
-            topBarAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+    private void setupBottomBarNavigation() {
+        InjectedViewContainer<HelpNavigationBarBottomAdapter> injectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_bottom);
+        if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
+            injectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getHelpNavigationBarBottomAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
+                            onBackPressed();
+                        }));
+                    }));
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/SupportedFormatsActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/SupportedFormatsActivity.java
@@ -14,6 +14,7 @@ import net.gini.android.capture.help.view.HelpNavigationBarBottomAdapter;
 import net.gini.android.capture.internal.ui.IntervalClickListener;
 import net.gini.android.capture.noresults.NoResultsActivity;
 import net.gini.android.capture.review.ReviewActivity;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
 import net.gini.android.capture.view.NavButtonType;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
@@ -45,29 +46,27 @@ public class SupportedFormatsActivity extends AppCompatActivity {
     private void setupTopBarNavigation() {
         InjectedViewContainer<NavigationBarTopAdapter> topBarInjectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_top);
         if (GiniCapture.hasInstance()) {
+            topBarInjectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getNavigationBarTopAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
+                        injectedViewAdapter.setTitle(getString(R.string.gc_title_supported_formats));
 
-            topBarInjectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getNavigationBarTopAdapter());
-
-            NavigationBarTopAdapter topBarAdapter = topBarInjectedViewContainer.getInjectedViewAdapter();
-            assert topBarAdapter != null;
-            topBarAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
-            topBarAdapter.setTitle(getString(R.string.gc_title_supported_formats));
-
-            topBarAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+                        injectedViewAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+                    }));
         }
     }
 
     private void setupBottomBarNavigation() {
         InjectedViewContainer<HelpNavigationBarBottomAdapter> injectedViewContainer = findViewById(R.id.gc_injected_navigation_bar_container_bottom);
         if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-
-            injectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getHelpNavigationBarBottomAdapter());
-
-            HelpNavigationBarBottomAdapter helpNavigationBarBottomAdapter = injectedViewContainer.getInjectedViewAdapter();
-            assert helpNavigationBarBottomAdapter != null;
-            helpNavigationBarBottomAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
-                onBackPressed();
-            }));
+            injectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getHelpNavigationBarBottomAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setOnBackClickListener(new IntervalClickListener(v -> {
+                            onBackPressed();
+                        }));
+                    }));
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -134,7 +134,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
 
         qrCheckImage.visibility = View.GONE
         qrImageFrame.visibility = View.INVISIBLE
-        loadingIndicatorContainer?.injectedViewAdapter?.onVisible()
+        loadingIndicatorContainer?.modifyAdapterIfOwned { it.onVisible() }
         mInvoiceTxt.visibility = View.VISIBLE
         supportedBackgroundView?.visibility = View.VISIBLE
     }
@@ -146,7 +146,7 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
         qrImageFrame.visibility = View.VISIBLE
         qrImageFrame.imageTintList =
             ColorStateList.valueOf(ContextCompat.getColor(popupView.context, R.color.Light_01))
-        loadingIndicatorContainer?.injectedViewAdapter?.onHidden()
+        loadingIndicatorContainer?.modifyAdapterIfOwned { it.onHidden() }
         mInvoiceTxt.visibility = View.GONE
         supportedBackgroundView?.visibility = View.GONE
         mUnknownQRCodeWrapper.visibility = View.GONE

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/IntervalClickListener.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/IntervalClickListener.kt
@@ -18,7 +18,9 @@ class IntervalClickListener(
     override var enabled: Runnable =
         Runnable { isEnabled = true }
 
-    override fun onClick(view: View) {
+    override fun onClick(view: View?) {
+        if (view == null) return;
+
         if (isEnabled) {
             isEnabled = false
             view.postDelayed(enabled, interval)

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsActivity.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsActivity.java
@@ -117,12 +117,13 @@ public class NoResultsActivity extends AppCompatActivity implements ImageRetakeO
 
     private void setupNoResultsBottomNavigationBar() {
         if (GiniCapture.hasInstance() && GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-            InjectedViewContainer<NoResultsNavigationBarBottomAdapter> injectedViewContainer =
-                    findViewById(R.id.gc_injected_navigation_bar_container_bottom);
-            NoResultsNavigationBarBottomAdapter adapter = GiniCapture.getInstance().getNoResultsNavigationBarBottomAdapter();
-            injectedViewContainer.setInjectedViewAdapter(adapter);
-
-            adapter.setOnBackButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
+            // TODO: will be removed
+//            InjectedViewContainer<NoResultsNavigationBarBottomAdapter> injectedViewContainer =
+//                    findViewById(R.id.gc_injected_navigation_bar_container_bottom);
+//            NoResultsNavigationBarBottomAdapter adapter = GiniCapture.getInstance().getNoResultsNavigationBarBottomAdapter();
+//            injectedViewContainer.setInjectedViewAdapter(adapter);
+//
+//            adapter.setOnBackButtonClickListener(new IntervalClickListener(v -> onBackPressed()));
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragmentImpl.java
@@ -16,6 +16,7 @@ import net.gini.android.capture.help.SupportedFormatsAdapter;
 import net.gini.android.capture.internal.ui.ClickListenerExtKt;
 import net.gini.android.capture.internal.ui.FragmentImplCallback;
 import net.gini.android.capture.internal.ui.IntervalClickListener;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
 import net.gini.android.capture.view.NavButtonType;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
@@ -125,22 +126,22 @@ class NoResultsFragmentImpl {
 
     private void setTopBarInjectedViewContainer() {
         if (GiniCapture.hasInstance()) {
-            topAdapterInjectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getNavigationBarTopAdapter());
+            topAdapterInjectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getNavigationBarTopAdapterInstance(),
+                    injectedViewAdapter -> {
+                        if (mFragment.getActivity() == null)
+                            return;
 
-            if (topAdapterInjectedViewContainer.getInjectedViewAdapter() == null)
-                return;
+                        injectedViewAdapter.setTitle(mFragment.getActivity().getResources().getString(R.string.gc_title_no_results));
 
-            if (mFragment.getActivity() == null)
-                return;
+                        if (GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
+                            return;
+                        }
 
-            topAdapterInjectedViewContainer.getInjectedViewAdapter().setTitle(mFragment.getActivity().getResources().getString(R.string.gc_title_no_results));
-
-            if (GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-                return;
-            }
-
-            topAdapterInjectedViewContainer.getInjectedViewAdapter().setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
-            topAdapterInjectedViewContainer.getInjectedViewAdapter().setOnNavButtonClickListener(new IntervalClickListener(view -> mFragment.getActivity().onBackPressed()));
+                        injectedViewAdapter.setNavButtonType(GiniCapture.getInstance().isBottomNavigationBarEnabled() ? NavButtonType.NONE : NavButtonType.BACK);
+                        injectedViewAdapter.setOnNavButtonClickListener(new IntervalClickListener(view -> mFragment.getActivity().onBackPressed()));
+                    })
+            );
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingFragment.java
@@ -28,6 +28,9 @@ import net.gini.android.capture.R;
 import net.gini.android.capture.internal.ui.ClickListenerExtKt;
 import net.gini.android.capture.internal.ui.IntervalClickListener;
 import net.gini.android.capture.onboarding.view.OnboardingNavigationBarBottomAdapter;
+import net.gini.android.capture.onboarding.view.OnboardingNavigationBarBottomButton;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
+import net.gini.android.capture.view.InjectedViewAdapterInstance;
 import net.gini.android.capture.view.InjectedViewContainer;
 
 import org.slf4j.Logger;
@@ -35,6 +38,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import kotlin.Unit;
 
 /**
  * Internal use only.
@@ -59,6 +64,7 @@ public class OnboardingFragment extends Fragment implements OnboardingScreenCont
     private Button buttonSkip;
     private Button buttonGetStarted;
     private Group groupNextAndSkipButtons;
+    private OnboardingNavigationBarBottomButton[] navigationBarBottomButtons = new OnboardingNavigationBarBottomButton[]{};
 
     /**
      * <p>
@@ -240,10 +246,11 @@ public class OnboardingFragment extends Fragment implements OnboardingScreenCont
 
     @Override
     public void showGetStartedButtonInNavigationBarBottom() {
-        final OnboardingNavigationBarBottomAdapter injectedViewAdapter = injectedNavigationBarBottomContainer.getInjectedViewAdapter();
-        if (injectedViewAdapter != null) {
-            injectedViewAdapter.showButtons(GET_STARTED);
-        }
+        navigationBarBottomButtons = new OnboardingNavigationBarBottomButton[]{GET_STARTED};
+        injectedNavigationBarBottomContainer.modifyAdapterIfOwned(adapter -> {
+            adapter.showButtons(navigationBarBottomButtons);
+            return Unit.INSTANCE;
+        });
     }
 
     @Override
@@ -254,19 +261,21 @@ public class OnboardingFragment extends Fragment implements OnboardingScreenCont
 
     @Override
     public void showSkipAndNextButtonsInNavigationBarBottom() {
-        final OnboardingNavigationBarBottomAdapter injectedViewAdapter = injectedNavigationBarBottomContainer.getInjectedViewAdapter();
-        if (injectedViewAdapter != null) {
-            injectedViewAdapter.showButtons(SKIP, NEXT);
-        }
+        navigationBarBottomButtons = new OnboardingNavigationBarBottomButton[]{SKIP, NEXT};
+        injectedNavigationBarBottomContainer.modifyAdapterIfOwned(adapter -> {
+            adapter.showButtons(navigationBarBottomButtons);
+            return Unit.INSTANCE;
+        });
     }
 
     @Override
-    public void setNavigationBarBottomAdapter(@NonNull OnboardingNavigationBarBottomAdapter adapter) {
-        injectedNavigationBarBottomContainer.setInjectedViewAdapter(adapter); // view.setNavigationBarBottomAdapter()
-
-        adapter.setOnNextButtonClickListener(new IntervalClickListener(v -> mPresenter.showNextPage()));
-        adapter.setOnSkipButtonClickListener(new IntervalClickListener(v -> mPresenter.skip()));
-        adapter.setOnGetStartedButtonClickListener(new IntervalClickListener(v -> mPresenter.showNextPage()));
+    public void setNavigationBarBottomAdapterInstance(@NonNull InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> adapterInstance) {
+        injectedNavigationBarBottomContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(adapterInstance, injectedViewAdapter -> {
+            injectedViewAdapter.setOnNextButtonClickListener(new IntervalClickListener(v -> mPresenter.showNextPage()));
+            injectedViewAdapter.setOnSkipButtonClickListener(new IntervalClickListener(v -> mPresenter.skip()));
+            injectedViewAdapter.setOnGetStartedButtonClickListener(new IntervalClickListener(v -> mPresenter.showNextPage()));
+            injectedViewAdapter.showButtons(navigationBarBottomButtons);
+        }));
     }
 
     static class PageIndicators {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingPageFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingPageFragment.java
@@ -9,6 +9,8 @@ import android.widget.TextView;
 
 import net.gini.android.capture.R;
 import net.gini.android.capture.onboarding.view.OnboardingIllustrationAdapter;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
+import net.gini.android.capture.view.InjectedViewAdapterInstance;
 import net.gini.android.capture.view.InjectedViewContainer;
 
 import androidx.annotation.NonNull;
@@ -119,7 +121,10 @@ public class OnboardingPageFragment extends Fragment implements OnboardingPageCo
 
     @Override
     public void showImage(@NonNull OnboardingIllustrationAdapter illustrationAdapter) {
-        injectedIconContainer.setInjectedViewAdapter(illustrationAdapter);
+        injectedIconContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                // We can create our local instance because onboarding illustrations are not shown on multiple screens
+                new InjectedViewAdapterInstance<>(illustrationAdapter), injectedViewAdapter -> {
+        }));
     }
 
     @Override

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingScreenContract.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingScreenContract.java
@@ -5,8 +5,7 @@ import android.app.Activity;
 import net.gini.android.capture.GiniCaptureBasePresenter;
 import net.gini.android.capture.GiniCaptureBaseView;
 import net.gini.android.capture.onboarding.view.OnboardingNavigationBarBottomAdapter;
-import net.gini.android.capture.view.DefaultNavigationBarTopAdapter;
-import net.gini.android.capture.view.NavigationBarTopAdapter;
+import net.gini.android.capture.view.InjectedViewAdapterInstance;
 
 import java.util.List;
 
@@ -36,7 +35,7 @@ interface OnboardingScreenContract {
         void showSkipAndNextButtons();
         void showSkipAndNextButtonsInNavigationBarBottom();
 
-        void setNavigationBarBottomAdapter(@NonNull final OnboardingNavigationBarBottomAdapter adapter);
+        void setNavigationBarBottomAdapterInstance(@NonNull final InjectedViewAdapterInstance<OnboardingNavigationBarBottomAdapter> adapterInstance);
 
         void hideButtons();
     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingScreenPresenter.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/onboarding/OnboardingScreenPresenter.java
@@ -7,11 +7,7 @@ import android.app.Activity;
 import net.gini.android.capture.GiniCapture;
 import net.gini.android.capture.GiniCaptureError;
 import net.gini.android.capture.internal.util.FeatureConfiguration;
-import net.gini.android.capture.onboarding.view.OnboardingNavigationBarBottomAdapter;
 import net.gini.android.capture.tracking.OnboardingScreenEvent;
-import net.gini.android.capture.view.DefaultNavigationBarTopAdapter;
-import net.gini.android.capture.view.NavButtonType;
-import net.gini.android.capture.view.NavigationBarTopAdapter;
 
 import java.util.List;
 
@@ -125,8 +121,8 @@ class OnboardingScreenPresenter extends OnboardingScreenContract.Presenter {
 
     private void setupNavigationBarBottom() {
         if (GiniCapture.hasInstance()) {
-            final OnboardingNavigationBarBottomAdapter navigationBarBottomAdapter = GiniCapture.getInstance().getOnboardingNavigationBarBottomAdapter();
-            getView().setNavigationBarBottomAdapter(navigationBarBottomAdapter);
+            getView().setNavigationBarBottomAdapterInstance(
+                    GiniCapture.getInstance().internal().getOnboardingNavigationBarBottomAdapterInstance());
             getView().hideButtons();
         }
     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
@@ -43,6 +43,7 @@ import net.gini.android.capture.review.multipage.view.ReviewNavigationBarBottomA
 import net.gini.android.capture.review.zoom.ZoomInPreviewActivity;
 import net.gini.android.capture.tracking.ReviewScreenEvent;
 import net.gini.android.capture.tracking.ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY;
+import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
 import net.gini.android.capture.view.NavButtonType;
 import net.gini.android.capture.view.NavigationBarTopAdapter;
@@ -68,6 +69,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.tabs.TabLayout;
 
 import jersey.repackaged.jsr166e.CompletableFuture;
+import kotlin.Unit;
 
 /**
  * Created by Alpar Szotyori on 07.05.2018.
@@ -106,6 +108,9 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     private SnapHelper mSnapHelper;
     private MiddlePageManager mSnapManager;
     private boolean mInstanceStateSaved;
+    private boolean isOnButtonLoadingIndicatorActive;
+    private boolean isBottomNavigationBarContinueButtonEnabled;
+    private boolean isBottomNavigationBarLoadingIndicatorActive;
 
     public static MultiPageReviewFragment newInstance() {
 
@@ -378,7 +383,14 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
     private void setInjectedLoadingIndicatorContainer() {
         if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-            injectedLoadingIndicatorContainer.setInjectedViewAdapter(GiniCapture.getInstance().getOnButtonLoadingIndicatorAdapter());
+            injectedLoadingIndicatorContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getOnButtonLoadingIndicatorAdapterInstance(), injectedViewAdapter -> {
+                        if (isOnButtonLoadingIndicatorActive) {
+                            injectedViewAdapter.onVisible();
+                        } else {
+                            injectedViewAdapter.onHidden();
+                        }
+            }));
         }
     }
 
@@ -393,23 +405,26 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
             mReviewNavigationBarBottomAdapter.setLayoutParams(params);
 
-            mReviewNavigationBarBottomAdapter.setInjectedViewAdapter(GiniCapture.getInstance().getReviewNavigationBarBottomAdapter());
-
-            if (mReviewNavigationBarBottomAdapter.getInjectedViewAdapter() == null) {
-                return;
-            }
-
             hideViewsIfBottomBarEnabled();
 
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter().setOnAddPageButtonClickListener(new IntervalClickListener(v -> mListener.onReturnToCameraScreenToAddPages()));
+            mReviewNavigationBarBottomAdapter.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getReviewNavigationBarBottomAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setOnAddPageButtonClickListener(new IntervalClickListener(v -> mListener.onReturnToCameraScreenToAddPages()));
 
-            boolean isMultiPage = GiniCapture.getInstance().isMultiPageEnabled();
+                        boolean isMultiPage = GiniCapture.getInstance().isMultiPageEnabled();
 
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter().setAddPageButtonVisibility(isMultiPage ? View.VISIBLE : View.GONE);
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter().setOnContinueButtonClickListener(new IntervalClickListener(v -> onNextButtonClicked()));
+                        injectedViewAdapter.setAddPageButtonVisibility(isMultiPage ? View.VISIBLE : View.GONE);
+                        injectedViewAdapter.setOnContinueButtonClickListener(new IntervalClickListener(v -> onNextButtonClicked()));
 
+                        injectedViewAdapter.setContinueButtonEnabled(isBottomNavigationBarContinueButtonEnabled);
+                        if (isBottomNavigationBarLoadingIndicatorActive) {
+                            injectedViewAdapter.showLoadingIndicator();
+                        } else {
+                            injectedViewAdapter.hideLoadingIndicator();
+                        }
+                    }));
         }
-
     }
 
     private void hideViewsIfBottomBarEnabled() {
@@ -464,24 +479,19 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
     private void setupTopNavigationBar() {
         if (GiniCapture.hasInstance()) {
-            mTopAdapterInjectedViewContainer.setInjectedViewAdapter(GiniCapture.getInstance().getNavigationBarTopAdapter());
+            mTopAdapterInjectedViewContainer.setInjectedViewAdapterHolder(new InjectedViewAdapterHolder<>(
+                    GiniCapture.getInstance().internal().getNavigationBarTopAdapterInstance(),
+                    injectedViewAdapter -> {
+                        injectedViewAdapter.setTitle(getString(R.string.gc_title_review));
 
-            if (mTopAdapterInjectedViewContainer.getInjectedViewAdapter() == null)
-                return;
+                        injectedViewAdapter.setNavButtonType(NavButtonType.CLOSE);
 
-            if (this.getActivity() == null)
-                return;
-
-            mTopAdapterInjectedViewContainer.getInjectedViewAdapter().setTitle(getString(R.string.gc_title_review));
-
-            mTopAdapterInjectedViewContainer.getInjectedViewAdapter().setNavButtonType(NavButtonType.CLOSE);
-
-            mTopAdapterInjectedViewContainer.getInjectedViewAdapter().setOnNavButtonClickListener(new IntervalClickListener(v -> {
-                if (MultiPageReviewFragment.this.getActivity() != null) {
-                    MultiPageReviewFragment.this.getActivity().onBackPressed();
-                }
-            }));
-
+                        injectedViewAdapter.setOnNavButtonClickListener(new IntervalClickListener(v -> {
+                            if (getActivity() != null) {
+                                getActivity().onBackPressed();
+                            }
+                        }));
+                    }));
         }
     }
 
@@ -617,10 +627,12 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
             } else {
                 mButtonNext.animate().alpha(0.5f).start();
             }
-        } else if (mReviewNavigationBarBottomAdapter != null
-                && mReviewNavigationBarBottomAdapter.getInjectedViewAdapter() != null) {
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter()
-                    .setContinueButtonEnabled(enabled);
+        } else {
+            isBottomNavigationBarContinueButtonEnabled = enabled;
+            mReviewNavigationBarBottomAdapter.modifyAdapterIfOwned(injectedViewAdapter -> {
+                injectedViewAdapter.setContinueButtonEnabled(enabled);
+                return Unit.INSTANCE;
+            });
         }
     }
 
@@ -752,18 +764,34 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     }
 
     private void showIndicator() {
-        if (injectedLoadingIndicatorContainer != null && injectedLoadingIndicatorContainer.getInjectedViewAdapter() != null)
-            injectedLoadingIndicatorContainer.getInjectedViewAdapter().onVisible();
-        else if (mReviewNavigationBarBottomAdapter != null && mReviewNavigationBarBottomAdapter.getInjectedViewAdapter() != null) {
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter().showLoadingIndicator();
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
+            isOnButtonLoadingIndicatorActive = true;
+            injectedLoadingIndicatorContainer.modifyAdapterIfOwned(injectedViewAdapter -> {
+                injectedViewAdapter.onVisible();
+                return Unit.INSTANCE;
+            });
+        } else {
+            isBottomNavigationBarLoadingIndicatorActive = true;
+            mReviewNavigationBarBottomAdapter.modifyAdapterIfOwned(injectedViewAdapter -> {
+                injectedViewAdapter.showLoadingIndicator();
+                return Unit.INSTANCE;
+            });
         }
     }
 
     private void hideIndicator() {
-        if (injectedLoadingIndicatorContainer != null && injectedLoadingIndicatorContainer.getInjectedViewAdapter() != null)
-            injectedLoadingIndicatorContainer.getInjectedViewAdapter().onHidden();
-        else if (mReviewNavigationBarBottomAdapter != null && mReviewNavigationBarBottomAdapter.getInjectedViewAdapter() != null) {
-            mReviewNavigationBarBottomAdapter.getInjectedViewAdapter().hideLoadingIndicator();
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
+            isOnButtonLoadingIndicatorActive = false;
+            injectedLoadingIndicatorContainer.modifyAdapterIfOwned(injectedViewAdapter -> {
+                injectedViewAdapter.onHidden();
+                return Unit.INSTANCE;
+            });
+        } else {
+            isBottomNavigationBarLoadingIndicatorActive = false;
+            mReviewNavigationBarBottomAdapter.modifyAdapterIfOwned(injectedViewAdapter -> {
+                injectedViewAdapter.hideLoadingIndicator();
+                return Unit.INSTANCE;
+            });
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
@@ -766,12 +766,18 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     private void showIndicator() {
         if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
             isOnButtonLoadingIndicatorActive = true;
+            if (injectedLoadingIndicatorContainer == null) {
+                return;
+            }
             injectedLoadingIndicatorContainer.modifyAdapterIfOwned(injectedViewAdapter -> {
                 injectedViewAdapter.onVisible();
                 return Unit.INSTANCE;
             });
         } else {
             isBottomNavigationBarLoadingIndicatorActive = true;
+            if (mReviewNavigationBarBottomAdapter == null) {
+                return;
+            }
             mReviewNavigationBarBottomAdapter.modifyAdapterIfOwned(injectedViewAdapter -> {
                 injectedViewAdapter.showLoadingIndicator();
                 return Unit.INSTANCE;
@@ -782,12 +788,18 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     private void hideIndicator() {
         if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
             isOnButtonLoadingIndicatorActive = false;
+            if (injectedLoadingIndicatorContainer == null) {
+                return;
+            }
             injectedLoadingIndicatorContainer.modifyAdapterIfOwned(injectedViewAdapter -> {
                 injectedViewAdapter.onHidden();
                 return Unit.INSTANCE;
             });
         } else {
             isBottomNavigationBarLoadingIndicatorActive = false;
+            if (mReviewNavigationBarBottomAdapter == null) {
+                return;
+            }
             mReviewNavigationBarBottomAdapter.modifyAdapterIfOwned(injectedViewAdapter -> {
                 injectedViewAdapter.hideLoadingIndicator();
                 return Unit.INSTANCE;

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/view/ReviewNavigationBarBottomAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/view/ReviewNavigationBarBottomAdapter.kt
@@ -5,8 +5,9 @@ import android.view.View
 import android.view.ViewGroup
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.databinding.GcReviewNavigationBarBottomBinding
-import net.gini.android.capture.internal.ui.IntervalClickListener
 import net.gini.android.capture.view.InjectedViewAdapter
+import net.gini.android.capture.view.InjectedViewAdapterHolder
+import net.gini.android.capture.view.InjectedViewAdapterInstance
 import net.gini.android.capture.view.OnButtonLoadingIndicatorAdapter
 
 /**
@@ -56,7 +57,6 @@ interface ReviewNavigationBarBottomAdapter : InjectedViewAdapter {
 class DefaultReviewNavigationBarBottomAdapter : ReviewNavigationBarBottomAdapter {
 
     private var viewBinding: GcReviewNavigationBarBottomBinding? = null
-    private var customLoadingIndicatorAdapter: OnButtonLoadingIndicatorAdapter? = null
 
     override fun setOnContinueButtonClickListener(clickListener: View.OnClickListener?) {
         this.viewBinding?.gcContinue?.setOnClickListener(clickListener)
@@ -75,11 +75,15 @@ class DefaultReviewNavigationBarBottomAdapter : ReviewNavigationBarBottomAdapter
     }
 
     override fun hideLoadingIndicator() {
-        this.customLoadingIndicatorAdapter?.onHidden()
+        viewBinding?.gcInjectedLoadingIndicatorContainer?.modifyAdapterIfOwned {
+            (it as OnButtonLoadingIndicatorAdapter).onHidden()
+        }
     }
 
     override fun showLoadingIndicator() {
-        this.customLoadingIndicatorAdapter?.onVisible()
+        viewBinding?.gcInjectedLoadingIndicatorContainer?.modifyAdapterIfOwned {
+            (it as OnButtonLoadingIndicatorAdapter).onVisible()
+        }
     }
 
 
@@ -90,8 +94,9 @@ class DefaultReviewNavigationBarBottomAdapter : ReviewNavigationBarBottomAdapter
         this.viewBinding = viewBinding
 
         if (GiniCapture.hasInstance()) {
-            this.customLoadingIndicatorAdapter = GiniCapture.getInstance().onButtonLoadingIndicatorAdapter
-            viewBinding.gcInjectedLoadingIndicatorContainer.injectedViewAdapter = this.customLoadingIndicatorAdapter
+            viewBinding.gcInjectedLoadingIndicatorContainer.injectedViewAdapterHolder = InjectedViewAdapterHolder(
+                GiniCapture.getInstance().internal().onButtonLoadingIndicatorAdapterInstance
+            ) {}
         }
 
         return viewBinding.root

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/CustomLoadingIndicatorAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/CustomLoadingIndicatorAdapter.kt
@@ -25,18 +25,18 @@ interface CustomLoadingIndicatorAdapter : InjectedViewAdapter {
 
 class DefaultLoadingIndicatorAdapter: CustomLoadingIndicatorAdapter {
 
-    private lateinit var progressBar: ProgressBar
+    private var progressBar: ProgressBar? = null
 
     override fun onVisible() {
-        progressBar.visibility = View.VISIBLE
+        progressBar?.visibility = View.VISIBLE
     }
 
     override fun onHidden() {
-        progressBar.visibility = View.GONE
+        progressBar?.visibility = View.GONE
     }
 
     override fun onCreateView(container: ViewGroup): View {
-        progressBar = ProgressBar(container.context).apply {
+        val progressBar = ProgressBar(container.context).apply {
             layoutParams =
                 ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
             indeterminateTintMode = PorterDuff.Mode.SRC_IN
@@ -44,6 +44,7 @@ class DefaultLoadingIndicatorAdapter: CustomLoadingIndicatorAdapter {
             indeterminateTintList = ColorStateList.valueOf(ContextCompat.getColor(context, R.color.Accent_01))
             visibility = View.GONE
         }
+        this.progressBar = progressBar
 
         return progressBar
     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/InjectedViewAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/InjectedViewAdapter.kt
@@ -26,3 +26,20 @@ interface InjectedViewAdapter {
      */
     fun onDestroy()
 }
+
+/**
+ * Internal use only.
+ *
+ * Represents an "instance" of an [InjectedViewAdapter] which will be shown in one or more screens' [InjectedViewContainer].
+ *
+ * We use this class to wrap the [InjectedViewAdapter] and attach additional information needed to manage it.
+ *
+ * We need to know with which [InjectedViewContainer] the view adapter is associated with to prevent destructive
+ * modifications from view containers that are not the currently associated one. For example if the view adapter is
+ * shown in a new view container and the previous one is destroyed then the view adapter won't be destroyed because
+ * the new associated view container is different than the old one.
+ */
+class InjectedViewAdapterInstance<T : InjectedViewAdapter> @JvmOverloads constructor(
+    val viewAdapter: T,
+    var viewContainer: InjectedViewContainer<T>? = null
+)

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/InjectedViewContainer.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/InjectedViewContainer.kt
@@ -8,6 +8,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
+import net.gini.android.capture.BuildConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -20,7 +21,17 @@ import org.slf4j.LoggerFactory
 /**
  * Internal use only.
  *
- * @suppress
+ * A container view for showing [InjectedViewAdapter]s. It uses the [InjectedViewAdapterHolder] in combination with the
+ * [InjectedViewAdapterInstance] and [InjectedViewAdapterConfigurator] to display the view provided by the
+ * [InjectedViewAdapter] and to configure the [InjectedViewAdapter].
+ *
+ * The [InjectedViewContainer] observes the lifecycle of the view tree lifecycle owner:
+ *   * `onStart`: takes ownership of the [InjectedViewAdapter], (re)creates its view, and (re)configures it,
+ *   * `onDestroy`: destroys the [InjectedViewAdapter] ONLY IF it owns it.
+ *
+ * IMPORTANT: In cases where an [InjectedViewAdapter] is used in [InjectedViewContainer]s on multiple screens
+ * the strategy is that the [InjectedViewContainer] which entered the started state last will own the
+ * [InjectedViewAdapter], will recreate its view, and will reconfigure it.
  */
 class InjectedViewContainer<T: InjectedViewAdapter> @JvmOverloads constructor(
     context: Context,
@@ -28,48 +39,115 @@ class InjectedViewContainer<T: InjectedViewAdapter> @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
-    var injectedViewAdapter: T? = null
+    var injectedViewAdapterHolder: InjectedViewAdapterHolder<T>? = null
         set(value) {
             if (value == null) {
+                if (field?.viewAdapterInstance?.viewContainer == this) {
+                    LOG?.debug(
+                        "{}: Remove container from view adapter instance {}",
+                        this.hashCode(),
+                        field?.viewAdapterInstance?.hashCode()
+                    )
+                    field?.viewAdapterInstance?.viewContainer = null
+                }
                 field = value
                 removeInjectedView()
                 return
             }
             if (field != value) {
+                if (field?.viewAdapterInstance?.viewContainer == this) {
+                    LOG?.debug(
+                        "{}: Remove container from previous view adapter instance {}",
+                        this,
+                        field?.viewAdapterInstance
+                    )
+                    field?.viewAdapterInstance?.viewContainer = null
+                }
+                // Set container for the new adapter
+                LOG?.debug(
+                    "{}: Set container for view adapter instance {}",
+                    this.hashCode(),
+                    value.viewAdapterInstance.hashCode()
+                )
+                value.viewAdapterInstance.viewContainer = this
                 field = value
-                injectView()
             }
         }
-
     private var injectedView: View? = null
+
+    /**
+     * Use this method to modify the [InjectedViewAdapter]. It makes sure to only apply the modifications, if
+     * the [InjectedViewAdapter] is still owned by this container.
+     *
+     * @param modify lambda containing the modifications to apply on the [InjectedViewAdapter]
+     */
+    fun modifyAdapterIfOwned(modify: (injectedViewAdapter: T) -> Unit) {
+        injectedView?.let {  }
+        if (injectedViewAdapterHolder?.viewAdapterInstance?.viewContainer == this) {
+            injectedViewAdapterHolder?.viewAdapterInstance?.viewAdapter?.let { modify(it) }
+        }
+    }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        LOG?.debug("Get lifecycle")
+        LOG?.debug("{}: Get lifecycle", this.hashCode())
         findViewTreeLifecycleOwner()?.lifecycle?.let { lifecycle ->
-            LOG?.debug("Add lifecycle observer")
+            LOG?.debug("{}: Add lifecycle observer", this.hashCode())
             lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onStart(owner: LifecycleOwner) {
+                    injectedViewAdapterHolder?.let { viewAdapterHolder ->
+                        viewAdapterHolder.viewAdapterInstance.viewContainer = this@InjectedViewContainer
+                        LOG?.debug(
+                            "{}: Show and configure injected view adapter for instance {}",
+                            this@InjectedViewContainer.hashCode(),
+                            viewAdapterHolder.viewAdapterInstance.hashCode()
+                        )
+                        injectView()
+                        viewAdapterHolder.configureViewAdapter()
+                    }
+                }
+
                 override fun onDestroy(owner: LifecycleOwner) {
-                    LOG?.debug("Destroy injected view provider")
-                    injectedViewAdapter?.onDestroy()
+                    injectedViewAdapterHolder?.let { viewAdapterHolder ->
+                        if (viewAdapterHolder.viewAdapterInstance.viewContainer == this@InjectedViewContainer) {
+                            LOG?.debug(
+                                "{}: Destroy injected view adapter for instance {}",
+                                this@InjectedViewContainer.hashCode(),
+                                viewAdapterHolder.viewAdapterInstance.hashCode()
+                            )
+                            viewAdapterHolder.viewAdapterInstance.viewAdapter.onDestroy()
+                        } else {
+                            LOG?.debug(
+                                "{}: Injected view adapter for instance {} is in another container and was not destroyed",
+                                this@InjectedViewContainer.hashCode(),
+                                viewAdapterHolder.viewAdapterInstance.hashCode()
+                            )
+                        }
+                        injectedViewAdapterHolder = null
+                    }
                 }
             })
         }
     }
 
     private fun removeInjectedView() {
-        LOG?.debug("Remove injected view")
+        LOG?.debug("{}: Remove injected view", this.hashCode())
         if (injectedView != null) {
             removeView(injectedView)
             injectedView = null
-            LOG?.debug("Injected view removed")
+            LOG?.debug("{}: Injected view removed", this.hashCode())
         }
     }
 
     private fun injectView() {
-        LOG?.debug("Inject view")
+        LOG?.debug(
+            "{}: Inject view for view adapter instance {}",
+            this.hashCode(),
+            injectedViewAdapterHolder?.viewAdapterInstance?.hashCode()
+        )
         removeInjectedView()
-        injectedViewAdapter?.onCreateView(container = this)?.let { view ->
+        injectedViewAdapterHolder?.viewAdapterInstance?.viewAdapter?.onDestroy()
+        injectedViewAdapterHolder?.viewAdapterInstance?.viewAdapter?.onCreateView(container = this)?.let { view ->
             view.layoutParams =
                 LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
                     .apply {
@@ -80,13 +158,61 @@ class InjectedViewContainer<T: InjectedViewAdapter> @JvmOverloads constructor(
                     }
             addView(view)
             injectedView = view
-            LOG?.debug("View injected")
+            LOG?.debug(
+                "{}: View injected for view adapter instance {}",
+                this.hashCode(),
+                injectedViewAdapterHolder?.viewAdapterInstance?.hashCode()
+            )
         }
     }
 
     companion object {
-        private const val DEBUG = true
+        private val DEBUG = BuildConfig.DEBUG
         private val LOG: Logger? = if (DEBUG) LoggerFactory.getLogger(InjectedViewContainer::class.java) else null
     }
 
+}
+
+/**
+ * Internal use only.
+ *
+ * Holds a [InjectedViewAdapterInstance] and an associated [InjectedViewAdapterConfigurator].
+ *
+ * The [InjectedViewAdapterConfigurator] will be used to configure the view adapter every time the
+ * [InjectedViewAdapter.onCreateView] function has been called.
+ */
+data class InjectedViewAdapterHolder<T : InjectedViewAdapter>(
+    val viewAdapterInstance: InjectedViewAdapterInstance<T>,
+    val viewAdapterConfigurator: InjectedViewAdapterConfigurator<T>
+) {
+
+    /**
+     * Convenience method to configure the [InjectedViewAdapter].
+     */
+    internal fun configureViewAdapter() {
+        viewAdapterConfigurator.onConfigure(viewAdapterInstance.viewAdapter)
+    }
+
+}
+
+/**
+ * Internal use only.
+ *
+ * An interface for configuring an [InjectedViewAdapter].
+ *
+ * Implement this method when creating an [InjectedViewAdapterHolder] to configure the [InjectedViewAdapter] when
+ * needed.
+ */
+fun interface InjectedViewAdapterConfigurator<T: InjectedViewAdapter> {
+
+    /**
+     * Called every time after the [InjectedViewAdapter.onCreateView] has been called.
+     *
+     * This method is called in `onStart` of the [InjectedViewContainer]'s lifecycle observer.
+     *
+     * IMPORTANT: When this is called the view adapter has lost its previous state and must be completely reconfigured to
+     * be in the required state. For example if a button has been disabled and this method was called afterwards
+     * then you have to disabled the button again.
+     */
+    fun onConfigure(injectedViewAdapter: T)
 }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/NavigationBarTopAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/NavigationBarTopAdapter.kt
@@ -94,7 +94,7 @@ class DefaultNavigationBarTopAdapter : NavigationBarTopAdapter {
             && GiniCapture.getInstance().isBottomNavigationBarEnabled
         ) {
             viewBinding?.gcNavigationBar?.setOnMenuItemClickListener {
-                listener?.onClick(viewBinding!!.root)
+                listener?.onClick(viewBinding?.root)
                 true
             }
         } else {
@@ -124,6 +124,7 @@ class DefaultNavigationBarTopAdapter : NavigationBarTopAdapter {
                 if (GiniCapture.hasInstance()
                     && GiniCapture.getInstance().isBottomNavigationBarEnabled
                 ) {
+                    viewBinding?.gcNavigationBar?.menu?.clear()
                     viewBinding?.gcNavigationBar?.inflateMenu(R.menu.gc_navigation_bar_top_close)
                 } else {
                     viewBinding?.root?.context?.let { context ->
@@ -138,6 +139,7 @@ class DefaultNavigationBarTopAdapter : NavigationBarTopAdapter {
     }
 
     override fun setMenuResource(menu: Int) {
+        viewBinding?.gcNavigationBar?.menu?.clear()
         viewBinding?.gcNavigationBar?.inflateMenu(menu)
     }
 
@@ -146,7 +148,6 @@ class DefaultNavigationBarTopAdapter : NavigationBarTopAdapter {
     }
 
     override fun onCreateView(container: ViewGroup): View {
-
         val binding = GcNavigationBarTopBinding
             .inflate(LayoutInflater.from(container.context), container, false)
         viewBinding = binding

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/OnButtonLoadingIndicatorAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/OnButtonLoadingIndicatorAdapter.kt
@@ -26,26 +26,27 @@ interface OnButtonLoadingIndicatorAdapter : InjectedViewAdapter {
 
 class DefaultOnButtonLoadingIndicatorAdapter: OnButtonLoadingIndicatorAdapter {
 
-    private lateinit var progressBar: ProgressBar
+    private var progressBar: ProgressBar? = null
 
     override fun onVisible() {
-        progressBar.visibility = View.VISIBLE
+        progressBar?.visibility = View.VISIBLE
     }
 
     override fun onHidden() {
-        progressBar.visibility = View.GONE
+        progressBar?.visibility = View.GONE
     }
 
     override fun onCreateView(container: ViewGroup): View {
-        progressBar = ProgressBar(container.context).apply {
+        val binding = ProgressBar(container.context).apply {
             layoutParams =
                 ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
             indeterminateTintMode = PorterDuff.Mode.SRC_IN
             isIndeterminate = true
             indeterminateTintList = ColorStateList.valueOf(ContextCompat.getColor(context, R.color.Accent_01))
         }
+        progressBar = binding
 
-        return progressBar
+        return binding
     }
 
     override fun onDestroy() {}

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/OnButtonLoadingIndicatorAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/view/OnButtonLoadingIndicatorAdapter.kt
@@ -37,16 +37,16 @@ class DefaultOnButtonLoadingIndicatorAdapter: OnButtonLoadingIndicatorAdapter {
     }
 
     override fun onCreateView(container: ViewGroup): View {
-        val binding = ProgressBar(container.context).apply {
+        val progressBar = ProgressBar(container.context).apply {
             layoutParams =
                 ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
             indeterminateTintMode = PorterDuff.Mode.SRC_IN
             isIndeterminate = true
             indeterminateTintList = ColorStateList.valueOf(ContextCompat.getColor(context, R.color.Accent_01))
         }
-        progressBar = binding
+        this.progressBar = progressBar
 
-        return binding
+        return progressBar
     }
 
     override fun onDestroy() {}

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/onboarding/OnboardingScreenPresenterTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/onboarding/OnboardingScreenPresenterTest.kt
@@ -263,7 +263,7 @@ class OnboardingScreenPresenterTest {
         presenter.start()
 
         // Then
-        verify(mView).setNavigationBarBottomAdapter(eq(GiniCapture.getInstance().onboardingNavigationBarBottomAdapter))
+        verify(mView).setNavigationBarBottomAdapterInstance(eq(GiniCapture.getInstance().internal().onboardingNavigationBarBottomAdapterInstance))
     }
 
     @Test
@@ -280,7 +280,7 @@ class OnboardingScreenPresenterTest {
         presenter.start()
 
         // Then
-        verify(mView).setNavigationBarBottomAdapter(eq(customOnboardingNavigationBarBottomAdapter))
+        verify(mView).setNavigationBarBottomAdapterInstance(eq(GiniCapture.getInstance().internal().onboardingNavigationBarBottomAdapterInstance))
     }
 
     @Test


### PR DESCRIPTION
Fix reuse of `InjectedViewAdapter`s in multiple `InjectedViewContainer`s.

Keep the association between an `InjectedViewAdapter` and an `InjectedViewContainer` in the new
`InjectedViewAdapterInstance` class. This is used to determine when an `InjectedViewContainer`
owns an adapter.

Associate the `InjectedViewAdapter` with the code it needs for configuration by using the new
`InjectedViewAdapterHolder`. This permits the adapter's view to be configured every time the view
is recreated.

The `InjectedViewContainer` that has entered the started state last will take ownership of the `InjectedViewAdapter`, recreate its view, and reconfigure it. When the `InjectedViewContainer` is destroyed it only destroys the `InjectedViewAdapter`'s view if it owns that adapter.
