### PR TITLE
fix(core-api-library): Update okio to 3.4.0 to fix a vulnerability issue

### DIFF
--- a/core-api-library/library/build.gradle.kts
+++ b/core-api-library/library/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 dependencies {
     api(libs.retrofit)
     implementation(libs.okhttp3)
+    implementation(libs.okio)
     implementation(libs.trustkit)
     implementation(libs.androidx.core.ktx)
     implementation(libs.kotlinx.coroutines.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ lottie = "com.airbnb.android:lottie:5.1.1"
 jUnitParams = "pl.pragmatists:JUnitParams:1.1.1"
 retrofit = "com.squareup.retrofit2:retrofit:2.9.0"
 okhttp3 = "com.squareup.okhttp3:okhttp:4.10.0"
+okio = "com.squareup.okio:okio:3.4.0"
 retrofit-moshi-converter = "com.squareup.retrofit2:converter-moshi:2.4.0"
 okhttp3-logging-interceptor = "com.squareup.okhttp3:logging-interceptor:4.10.0"
 hilt-library = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
Following vulnerability is fixed in okio 3.4.0
https://github.com/advisories/GHSA-w33c-445m-f8w7

PIA-4424