### PR TITLE
fix: Preserve theme properties from Bank SDK when overriding the `GiniCaptureTheme`

### DIFF
--- a/bank-sdk/screen-api-example-app/src/main/res/values/themes.xml
+++ b/bank-sdk/screen-api-example-app/src/main/res/values/themes.xml
@@ -8,6 +8,13 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <!--Example of customizing the GiniCaptureTheme -->
+<!--    <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme">-->
+<!--        <item name="colorPrimary">@color/gc_error_02</item>-->
+<!--        <item name="gbsSwitchTrack">@color/gc_error_03</item>-->
+<!--        <item name="gcPageItemBackground">@color/gc_warning_01</item>-->
+<!--    </style>-->
+
     <!--Example of customizing the Onboarding Screen text style-->
 <!--    <style name="GiniCaptureTheme.Onboarding.Message.TextStyle" parent="Root.GiniCaptureTheme.Onboarding.Message.TextStyle">-->
 <!--        <item name="android:gravity">start</item>-->

--- a/bank-sdk/sdk/src/main/res/values-night/styles.xml
+++ b/bank-sdk/sdk/src/main/res/values-night/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme.Night">
+    <style name="Root.GiniCaptureTheme.Night" parent="Root.GiniCaptureTheme.Internal.Night">
         <item name="gbsSwitchTrack">@color/gc_dark_03</item>
         <item name="gbsTextInputLayout">@color/gc_dark_04</item>
         <item name="gbsBottomSheetItemTitle">@color/gc_light_05</item>

--- a/bank-sdk/sdk/src/main/res/values/styles.xml
+++ b/bank-sdk/sdk/src/main/res/values/styles.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <style name="Root.GiniCaptureTheme" parent="Root.GiniCaptureTheme.Internal">
+        <item name="gbsSwitchTrack">@color/gc_light_03</item>
+        <item name="gbsTextInputLayout">@color/gc_light_03</item>
+        <item name="gbsBottomSheetItemTitle">@color/gc_dark_06</item>
+        <item name="gbsCurrencyPickerItemBackgroundColor">@color/gc_light_03</item>
+        <item name="gbsCurrencyPickerItemSelectedColor">@color/gc_light_02</item>
+        <item name="gbsReturnDialogTitle">@color/gc_dark_04</item>
+        <item name="gbsAddonTextColor">@color/gc_dark_06</item>
+    </style>
+
     <style name="Root.GiniCaptureTheme.DigitalInvoice.Title.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textColor">@color/gbs_digital_invoice_title_text</item>
@@ -368,16 +378,6 @@
         <item name="android:windowIsFloating">false</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowSoftInputMode">adjustResize|stateAlwaysVisible</item>
-    </style>
-
-    <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme">
-        <item name="gbsSwitchTrack">@color/gc_light_03</item>
-        <item name="gbsTextInputLayout">@color/gc_light_03</item>
-        <item name="gbsBottomSheetItemTitle">@color/gc_dark_06</item>
-        <item name="gbsCurrencyPickerItemBackgroundColor">@color/gc_light_03</item>
-        <item name="gbsCurrencyPickerItemSelectedColor">@color/gc_light_02</item>
-        <item name="gbsReturnDialogTitle">@color/gc_dark_04</item>
-        <item name="gbsAddonTextColor">@color/gc_dark_06</item>
     </style>
 
     <style name="GiniCaptureTheme.DigitalInvoice.Title.TextStyle" parent="Root.GiniCaptureTheme.DigitalInvoice.Title.TextStyle" />

--- a/capture-sdk/sdk/src/main/res/values-night/styles.xml
+++ b/capture-sdk/sdk/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Root.GiniCaptureTheme.Night" parent="Root.GiniCaptureTheme">
+    <style name="Root.GiniCaptureTheme.Internal.Night" parent="Root.GiniCaptureTheme.Internal">
         <item name="colorPrimary">@color/gc_accent_01</item>
         <item name="colorPrimaryDark">@color/gc_dark_01</item>
         <item name="colorOnPrimary">@color/gc_light_01</item>
@@ -16,6 +16,7 @@
         <item name="android:windowLightStatusBar">false</item>
     </style>
 
+    <style name="Root.GiniCaptureTheme.Night" parent="Root.GiniCaptureTheme.Internal.Night"/>
     <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme.Night"/>
 
 </resources>

--- a/capture-sdk/sdk/src/main/res/values/styles.xml
+++ b/capture-sdk/sdk/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Root.GiniCaptureTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Root.GiniCaptureTheme.Internal" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/gc_accent_01</item>
         <item name="colorPrimaryDark">@color/gc_light_02</item>
         <item name="colorOnPrimary">@color/gc_light_01</item>
@@ -46,6 +46,7 @@
         <item name="textAppearanceLabelMedium">?attr/textAppearanceOverline</item>
     </style>
 
+    <style name="Root.GiniCaptureTheme" parent="Root.GiniCaptureTheme.Internal"/>
     <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme"/>
 
     <style name="GiniCaptureTheme.ThemeOverlay.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.Dialog.Alert">


### PR DESCRIPTION
By introducing an intermediate "internal" style we can extend the `Root.GiniCaptureTheme` in Bank SDK and when clients override the `GiniCaptureTheme` (which inherits the `Root.GiniCaptureTheme`) they will also inherit the Bank SDK's additions.

Affects: capture-sdk, bank-sdk

PIA-3874