### PR TITLE
Pp 226 prevent screenshots

### DIFF
--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
@@ -209,6 +209,10 @@ class ConfigurationActivity : AppCompatActivity() {
         binding.switchDigitalInvoiceBottomNavigationBar.isChecked =
             configuration.isDigitalInvoiceBottomNavigationBarEnabled
 
+        // Allow screenshots
+        binding.switchAllowScreenshots.isChecked =
+            configuration.isAllowScreenshotsEnabled
+
         // 37 Debug mode
         binding.switchDebugMode.isChecked =
             configuration.isDebugModeEnabled
@@ -566,6 +570,15 @@ class ConfigurationActivity : AppCompatActivity() {
             configurationViewModel.setConfiguration(
                 configurationViewModel.configurationFlow.value.copy(
                     isDigitalInvoiceBottomNavigationBarEnabled = isChecked
+                )
+            )
+        }
+
+        // Allow screenshots
+        binding.switchAllowScreenshots.setOnCheckedChangeListener { _, isChecked ->
+            configurationViewModel.setConfiguration(
+                configurationViewModel.configurationFlow.value.copy(
+                    isAllowScreenshotsEnabled = isChecked
                 )
             )
         }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationViewModel.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationViewModel.kt
@@ -119,7 +119,10 @@ class ConfigurationViewModel @Inject constructor(
             entryPoint = configuration.entryPoint,
 
             // 31 enable return assistant
-            returnAssistantEnabled = configuration.isReturnAssistantEnabled
+            returnAssistantEnabled = configuration.isReturnAssistantEnabled,
+
+            // allow screenshots
+            allowScreenshots = configuration.isAllowScreenshotsEnabled
         )
 
         // 9 enable Help screens custom bottom navigation bar

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/Configuration.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/Configuration.kt
@@ -154,6 +154,8 @@ data class Configuration(
     // 37 Debug mode
     val isDebugModeEnabled: Boolean = false,
 
+    val isAllowScreenshotsEnabled: Boolean = true,
+
     ) : Parcelable {
 
     companion object {
@@ -171,7 +173,8 @@ data class Configuration(
                 isOnboardingAtEveryLaunchEnabled = defaultCaptureConfiguration.showOnboarding,
                 isSupportedFormatsHelpScreenEnabled = defaultCaptureConfiguration.supportedFormatsHelpScreenEnabled,
                 isGiniErrorLoggerEnabled = defaultCaptureConfiguration.giniErrorLoggerIsOn,
-                isReturnAssistantEnabled = defaultCaptureConfiguration.returnAssistantEnabled
+                isReturnAssistantEnabled = defaultCaptureConfiguration.returnAssistantEnabled,
+                isAllowScreenshotsEnabled = defaultCaptureConfiguration.allowScreenshots
             )
 
 

--- a/bank-sdk/example-app/src/main/res/layout/activity_configuration.xml
+++ b/bank-sdk/example-app/src/main/res/layout/activity_configuration.xml
@@ -532,6 +532,14 @@
                 android:text="@string/disable_camera_permission" />
 
             <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/switch_allowScreenshots"
+                style="@style/SwitchConfigurationStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/gc_medium_12"
+                android:text="@string/allow_screenshots_label" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
                 android:id="@+id/switch_debugMode"
                 style="@style/SwitchConfigurationStyle"
                 android:layout_width="match_parent"

--- a/bank-sdk/example-app/src/main/res/values/strings.xml
+++ b/bank-sdk/example-app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="imported_file_size_bytes_limit">Imported File Size Bytes Limit</string>
     <string name="file_import_feature_is_disabled_dialog_message">`File import` feature is currently disabled. If you want to test this, please enable it in Gini configuration.</string>
     <string name="debug_mode_switch_label">Debug mode</string>
+    <string name="allow_screenshots_label">Allow screenshots</string>
 
     <string name="recipient_hint">recipient</string>
     <string name="iban_hint">IBAN</string>

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowFragment.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowFragment.kt
@@ -15,8 +15,10 @@ import net.gini.android.bank.sdk.capture.digitalinvoice.DigitalInvoiceException
 import net.gini.android.bank.sdk.capture.digitalinvoice.DigitalInvoiceFragment
 import net.gini.android.bank.sdk.capture.digitalinvoice.DigitalInvoiceFragmentListener
 import net.gini.android.bank.sdk.capture.digitalinvoice.LineItemsValidator
+import net.gini.android.bank.sdk.util.disallowScreenshots
 import net.gini.android.capture.CaptureSDKResult
 import net.gini.android.capture.Document
+import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.GiniCaptureFragment
 import net.gini.android.capture.GiniCaptureFragmentDirections
 import net.gini.android.capture.GiniCaptureFragmentListener
@@ -66,6 +68,9 @@ class CaptureFlowFragment(private val openWithDocument: Document? = null) :
     override fun onCreate(savedInstanceState: Bundle?) {
         childFragmentManager.fragmentFactory = CaptureFlowFragmentFactory(this, openWithDocument, this)
         super.onCreate(savedInstanceState)
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            requireActivity().window.disallowScreenshots()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
@@ -191,7 +191,17 @@ data class CaptureConfiguration(
      *
      * Default value is [EntryPoint.BUTTON].
      */
-    val entryPoint: EntryPoint = GiniCapture.Internal.DEFAULT_ENTRY_POINT
+    val entryPoint: EntryPoint = GiniCapture.Internal.DEFAULT_ENTRY_POINT,
+
+    /**
+     * Set whether screenshots should be allowed or not.
+     *
+     * Screenshots are allowed by default.
+     *
+     * IMPORTANT: If you disallow screenshots and use the [CaptureFlowFragment] for launching the SDK in your activity, please clear the [android.view.WindowManager.LayoutParams.FLAG_SECURE]
+     * on your activity's window after the SDK has finished to allow users to take screenshots of your app again.
+    */
+    val allowScreenshots: Boolean = true
 )
 
 internal fun GiniCapture.Builder.applyConfiguration(configuration: CaptureConfiguration): GiniCapture.Builder {
@@ -211,6 +221,7 @@ internal fun GiniCapture.Builder.applyConfiguration(configuration: CaptureConfig
         .setImportedFileSizeBytesLimit(configuration.importedFileSizeBytesLimit)
         .setBottomNavigationBarEnabled(configuration.bottomNavigationBarEnabled)
         .setEntryPoint(configuration.entryPoint)
+        .setAllowScreenshots(configuration.allowScreenshots)
         .apply {
             configuration.eventTracker?.let { setEventTracker(it) }
             configuration.errorLoggerListener?.let { setCustomErrorLoggerListener(it) }

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceBottomSheet.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceBottomSheet.kt
@@ -24,8 +24,10 @@ import net.gini.android.bank.sdk.capture.digitalinvoice.details.doAfterTextChang
 import net.gini.android.bank.sdk.capture.util.amountWatcher
 import net.gini.android.bank.sdk.capture.util.hideKeyboard
 import net.gini.android.bank.sdk.databinding.GbsEditItemBottomSheetBinding
+import net.gini.android.bank.sdk.util.disallowScreenshots
 import net.gini.android.bank.sdk.util.getLayoutInflaterWithGiniCaptureTheme
 import net.gini.android.capture.AmountCurrency
+import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.network.model.GiniCaptureReturnReason
 
 private const val ARGS_SELECTABLE_LINE_ITEM = "GBS_ARGS_SELECTABLE_LINE_ITEM"
@@ -114,6 +116,10 @@ internal class DigitalInvoiceBottomSheet : BottomSheetDialogFragment(), LineItem
         super.onViewCreated(view, savedInstanceState)
 
         setUpBindings()
+
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            dialog?.window?.disallowScreenshots()
+        }
     }
 
     /**

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceFragment.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/DigitalInvoiceFragment.kt
@@ -20,6 +20,7 @@ import net.gini.android.bank.sdk.capture.digitalinvoice.view.DigitalInvoiceNavig
 import net.gini.android.bank.sdk.capture.util.autoCleared
 import net.gini.android.bank.sdk.capture.util.parentFragmentManagerOrNull
 import net.gini.android.bank.sdk.databinding.GbsFragmentDigitalInvoiceBinding
+import net.gini.android.bank.sdk.util.disallowScreenshots
 import net.gini.android.bank.sdk.util.getLayoutInflaterWithGiniCaptureTheme
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.internal.ui.IntervalToolbarMenuItemIntervalClickListener
@@ -99,6 +100,9 @@ open class DigitalInvoiceFragment : Fragment(), DigitalInvoiceScreenContract.Vie
         val activity = this.activity
         checkNotNull(activity) {
             "Missing activity for fragment."
+        }
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            requireActivity().window.disallowScreenshots()
         }
         forcePortraitOrientationOnPhones(activity)
         readArguments()

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/ReturnReasonsDialog.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/digitalinvoice/ReturnReasonsDialog.kt
@@ -14,7 +14,9 @@ import net.gini.android.capture.network.model.GiniCaptureReturnReason
 import net.gini.android.bank.sdk.R
 import net.gini.android.bank.sdk.capture.util.autoCleared
 import net.gini.android.bank.sdk.databinding.GbsFragmentReturnReasonDialogBinding
+import net.gini.android.bank.sdk.util.disallowScreenshots
 import net.gini.android.bank.sdk.util.getLayoutInflaterWithGiniCaptureTheme
+import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.internal.util.ContextHelper
 
 /**
@@ -79,6 +81,9 @@ internal class ReturnReasonDialog : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initListView()
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            dialog?.window?.disallowScreenshots()
+        }
     }
 
     private fun initListView() {

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/util/WindowExtensions.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/util/WindowExtensions.kt
@@ -1,0 +1,12 @@
+package net.gini.android.bank.sdk.util
+
+import android.view.Window
+import android.view.WindowManager
+
+/**
+ * Disables screenshots for the given [Window] by setting the [android.view.WindowManager.LayoutParams.FLAG_SECURE]
+ * flag.
+ */
+internal fun Window.disallowScreenshots() {
+    setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+}

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
@@ -122,7 +122,7 @@ public class GiniCapture {
     private final InjectedViewAdapterInstance<ReviewNavigationBarBottomAdapter> reviewNavigationBarBottomAdapterInstance;
     private final InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> onButtonLoadingIndicatorAdapterInstance;
     private final EntryPoint entryPoint;
-
+    private final boolean allowScreenshots;
 
 
     /**
@@ -342,6 +342,7 @@ public class GiniCapture {
         reviewNavigationBarBottomAdapterInstance = builder.getReviewNavigationBarBottomAdapterInstance();
         onButtonLoadingIndicatorAdapterInstance = builder.getOnButtonLoadingIndicatorAdapterInstance();
         entryPoint = builder.getEntryPoint();
+        allowScreenshots = builder.getAllowScreenshots();
     }
 
     /**
@@ -681,6 +682,16 @@ public class GiniCapture {
         return entryPoint;
     }
 
+    /**
+     * Get whether screenshots are allowed or not.
+     *
+     * <p> Default value is {@code true}.
+     *
+     * @return {@code true} if screenshots are allowed
+     */
+    public boolean getAllowScreenshots() {
+        return allowScreenshots;
+    }
 
     public static GiniCaptureFragment createGiniCaptureFragment() {
         if (!GiniCapture.hasInstance()) {
@@ -793,6 +804,7 @@ public class GiniCapture {
 
         private InjectedViewAdapterInstance<OnButtonLoadingIndicatorAdapter> onButtonLoadingIndicatorAdapterInstance = new InjectedViewAdapterInstance<>(new DefaultOnButtonLoadingIndicatorAdapter());
         private EntryPoint entryPoint = Internal.DEFAULT_ENTRY_POINT;
+        private boolean allowScreenshots = true;
 
         /**
          * Create a new {@link GiniCapture} instance.
@@ -1308,6 +1320,27 @@ public class GiniCapture {
 
         private EntryPoint getEntryPoint() {
             return entryPoint;
+        }
+
+        /**
+         * Set whether screenshots should be allowed or not.
+         *
+         * <p>Screenshots are allowed by default.
+         *
+         * <p>IMPORTANT: If you disallow screenshots and use the {@link GiniCaptureFragment} for launching the SDK in your activity, please clear the {@link android.view.WindowManager.LayoutParams#FLAG_SECURE}
+         * on your activity's window after the SDK has finished to allow users to take screenshots of your app again.
+         *
+         * @param allowScreenshots pass {@code true} to allow screenshots or {@code false} otherwise.
+         *
+         * @return the {@link Builder} instance
+         */
+        public Builder setAllowScreenshots(boolean allowScreenshots) {
+            this.allowScreenshots = allowScreenshots;
+            return this;
+        }
+
+        private boolean getAllowScreenshots() {
+            return allowScreenshots;
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureFragment.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureFragment.kt
@@ -17,12 +17,12 @@ import net.gini.android.capture.camera.CameraFragmentListener
 import net.gini.android.capture.error.ErrorFragment
 import net.gini.android.capture.internal.util.FeatureConfiguration.shouldShowOnboarding
 import net.gini.android.capture.internal.util.FeatureConfiguration.shouldShowOnboardingAtFirstRun
+import net.gini.android.capture.internal.util.disallowScreenshots
 import net.gini.android.capture.internal.util.getLayoutInflaterWithGiniCaptureTheme
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
 import net.gini.android.capture.network.model.GiniCaptureReturnReason
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
 import net.gini.android.capture.noresults.NoResultsFragment
-import net.gini.android.capture.review.multipage.MultiPageReviewFragment
 
 class GiniCaptureFragment(private val openWithDocument: Document? = null) :
     Fragment(),
@@ -47,6 +47,9 @@ class GiniCaptureFragment(private val openWithDocument: Document? = null) :
     override fun onCreate(savedInstanceState: Bundle?) {
         childFragmentManager.fragmentFactory = CaptureFragmentFactory(this, this, this)
         super.onCreate(savedInstanceState)
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            requireActivity().window.disallowScreenshots()
+        }
     }
 
     override fun onGetLayoutInflater(savedInstanceState: Bundle?): LayoutInflater {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/fileimport/FileChooserFragment.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/fileimport/FileChooserFragment.kt
@@ -22,6 +22,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.parcelize.Parcelize
 import net.gini.android.capture.DocumentImportEnabledFileTypes
+import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.GiniCaptureError
 import net.gini.android.capture.R
 import net.gini.android.capture.databinding.GcFragmentFileChooserBinding
@@ -35,6 +36,7 @@ import net.gini.android.capture.internal.util.ContextHelper
 import net.gini.android.capture.internal.util.FeatureConfiguration
 import net.gini.android.capture.internal.util.MimeType
 import net.gini.android.capture.internal.util.autoCleared
+import net.gini.android.capture.internal.util.disallowScreenshots
 import net.gini.android.capture.internal.util.getLayoutInflaterWithGiniCaptureTheme
 
 private const val ARG_DOCUMENT_IMPORT_FILE_TYPES = "GC_EXTRA_IN_DOCUMENT_IMPORT_FILE_TYPES"
@@ -79,6 +81,13 @@ class FileChooserFragment : BottomSheetDialogFragment() {
             peekHeight = 0
         }
         return dialog
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().allowScreenshots) {
+            dialog?.window?.disallowScreenshots()
+        }
     }
 
     private fun setupFileProvidersView() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/AlertDialogFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/AlertDialogFragment.java
@@ -6,6 +6,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,6 +16,9 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import net.gini.android.capture.GiniCapture;
+import net.gini.android.capture.internal.util.WindowExtensionsKt;
 
 /**
  * Created by Alpar Szotyori on 05.06.2018.
@@ -52,6 +56,16 @@ public class AlertDialogFragment extends DialogFragment {
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         readArguments();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().getAllowScreenshots()) {
+            if (getDialog() != null && getDialog().getWindow() != null) {
+                WindowExtensionsKt.disallowScreenshots(getDialog().getWindow());
+            }
+        }
     }
 
     private void readArguments() {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/AlertDialogHelperCompat.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/AlertDialogHelperCompat.java
@@ -8,6 +8,8 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import net.gini.android.capture.GiniCapture;
 /**
  * Created by Alpar Szotyori on 04.02.2019.
  *
@@ -37,6 +39,11 @@ public final class AlertDialogHelperCompat {
                 .setNegativeButton(negativeButtonTitle, negativeButtonClickListener)
                 .setOnCancelListener(cancelListener)
                 .create();
+        if (GiniCapture.hasInstance() && !GiniCapture.getInstance().getAllowScreenshots()) {
+            if (alertDialog.getWindow() != null) {
+                WindowExtensionsKt.disallowScreenshots(alertDialog.getWindow());
+            }
+        }
         alertDialog.setCanceledOnTouchOutside(false);
         alertDialog.show();
     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/WindowExtensions.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/util/WindowExtensions.kt
@@ -1,0 +1,12 @@
+package net.gini.android.capture.internal.util
+
+import android.view.Window
+import android.view.WindowManager
+
+/**
+ * Disables screenshots for the given [Window] by setting the [android.view.WindowManager.LayoutParams.FLAG_SECURE]
+ * flag.
+ */
+internal fun Window.disallowScreenshots() {
+    setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+}


### PR DESCRIPTION
- Adds a new configuration option to Capture SDK and Bank SDK to allow or disallow screenshots. By default screenshots are allowed.
- Also adds this new configuration option to the example app's configuration screen.

The new configuration option can be used as follows:
* Capture SDK: 
   ```
    GiniCapture.newInstance(context)
        .setAllowScreenshots(false) // or true
        ...
        .build()
   ```
* Bank SDK: 
   ```
        GiniBank.setCaptureConfiguration(context, CaptureConfiguration(
            allowScreenshots = false, // or true
            ...
        ))
   ```

Note: builds upon the host fragments branch which we plan to be our upcoming version. In the extreme case that our release of that is delayed we can easily port this to work with latest version we have in `main`.