### PR TITLE
fix(capture-sdk): Accept EPC069-12 QR codes with CR (\r) line delimiters in version 2.x.x

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/qrcode/EPC069_12Parser.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/qrcode/EPC069_12Parser.java
@@ -39,7 +39,10 @@ class EPC069_12Parser implements QRCodeParser<PaymentQRCodeData> {
     @Override
     public PaymentQRCodeData parse(@NonNull final String qrCodeContent)
             throws IllegalArgumentException {
-        final String[] lines = qrCodeContent.split("\r\n|\n", 12);
+        // Replace occurrences of the line separators "\r\n" and "\r\r\n" with the line feed character "\n"
+        // and split the string into lines with either the new line (\n) or carriage feed (\r) delimiter.
+        final String[] lines = qrCodeContent.replaceAll("\r\r?\n", "\n")
+                .split("\n|\r", 12);
         if (lines.length == 0 || !"BCD".equals(lines[0])) {
             throw new IllegalArgumentException(
                     "QRCode content does not conform to the EPC069-12 format.");

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/internal/qrcode/EPC069_12ParserTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/internal/qrcode/EPC069_12ParserTest.kt
@@ -1,0 +1,146 @@
+package net.gini.android.capture.internal.qrcode
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EPC06912ParserTest {
+
+    private lateinit var parser: EPC069_12Parser
+
+    @Before
+    fun setup() {
+        parser = EPC069_12Parser()
+    }
+
+    @Test
+    fun `accepts LF as line delimiter`() {
+        // Given
+        val qrCodeContent = "BCD\n" +
+                "001\n" +
+                "2\n" +
+                "SCT\n" +
+                "BAWAATWW\n" +
+                "Magistrat der Stadt Wien\n" +
+                "AT736000000002386492\n" +
+                "EUR58.99\n" +
+                "\n" +
+                "\n" +
+                "Fuer Franz Mustermann"
+
+        // When
+        val paymentData = parser.parse(qrCodeContent)
+
+        // Then
+        Truth.assertThat(paymentData).isEqualTo(
+            PaymentQRCodeData(
+                PaymentQRCodeData.Format.EPC069_12,
+                qrCodeContent,
+                "Magistrat der Stadt Wien",
+                "Fuer Franz Mustermann",
+                "AT736000000002386492",
+                "BAWAATWW",
+                "58.99:EUR"
+            )
+        )
+    }
+
+    @Test
+    fun `accepts CRLF as line delimiter`() {
+        // Given
+        val qrCodeContent = "BCD\r\n" +
+                "001\r\n" +
+                "2\r\n" +
+                "SCT\r\n" +
+                "BAWAATWW\r\n" +
+                "Magistrat der Stadt Wien\r\n" +
+                "AT736000000002386492\r\n" +
+                "EUR58.99\r\n" +
+                "\r\n" +
+                "\r\n" +
+                "Fuer Franz Mustermann"
+
+        // When
+        val paymentData = parser.parse(qrCodeContent)
+
+        // Then
+        Truth.assertThat(paymentData).isEqualTo(
+            PaymentQRCodeData(
+                PaymentQRCodeData.Format.EPC069_12,
+                qrCodeContent,
+                "Magistrat der Stadt Wien",
+                "Fuer Franz Mustermann",
+                "AT736000000002386492",
+                "BAWAATWW",
+                "58.99:EUR"
+            )
+        )
+    }
+
+    @Test
+    fun `accepts CR as line delimiter`() {
+        // Given
+        val qrCodeContent = "BCD\r" +
+                "001\r" +
+                "2\r" +
+                "SCT\r" +
+                "BAWAATWW\r" +
+                "Magistrat der Stadt Wien\r" +
+                "AT736000000002386492\r" +
+                "EUR58.99\r" +
+                "\r" +
+                "\r" +
+                "Fuer Franz Mustermann"
+
+        // When
+        val paymentData = parser.parse(qrCodeContent)
+
+        // Then
+        Truth.assertThat(paymentData).isEqualTo(
+            PaymentQRCodeData(
+                PaymentQRCodeData.Format.EPC069_12,
+                qrCodeContent,
+                "Magistrat der Stadt Wien",
+                "Fuer Franz Mustermann",
+                "AT736000000002386492",
+                "BAWAATWW",
+                "58.99:EUR"
+            )
+        )
+    }
+
+    @Test
+    fun `accepts CRCRLF as line delimiter`() {
+        // Given
+        val parser = EPC069_12Parser()
+        val qrCodeContent = "BCD\r\n" +
+                "001\r\n" +
+                "2\r\n" +
+                "SCT\r\n" +
+                "BAWAATWW\r\r\n" +
+                "Magistrat der Stadt Wien\r\r\n" +
+                "AT736000000002386492\r\r\n" +
+                "EUR58.99\r\n" +
+                "\r\n" +
+                "3372/12 RgNr.: 2201207\r\n"
+
+        // When
+        val paymentData = parser.parse(qrCodeContent)
+
+        // Then
+        Truth.assertThat(paymentData).isEqualTo(
+            PaymentQRCodeData(
+                PaymentQRCodeData.Format.EPC069_12,
+                qrCodeContent,
+                "Magistrat der Stadt Wien",
+                "3372/12 RgNr.: 2201207 ",
+                "AT736000000002386492",
+                "BAWAATWW",
+                "58.99:EUR"
+            )
+        )
+    }
+}


### PR DESCRIPTION
Even though according to the standard only LF (\n) or CRLF (\r\n) line delimiters are allowed some invoice issuers use CR line delimiters.

PIA-4468