### PR TITLE
WIP: Pia 3928 accessibility talkbar

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -195,6 +195,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private TextView mCameraFlashButtonSubtitle;
     private ConstraintLayout mLayoutNoPermission;
     private ViewGroup mButtonImportDocumentWrapper;
+    private Button mButtonImportDocument;
     private ConstraintLayout mCameraFrameWrapper;
     private View mActivityIndicatorBackground;
     private ImageView mImageFrame;
@@ -625,6 +626,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         final ViewStub stubNoPermission = view.findViewById(R.id.gc_stub_camera_no_permission);
         mViewStubInflater = new ViewStubSafeInflater(stubNoPermission);
         mButtonImportDocumentWrapper = view.findViewById(R.id.gc_button_import_wrapper);
+        mButtonImportDocument = view.findViewById(R.id.gc_button_import);
         mImportButtonGroup = view.findViewById(R.id.gc_document_import_button_group);
         mActivityIndicatorBackground =
                 view.findViewById(R.id.gc_activity_indicator_background);
@@ -780,7 +782,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             updateCameraFlashState();
         });
 
-        ClickListenerExtKt.setIntervalClickListener(mButtonImportDocumentWrapper, v -> showFileChooser());
+        ClickListenerExtKt.setIntervalClickListener(mButtonImportDocument, v -> showFileChooser());
 
         ClickListenerExtKt.setIntervalClickListener(mPhotoThumbnail, v -> {
             if (mFragment.getActivity() != null)
@@ -1239,7 +1241,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             return;
         }
         mCameraPreview.setEnabled(true);
-        mButtonImportDocumentWrapper.setEnabled(true);
+        mButtonImportDocument.setEnabled(true);
         mButtonCameraFlashWrapper.setEnabled(true);
         mPhotoThumbnail.setEnabled(true);
         mButtonCameraTrigger.setEnabled(true);
@@ -1254,7 +1256,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             return;
         }
         mCameraPreview.setEnabled(false);
-        mButtonImportDocumentWrapper.setEnabled(false);
+        mButtonImportDocument.setEnabled(false);
         mButtonCameraFlashWrapper.setEnabled(false);
         mPhotoThumbnail.setEnabled(false);
         mButtonCameraTrigger.setEnabled(false);
@@ -1467,7 +1469,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void showImportDocumentButtonAnimated() {
         mButtonImportDocumentWrapper.animate().alpha(1.0f);
-        mButtonImportDocumentWrapper.setEnabled(true);
+        mButtonImportDocument.setEnabled(true);
     }
 
     private void showFlashButtonAnimated() {
@@ -1505,7 +1507,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void hideImportDocumentButtonAnimated() {
         mButtonImportDocumentWrapper.animate().alpha(0.0f);
-        mButtonImportDocumentWrapper.setEnabled(false);
+        mButtonImportDocument.setEnabled(false);
     }
 
     private void hidePaneAnimated() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -191,6 +191,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     ImageButton mButtonCameraTrigger;
     private ImageButton mButtonCameraFlash;
     private ViewGroup mButtonCameraFlashWrapper;
+    private Button mButtonCameraFlashTrigger;
     private Group mCameraFlashButtonGroup;
     private TextView mCameraFlashButtonSubtitle;
     private ConstraintLayout mLayoutNoPermission;
@@ -621,6 +622,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mButtonCameraTrigger = view.findViewById(R.id.gc_button_camera_trigger);
         mButtonCameraFlash = view.findViewById(R.id.gc_button_camera_flash);
         mButtonCameraFlashWrapper = view.findViewById(R.id.gc_flash_group_wrapper);
+        mButtonCameraFlashTrigger = view.findViewById(R.id.gc_button_flash);
         mCameraFlashButtonGroup = view.findViewById(R.id.gc_camera_flash_button_group);
         mCameraFlashButtonSubtitle = view.findViewById(R.id.gc_camera_flash_button_subtitle);
         final ViewStub stubNoPermission = view.findViewById(R.id.gc_stub_camera_no_permission);
@@ -777,7 +779,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void setInputHandlers() {
         ClickListenerExtKt.setIntervalClickListener(mButtonCameraTrigger, v -> onCameraTriggerClicked());
 
-        ClickListenerExtKt.setIntervalClickListener(mButtonCameraFlashWrapper, v -> {
+        ClickListenerExtKt.setIntervalClickListener(mButtonCameraFlashTrigger, v -> {
             mIsFlashEnabled = !mCameraController.isFlashEnabled();
             updateCameraFlashState();
         });
@@ -1234,34 +1236,33 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void enableInteraction() {
         if (mCameraPreview == null
-                || mButtonImportDocumentWrapper == null
-                || mButtonCameraFlashWrapper == null
+                || mButtonImportDocument == null
+                || mButtonCameraFlashTrigger == null
                 || mPhotoThumbnail == null
                 || mButtonCameraTrigger == null) {
             return;
         }
         mCameraPreview.setEnabled(true);
         mButtonImportDocument.setEnabled(true);
-        mButtonCameraFlashWrapper.setEnabled(true);
+        mButtonCameraFlashTrigger.setEnabled(true);
         mPhotoThumbnail.setEnabled(true);
         mButtonCameraTrigger.setEnabled(true);
     }
 
     private void disableInteraction() {
         if (mCameraPreview == null
-                || mButtonImportDocumentWrapper == null
-                || mButtonCameraFlashWrapper == null
+                || mButtonImportDocument == null
+                || mButtonCameraFlashTrigger == null
                 || mPhotoThumbnail == null
                 || mButtonCameraTrigger == null) {
             return;
         }
         mCameraPreview.setEnabled(false);
         mButtonImportDocument.setEnabled(false);
-        mButtonCameraFlashWrapper.setEnabled(false);
+        mButtonCameraFlashTrigger.setEnabled(false);
         mPhotoThumbnail.setEnabled(false);
         mButtonCameraTrigger.setEnabled(false);
     }
-
 
     private void showGenericInvalidFileError(ErrorType errorType) {
         final Activity activity = mFragment.getActivity();
@@ -1474,7 +1475,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void showFlashButtonAnimated() {
         mButtonCameraFlashWrapper.animate().alpha(1.0f);
-        mButtonCameraFlashWrapper.setEnabled(true);
+        mButtonCameraFlashTrigger.setEnabled(true);
     }
 
     private void showPaneAnimated() {
@@ -1584,7 +1585,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void hideFlashButtonAnimated() {
         mButtonCameraFlashWrapper.animate().alpha(0.0f);
-        mButtonCameraFlashWrapper.setEnabled(false);
+        mButtonCameraFlashTrigger.setEnabled(false);
     }
 
     private void startApplicationDetailsSettings() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -862,6 +862,14 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         final int flashSubtitleRes = mIsFlashEnabled ? R.string.gc_camera_flash_on_subtitle
                 : R.string.gc_camera_flash_off_subtitle;
         mCameraFlashButtonSubtitle.setText(flashSubtitleRes);
+
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return;
+        }
+
+        final int flashButtonContentDescription = mIsFlashEnabled ? R.string.gc_turn_flash_off_content_description : R.string.gc_turn_flash_on_content_description;
+        mButtonCameraFlashTrigger.setContentDescription(activity.getString(flashButtonContentDescription));
     }
 
     @VisibleForTesting

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/MultiPageReviewFragment.java
@@ -97,7 +97,8 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     private PreviewPagesAdapter mPreviewPagesAdapter;
     private RecyclerView mRecyclerView;
     private Button mButtonNext;
-    private LinearLayout mAddPages;
+    private LinearLayout mAddPagesWrapperLayout;
+    private Button mAddPagesButton;
     private TabLayout mTabIndicator;
     private ConstraintLayout mProcessDocumentsWrapper;
     private InjectedViewContainer<NavigationBarTopAdapter> mTopAdapterInjectedViewContainer;
@@ -374,7 +375,8 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         mButtonNext = view.findViewById(R.id.gc_button_next);
         mTabIndicator = view.findViewById(R.id.gc_tab_indicator);
         mTopAdapterInjectedViewContainer = view.findViewById(R.id.gc_navigation_top_bar);
-        mAddPages = view.findViewById(R.id.gc_add_pages_wrapper);
+        mAddPagesWrapperLayout = view.findViewById(R.id.gc_add_pages_wrapper);
+        mAddPagesButton = view.findViewById(R.id.gc_add_page_button);
         mRecyclerView = view.findViewById(R.id.gc_pager_recycler_view);
         injectedLoadingIndicatorContainer = view.findViewById(R.id.gc_injected_loading_indicator_container);
         mProcessDocumentsWrapper = view.findViewById(R.id.gc_process_documents_wrapper);
@@ -499,10 +501,11 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         ClickListenerExtKt.setIntervalClickListener(mButtonNext, v -> onNextButtonClicked());
 
         if (GiniCapture.hasInstance() && !GiniCapture.getInstance().isBottomNavigationBarEnabled()) {
-            mAddPages.setVisibility(GiniCapture.getInstance().isMultiPageEnabled() ? View.VISIBLE : View.GONE);
+            mAddPagesWrapperLayout.setVisibility(GiniCapture.getInstance().isMultiPageEnabled() ? View.VISIBLE : View.GONE);
+            mAddPagesButton.setVisibility(GiniCapture.getInstance().isMultiPageEnabled() ? View.VISIBLE : View.GONE);
         }
 
-        ClickListenerExtKt.setIntervalClickListener(mAddPages, v -> mListener.onReturnToCameraScreenToAddPages());
+        ClickListenerExtKt.setIntervalClickListener(mAddPagesButton, v -> mListener.onReturnToCameraScreenToAddPages());
     }
 
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/view/ReviewNavigationBarBottomAdapter.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/review/multipage/view/ReviewNavigationBarBottomAdapter.kt
@@ -63,11 +63,11 @@ class DefaultReviewNavigationBarBottomAdapter : ReviewNavigationBarBottomAdapter
     }
 
     override fun setOnAddPageButtonClickListener(clickListener: View.OnClickListener?) {
-        this.viewBinding?.gcAddPagesWrapper?.setOnClickListener(clickListener)
+        this.viewBinding?.gcAddPageButton?.setOnClickListener(clickListener)
     }
 
     override fun setAddPageButtonVisibility(visibility: Int) {
-        this.viewBinding?.gcAddPagesWrapper?.visibility = visibility
+        this.viewBinding?.gcAddPageButton?.visibility = visibility
     }
 
     override fun setContinueButtonEnabled(enabled: Boolean) {

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -92,7 +92,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_button_import_wrapper"
+            app:constraint_referenced_ids="gc_button_import_wrapper, gc_button_import"
             tools:visibility="gone" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -186,6 +186,17 @@
                 android:text="@string/gc_camera_document_import_subtitle" />
 
         </LinearLayout>
+
+        <Button
+            android:id="@+id/gc_button_import"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_camera_document_import_subtitle"
+            app:layout_constraintTop_toTopOf="@id/gc_button_import_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_button_import_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_button_import_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_button_import_wrapper" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -144,7 +144,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@android:color/transparent"
-            android:contentDescription="@string/gc_flash_button"
             app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
             app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
             app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -83,7 +83,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_flash_group_wrapper"
+            app:constraint_referenced_ids="gc_flash_group_wrapper, gc_button_flash"
             tools:visibility="gone" />
 
 
@@ -138,6 +138,17 @@
                 app:layout_constraintTop_toBottomOf="@id/gc_button_camera_flash" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <Button
+            android:id="@+id/gc_button_flash"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_flash_button"
+            app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_flash_group_wrapper" />
 
         <net.gini.android.capture.camera.PhotoThumbnail
             android:id="@+id/gc_photo_thumbnail"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -66,7 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_button_import_wrapper"
+            app:constraint_referenced_ids="gc_button_import_wrapper, gc_button_import"
             tools:visibility="gone" />
 
         <View
@@ -187,6 +187,17 @@
                 android:textColor="@color/gc_light_01" />
 
         </LinearLayout>
+
+        <Button
+            android:id="@+id/gc_button_import"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_camera_document_import_subtitle"
+            app:layout_constraintTop_toTopOf="@id/gc_button_import_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_button_import_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_button_import_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_button_import_wrapper" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -144,7 +144,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@android:color/transparent"
-            android:contentDescription="@string/gc_flash_button"
             app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
             app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
             app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"

--- a/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -58,7 +58,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_flash_group_wrapper"
+            app:constraint_referenced_ids="gc_flash_group_wrapper, gc_button_flash"
             tools:visibility="gone" />
 
         <androidx.constraintlayout.widget.Group
@@ -138,6 +138,17 @@
                 app:layout_constraintTop_toBottomOf="@id/gc_button_camera_flash" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <Button
+            android:id="@+id/gc_button_flash"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_flash_button"
+            app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_flash_group_wrapper" />
 
 
         <net.gini.android.capture.camera.PhotoThumbnail

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -136,7 +136,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@android:color/transparent"
-            android:contentDescription="@string/gc_flash_button"
             app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
             app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
             app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -89,7 +89,7 @@
             android:layout_height="wrap_content"
             android:visibility="gone"
             tools:visibility="gone"
-            app:constraint_referenced_ids="gc_flash_group_wrapper" />
+            app:constraint_referenced_ids="gc_flash_group_wrapper, gc_button_flash" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/gc_flash_group_wrapper"
@@ -131,6 +131,16 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <Button
+            android:id="@+id/gc_button_flash"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_flash_button"
+            app:layout_constraintTop_toTopOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_flash_group_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_flash_group_wrapper" />
 
         <net.gini.android.capture.camera.PhotoThumbnail
             android:id="@+id/gc_photo_thumbnail"

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -88,8 +88,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_flash_group_wrapper"
-            tools:visibility="gone" />
+            tools:visibility="gone"
+            app:constraint_referenced_ids="gc_flash_group_wrapper" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/gc_flash_group_wrapper"
@@ -148,10 +148,10 @@
         <androidx.constraintlayout.widget.Group
             android:id="@+id/gc_document_import_button_group"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:visibility="gone"
-            app:constraint_referenced_ids="gc_button_import_wrapper"
-            tools:visibility="gone" />
+            tools:visibility="gone"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="gc_button_import_wrapper, gc_button_import" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/gc_button_import_wrapper"
@@ -162,7 +162,6 @@
             app:layout_constraintEnd_toStartOf="@+id/gc_flash_group_wrapper"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/gc_button_camera_trigger">
-
 
             <ImageButton
                 android:id="@+id/gc_button_import_document"
@@ -191,6 +190,16 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <Button
+            android:id="@+id/gc_button_import"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/gc_camera_document_import_subtitle"
+            app:layout_constraintTop_toTopOf="@id/gc_button_import_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_button_import_wrapper"
+            app:layout_constraintStart_toStartOf="@id/gc_button_import_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_button_import_wrapper" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_multi_page_review.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_multi_page_review.xml
@@ -142,6 +142,17 @@
 
             </LinearLayout>
 
+            <Button
+                android:id="@+id/gc_add_page_button"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:contentDescription="@string/gc_multi_page_review_add_pages_subtitle"
+                android:background="@android:color/transparent"
+                app:layout_constraintStart_toStartOf="@id/gc_add_pages_wrapper"
+                app:layout_constraintTop_toTopOf="@id/gc_add_pages_wrapper"
+                app:layout_constraintBottom_toBottomOf="@id/gc_add_pages_wrapper"
+                app:layout_constraintEnd_toEndOf="@id/gc_add_pages_wrapper"/>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/layout/gc_review_navigation_bar_bottom.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_review_navigation_bar_bottom.xml
@@ -63,8 +63,18 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:text="@string/gc_pages" />
-
         </LinearLayout>
+
+        <Button
+            android:id="@+id/gc_add_page_button"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:contentDescription="@string/gc_multi_page_review_add_pages_subtitle"
+            android:background="@android:color/transparent"
+            app:layout_constraintStart_toStartOf="@id/gc_add_pages_wrapper"
+            app:layout_constraintTop_toTopOf="@id/gc_add_pages_wrapper"
+            app:layout_constraintBottom_toBottomOf="@id/gc_add_pages_wrapper"
+            app:layout_constraintEnd_toEndOf="@id/gc_add_pages_wrapper"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/capture-sdk/sdk/src/main/res/values-en/strings.xml
+++ b/capture-sdk/sdk/src/main/res/values-en/strings.xml
@@ -157,6 +157,8 @@
     <string name="gc_photos_of_monitors_or_screens">Photos of monitors or screens</string>
     <string name="gc_camera_flash_on_subtitle">On</string>
     <string name="gc_camera_flash_off_subtitle">Off</string>
+    <string name="gc_turn_flash_on_content_description">Turn on flash</string>
+    <string name="gc_turn_flash_off_content_description">Turn off flash</string>
     <string name="gc_camera_title">Scan an invoice or a QR code</string>
     <string name="gc_qr_code_detected">QR code detected</string>
     <string name="gc_unknown_qr_code">Unknown QR code</string>

--- a/capture-sdk/sdk/src/main/res/values/strings.xml
+++ b/capture-sdk/sdk/src/main/res/values/strings.xml
@@ -177,6 +177,8 @@
     <string name="gc_photos_of_monitors_or_screens">Monitoraufnahmen und Screenshots</string>
     <string name="gc_camera_flash_on_subtitle">An</string>
     <string name="gc_camera_flash_off_subtitle">Aus</string>
+    <string name="gc_turn_flash_on_content_description">Blitz einschalten</string>
+    <string name="gc_turn_flash_off_content_description">Blitz ausschalten</string>
     <string name="gc_camera_title">Rechnung oder QR Code scannen</string>
     <string name="gc_qr_code_detected">QR Code erkannt</string>
     <string name="gc_unknown_qr_code">QR Code ohne Zahlinformationen</string>


### PR DESCRIPTION
[NOTE]: Contains fix for PIA-3927 also... These were not buttons, but different elements put together in a wrapper layout so the accessibility couldn't work good, because it could select the textview and the image separately and it read the label's text but did not know that it functions as a button.... So everywhere i put a transparent button with the size of the wrapper layout and then the Talkbar reads the text and automatically the "button" part so no string res change needed.... also for the user now the whole "wrapper" (the full button size) is selected (image + text) so it is also more user friendly