### PR TITLE
fix(bank-sdk): Fixed example app feedback UI

### DIFF
--- a/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/ExtractionsActivity.kt
+++ b/bank-sdk/screen-api-example-app/src/main/java/net/gini/android/bank/sdk/screenapiexample/ExtractionsActivity.kt
@@ -136,10 +136,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
 
         if (amount.isEmpty()) {
             amount = Amount.EMPTY.amountToPay()
-            mExtractions["amountToPay"]?.value = amount
-            mExtractionsAdapter?.extractions = getSortedExtractions(mExtractions)
         }
-        mExtractionsAdapter?.notifyDataSetChanged()
 
         GiniBank.releaseCapture(applicationContext, paymentRecipient, paymentReference, paymentPurpose, iban, bic, Amount(
             BigDecimal(amount.removeSuffix(":EUR")), AmountCurrency.EUR)


### PR DESCRIPTION
[NOTE]: There was no need to reload the list because we're instantly closing the screen so just need to use the updated amount at the cleanup