### PR TITLE
Pia 4104 2.x.x allow charles proxy to intercept https requests

### DIFF
--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -24,6 +24,8 @@ on:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:
         required: true
+      BANK_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD:
+        required: true
 
 jobs:
   test:
@@ -130,17 +132,33 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: build screen api example app
+      - name: build debug screen api example app
         run: >
           ./gradlew bank-sdk:screen-api-example-app:assembleDebug
           -PclientId="gini-mobile-test" 
           -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
 
-      - name: archive screen api example app
+      - name: archive debug screen api example app
         uses: actions/upload-artifact@v3
         with:
-          name: bank-sdk-screen-api-example-app
-          path: bank-sdk/screen-api-example-app/build/outputs/apk
+          name: bank-sdk-screen-api-example-app-debug
+          path: bank-sdk/screen-api-example-app/build/outputs/apk/debug
+
+      - name: build release screen api example app
+        run: >
+          ./gradlew bank-sdk:screen-api-example-app:assembleRelease
+          -PclientId="gini-mobile-test" 
+          -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+          -PreleaseKeystoreFile="screen_api_example.jks"
+          -PreleaseKeystorePassword='${{ secrets.BANK_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+          -PreleaseKeyAlias="screen_api_example"
+          -PreleaseKeyPassword='${{ secrets.BANK_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+
+      - name: archive release screen api example app
+        uses: actions/upload-artifact@v3
+        with:
+          name: bank-sdk-screen-api-example-app-release
+          path: bank-sdk/screen-api-example-app/build/outputs/apk/release
 
       - name: build component api example app
         run: >

--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: gini/gini-mobile-android/.github/workflows/bank-sdk.check.yml@2.x.x
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+      BANK_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD: ${{ secrets.BANK_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}
         
   release:
     needs: check

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -22,6 +22,8 @@ on:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:
         required: true
+      CAPTURE_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD:
+        required: true
 
 jobs:
   test:
@@ -159,17 +161,33 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: build screen api example app
+      - name: build debug screen api example app
         run: >
           ./gradlew capture-sdk:screen-api-example-app:assembleDebug 
           -PclientId="gini-mobile-test" 
           -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
 
-      - name: archive screen api example app
+      - name: archive debug screen api example app
         uses: actions/upload-artifact@v3
         with:
-          name: capture-sdk-screen-api-example-app
-          path: capture-sdk/screen-api-example-app/build/outputs/apk
+          name: capture-sdk-screen-api-example-app-debug
+          path: capture-sdk/screen-api-example-app/build/outputs/apk/debug
+
+      - name: build release screen api example app
+        run: >
+          ./gradlew capture-sdk:screen-api-example-app:assembleRelease
+          -PclientId="gini-mobile-test" 
+          -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+          -PreleaseKeystoreFile="screen_api_example.jks"
+          -PreleaseKeystorePassword='${{ secrets.CAPTURE_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+          -PreleaseKeyAlias="screen_api_example"
+          -PreleaseKeyPassword='${{ secrets.CAPTURE_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+
+      - name: archive release screen api example app
+        uses: actions/upload-artifact@v3
+        with:
+          name: capture-sdk-screen-api-example-app-release
+          path: capture-sdk/screen-api-example-app/build/outputs/apk/release
 
       - name: build component api example app
         run: >

--- a/.github/workflows/capture-sdk.release.yml
+++ b/.github/workflows/capture-sdk.release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: gini/gini-mobile-android/.github/workflows/capture-sdk.check.yml@2.x.x
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+      CAPTURE_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD: ${{ secrets.CAPTURE_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}
         
   release:
     needs: check

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -7,9 +7,12 @@ on:
       - 'health-api-library/**'
       - 'core-api-library/**'
       - 'gradle/**'
+    branches:
+      - '**'
     tags-ignore:
       - '**'
   pull_request:
+    types: [opened, edited, reopened]
     paths:
       - 'health-sdk/**'
       - 'health-api-library/**'

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -19,6 +19,8 @@ on:
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET:
         required: true
+      HEALTH_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD:
+        required: true
 
 jobs:
   test:
@@ -56,17 +58,33 @@ jobs:
           java-version: '11'
           cache: 'gradle'
 
-      - name: build example app
-        env:
-          client_id: gini-mobile-test
-          client_secret: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
-        run: ./gradlew health-sdk:example-app:assembleDebug -PclientId="$client_id" -PclientSecret="$client_secret"
+      - name: build debug example app
+        run: >
+          ./gradlew health-sdk:example-app:assembleDebug 
+          -PclientId="gini-mobile-test" 
+          -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
 
-      - name: archive example app
+      - name: archive debug example app
         uses: actions/upload-artifact@v3
         with:
-          name: health-sdk-example-app
-          path: health-sdk/example-app/build/outputs/apk
+          name: health-sdk-example-app-debug
+          path: health-sdk/example-app/build/outputs/apk/debug
+
+      - name: build release example app
+        run: >
+          ./gradlew health-sdk:example-app:assembleRelease 
+          -PclientId="gini-mobile-test" 
+          -PclientSecret="${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+          -PreleaseKeystoreFile="health_sdk_example.jks"
+          -PreleaseKeystorePassword='${{ secrets.HEALTH_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+          -PreleaseKeyAlias="health_sdk_example"
+          -PreleaseKeyPassword='${{ secrets.HEALTH_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}'
+
+      - name: archive release example app
+        uses: actions/upload-artifact@v3
+        with:
+          name: health-sdk-example-app-release
+          path: health-sdk/example-app/build/outputs/apk/release
 
   android-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/health-sdk.release.yml
+++ b/.github/workflows/health-sdk.release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: gini/gini-mobile-android/.github/workflows/health-sdk.check.yml@2.x.x
     secrets:
       GINI_MOBILE_TEST_CLIENT_SECRET: ${{ secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}
+      HEALTH_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD: ${{ secrets.HEALTH_SDK_EXAMPLE_APP_KEYSTORE_PASSWORD }}
         
   release:
     needs: check

--- a/bank-sdk/screen-api-example-app/src/debug/AndroidManifest.xml
+++ b/bank-sdk/screen-api-example-app/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+
+</manifest>

--- a/bank-sdk/screen-api-example-app/src/debug/res/xml/network_security_config.xml
+++ b/bank-sdk/screen-api-example-app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/capture-sdk/screen-api-example-app/src/debug/AndroidManifest.xml
+++ b/capture-sdk/screen-api-example-app/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+
+</manifest>

--- a/capture-sdk/screen-api-example-app/src/debug/res/xml/network_security_config.xml
+++ b/capture-sdk/screen-api-example-app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/health-sdk/example-app/build.gradle.kts
+++ b/health-sdk/example-app/build.gradle.kts
@@ -14,8 +14,9 @@ android {
         applicationId = "net.gini.android.health.sdk.exampleapp"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk =libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName ="1.0"
+
+        versionName = version as String
+        versionCode = (properties["versionCode"] as? String)?.toInt() ?: 0
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/health-sdk/example-app/build.gradle.kts
+++ b/health-sdk/example-app/build.gradle.kts
@@ -21,10 +21,21 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(properties["releaseKeystoreFile"] ?: "")
+            storePassword = (properties["releaseKeystorePassword"] as? String) ?: ""
+            keyAlias = (properties["releaseKeyAlias"] as? String) ?: ""
+            keyPassword = (properties["releaseKeyPassword"] as? String) ?: ""
+        }
+    }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     buildFeatures {

--- a/health-sdk/example-app/gradle.properties
+++ b/health-sdk/example-app/gradle.properties
@@ -1,2 +1,8 @@
 version=1.0.0
 versionCode=1
+
+# Signing
+releaseKeystoreFile=health_sdk_example.jks
+releaseKeystorePassword=***
+releaseKeyAlias=health_sdk_example
+releaseKeyPassword=***

--- a/health-sdk/example-app/gradle.properties
+++ b/health-sdk/example-app/gradle.properties
@@ -1,0 +1,2 @@
+version=1.0.0
+versionCode=1

--- a/health-sdk/example-app/src/debug/AndroidManifest.xml
+++ b/health-sdk/example-app/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:networkSecurityConfig="@xml/network_security_config" />
+
+</manifest>

--- a/health-sdk/example-app/src/debug/res/xml/network_security_config.xml
+++ b/health-sdk/example-app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
* Add the needed network security configuration for [Charles proxy](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/) to example app debug builds.
* Create release builds in the check workflows. Release builds don't contain the network security configuration and are safe to distribute to clients.