### PR TITLE
2.x.x - Don't delete image multi-page documents when leaving the camera screen via cancellation

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -642,13 +642,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             mImportUrisAsyncTask.cancel(true);
         }
 
-        if (!mInstanceStateSaved) {
-            if (!mProceededToMultiPageReview) {
-                clearMultiPageDocument();
-            }
-            if (!mQRCodeAnalysisCompleted) {
-                deleteUploadedQRCodeDocument();
-            }
+        if (!mInstanceStateSaved && !mProceededToMultiPageReview) {
+            clearMultiPageDocument();
         }
     }
 
@@ -657,24 +652,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             mMultiPageDocument = null; // NOPMD
             GiniCapture.getInstance().internal()
                     .getImageMultiPageDocumentMemoryStore().clear();
-        }
-    }
-
-    private void deleteUploadedQRCodeDocument() {
-        final Activity activity = mFragment.getActivity();
-        if (activity == null) {
-            return;
-        }
-        if (mQRCodeDocument == null) {
-            return;
-        }
-        if (GiniCapture.hasInstance()) {
-            final NetworkRequestsManager networkRequestsManager = GiniCapture.getInstance()
-                    .internal().getNetworkRequestsManager();
-            if (networkRequestsManager != null) {
-                networkRequestsManager.cancel(mQRCodeDocument);
-                networkRequestsManager.delete(mQRCodeDocument);
-            }
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -644,7 +644,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
         if (!mInstanceStateSaved) {
             if (!mProceededToMultiPageReview) {
-                deleteUploadedMultiPageDocuments();
                 clearMultiPageDocument();
             }
             if (!mQRCodeAnalysisCompleted) {
@@ -658,40 +657,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             mMultiPageDocument = null; // NOPMD
             GiniCapture.getInstance().internal()
                     .getImageMultiPageDocumentMemoryStore().clear();
-        }
-    }
-
-    private void deleteUploadedMultiPageDocuments() {
-        final Activity activity = mFragment.getActivity();
-        if (activity == null) {
-            return;
-        }
-        if (mMultiPageDocument == null) {
-            return;
-        }
-
-        if (GiniCapture.hasInstance()) {
-            final NetworkRequestsManager networkRequestsManager = GiniCapture.getInstance()
-                    .internal().getNetworkRequestsManager();
-            if (networkRequestsManager != null) {
-                networkRequestsManager.cancel(mMultiPageDocument);
-                networkRequestsManager.delete(mMultiPageDocument)
-                        .handle(new CompletableFuture.BiFun<NetworkRequestResult<
-                                GiniCaptureDocument>, Throwable, Void>() {
-                            @Override
-                            public Void apply(
-                                    final NetworkRequestResult<GiniCaptureDocument> requestResult,
-                                    final Throwable throwable) {
-                                for (final Object document : mMultiPageDocument.getDocuments()) {
-                                    final GiniCaptureDocument giniCaptureDocument =
-                                            (GiniCaptureDocument) document;
-                                    networkRequestsManager.cancel(giniCaptureDocument);
-                                    networkRequestsManager.delete(giniCaptureDocument);
-                                }
-                                return null;
-                            }
-                        });
-            }
         }
     }
 


### PR DESCRIPTION
It's not critical for our backend that unused documents are deleted.

By removing deletion when leaving the camera screen due to cancellation we eliminate unwanted deletions caused by an unexpected lifecylce behaviour change in Android 13 (onStart is called before onActivityResult in Android 13).