### PR TITLE
Pia 4547 deprecate requirements check

### DIFF
--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -142,11 +142,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun startGiniCaptureSdk(intent: Intent? = null) {
-        val report = GiniBank.checkCaptureRequirements(this@MainActivity)
-        if (!report.isFulfilled) {
-            showUnfulfilledRequirementsToast(report)
-        }
-
         configureGiniCapture()
 
         if (intent != null) {

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/GiniBank.kt
@@ -184,7 +184,13 @@ object GiniBank {
     /**
      *  Checks hardware requirements for Capture feature.
      *  Requirements are not enforced, but are recommended to be checked before using.
+     *
+     * @deprecated Checking the requirements is no longer necessary and this method will be removed in a future release.
+     *             The majority of Android devices already meet the SDK's requirements.
      */
+    @Deprecated(
+        "Checking the requirements is no longer necessary and this method will be removed in a future release."
+    )
     fun checkCaptureRequirements(context: Context): RequirementsReport =
         GiniCaptureRequirements.checkRequirements(context)
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/GiniCaptureRequirements.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/GiniCaptureRequirements.java
@@ -25,7 +25,11 @@ import androidx.annotation.NonNull;
  * <p>
  *     On Android 6.0 and later you need to ask the user for the camera permission before you check the requirements.
  * </p>
+ *
+ * @deprecated Checking the requirements is no longer necessary and this class will be removed in a future release.
+ *             The majority of Android devices already meet the SDK's requirements.
  */
+@Deprecated
 public final class GiniCaptureRequirements {
 
     private static final Logger LOG = LoggerFactory.getLogger(GiniCaptureRequirements.class);

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/RequirementReport.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/RequirementReport.java
@@ -6,7 +6,11 @@ import androidx.annotation.NonNull;
  * <p>
  *     Contains the report of a requirement check result.
  * </p>
+ *
+ * @deprecated Checking the requirements is no longer necessary and this class will be removed in a future release.
+ *             The majority of Android devices already meet the SDK's requirements.
  */
+@Deprecated
 public class RequirementReport {
 
     private final RequirementId mRequirementId;

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/RequirementsReport.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/requirements/RequirementsReport.java
@@ -8,7 +8,11 @@ import androidx.annotation.NonNull;
  * <p>
  *     Contains the report of the requirements check result.
  * </p>
+ *
+ * @deprecated Checking the requirements is no longer necessary and this class will be removed in a future release.
+ *             The majority of Android devices already meet the SDK's requirements.
  */
+@Deprecated
 public class RequirementsReport {
 
     private final boolean mFulfilled;


### PR DESCRIPTION
The majority of Android devices meet the Capture/Bank SDK's requirements. Also sometimes the requirements checking fails due issues in the Android camera apis (e.g., [PIA-2482](https://ginis.atlassian.net/browse/PIA-2482)).

By deprecating (and later removing) the requirements checking we will allow a small number of additional old devices to use the SDK. The extraction quality might be lower due to the smaller camera resolution (less than 8MP), but we won't block users anymore and also will prevent wrongly blocking users with adequate devices.