### PR TITLE
refactor(health-sdk): Rename `paymentComponentViewIdentifier` to `doc…

### DIFF
--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesActivity.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesActivity.kt
@@ -1,7 +1,6 @@
 package net.gini.android.health.sdk.exampleapp.invoices.ui
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -11,7 +10,6 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -160,10 +158,10 @@ class InvoicesActivity : AppCompatActivity() {
                 }
             }
 
-            override fun onPayInvoiceClicked(paymentComponentViewIdentifier: String) {
+            override fun onPayInvoiceClicked(documentId: String) {
                 LOG.debug("Pay invoice clicked")
 
-                viewModel.getPaymentReviewFragment(paymentComponentViewIdentifier)
+                viewModel.getPaymentReviewFragment(documentId)
             }
         }
 
@@ -219,14 +217,14 @@ class InvoicesAdapter(
         val recipient: TextView
         val dueDate: TextView
         val amount: TextView
-        val paymentComponent: PaymentComponentView
+        val paymentComponentView: PaymentComponentView
 
         init {
             recipient = view.findViewById(R.id.recipient)
             dueDate = view.findViewById(R.id.due_date)
             amount = view.findViewById(R.id.amount)
-            this.paymentComponent = view.findViewById(R.id.payment_component)
-            this.paymentComponent.paymentComponent = paymentComponent
+            this.paymentComponentView = view.findViewById(R.id.payment_component)
+            this.paymentComponentView.paymentComponent = paymentComponent
         }
     }
 
@@ -243,9 +241,9 @@ class InvoicesAdapter(
         viewHolder.dueDate.text = invoiceItem.dueDate ?: ""
         viewHolder.amount.text = invoiceItem.amount ?: ""
 
-        viewHolder.paymentComponent.prepareForReuse()
-        viewHolder.paymentComponent.isPayable = invoiceItem.isPayable
-        viewHolder.paymentComponent.identifier = invoiceItem.documentId
+        viewHolder.paymentComponentView.prepareForReuse()
+        viewHolder.paymentComponentView.isPayable = invoiceItem.isPayable
+        viewHolder.paymentComponentView.documentId = invoiceItem.documentId
     }
 
     override fun getItemCount() = dataSet.size

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
@@ -1,6 +1,5 @@
 package net.gini.android.health.sdk.exampleapp.invoices.ui
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -49,14 +48,14 @@ class InvoicesViewModel(
         }
     }
 
-    fun getPaymentReviewFragment(paymentComponentViewIdentifier: String) {
+    fun getPaymentReviewFragment(documentId: String) {
         viewModelScope.launch {
-            LOG.debug("Getting payment review fragment for id: {}", paymentComponentViewIdentifier)
+            LOG.debug("Getting payment review fragment for id: {}", documentId)
 
             _paymentReviewFragmentFlow.value = PaymentReviewFragmentState.Loading
 
             val documentWithExtractions =
-                invoicesRepository.invoicesFlow.value.find { it.documentId == paymentComponentViewIdentifier }
+                invoicesRepository.invoicesFlow.value.find { it.documentId == documentId }
 
             if (documentWithExtractions != null) {
                 try {
@@ -70,8 +69,8 @@ class InvoicesViewModel(
                     _paymentReviewFragmentFlow.value = PaymentReviewFragmentState.Error(e)
                 }
             } else {
-                LOG.error("Document with id {} not found", paymentComponentViewIdentifier)
-                _paymentReviewFragmentFlow.value = PaymentReviewFragmentState.Error(IllegalStateException("Document with id $paymentComponentViewIdentifier not found"))
+                LOG.error("Document with id {} not found", documentId)
+                _paymentReviewFragmentFlow.value = PaymentReviewFragmentState.Error(IllegalStateException("Document with id $documentId not found"))
             }
             _paymentReviewFragmentFlow.emit(PaymentReviewFragmentState.Idle)
         }

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/review/ReviewActivity.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/review/ReviewActivity.kt
@@ -5,7 +5,6 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -114,14 +113,14 @@ class ReviewActivity : AppCompatActivity() {
                 }
             }
 
-            override fun onPayInvoiceClicked(paymentComponentViewIdentifier: String) {
+            override fun onPayInvoiceClicked(documentId: String) {
                 // Get and show the payment ReviewFragment for the document id in paymentComponentViewIdentifier
                 lifecycleScope.launch {
                     binding.progress.visibility = View.VISIBLE
 
                     try {
                         val reviewFragment = viewModel.paymentComponent.getPaymentReviewFragment(
-                            documentId = paymentComponentViewIdentifier,
+                            documentId = documentId,
                             configuration = ReviewConfiguration(showCloseButton = showCloseButton)
                         )
 
@@ -166,7 +165,7 @@ class ReviewActivity : AppCompatActivity() {
 
             // Configure the PaymentComponentView
             binding.paymentComponentView.isPayable = true
-            binding.paymentComponentView.identifier = documentId
+            binding.paymentComponentView.documentId = documentId
 
             // Load the payment provider apps and show an alert dialog for errors
             viewModel.paymentComponent.loadPaymentProviderApps()

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -1,12 +1,9 @@
 package net.gini.android.health.sdk.paymentcomponent
 
 import android.content.Context
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import net.gini.android.core.api.Resource
 import net.gini.android.health.api.models.PaymentProvider
 import net.gini.android.health.sdk.GiniHealth
@@ -215,7 +212,7 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
     interface Listener {
         fun onMoreInformationClicked()
         fun onBankPickerClicked()
-        fun onPayInvoiceClicked(paymentComponentViewIdentifier: String)
+        fun onPayInvoiceClicked(documentId: String)
     }
 
 }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponentView.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponentView.kt
@@ -43,7 +43,7 @@ class PaymentComponentView(context: Context, attrs: AttributeSet?) : ConstraintL
             }
         }
 
-    var identifier: String? = null
+    var documentId: String? = null
 
     private val binding = GhsViewPaymentComponentBinding.inflate(getLayoutInflaterWithGiniHealthTheme(), this)
 
@@ -189,7 +189,7 @@ class PaymentComponentView(context: Context, attrs: AttributeSet?) : ConstraintL
 
     fun prepareForReuse() {
         isPayable = false
-        identifier = null
+        documentId = null
         disablePayInvoiceButton()
         restorePayInvoiceButtonDefaultState()
         restoreBankPickerDefaultState()
@@ -259,10 +259,10 @@ class PaymentComponentView(context: Context, attrs: AttributeSet?) : ConstraintL
             if (paymentComponent == null) {
                 LOG.warn("Cannot call PaymentComponent's listener: PaymentComponent must be set before showing the PaymentComponentView")
             }
-            identifier?.let { identifier ->
-                paymentComponent?.listener?.onPayInvoiceClicked(identifier)
+            documentId?.let { docId ->
+                paymentComponent?.listener?.onPayInvoiceClicked(docId)
             } ?: run {
-                LOG.warn("Cannot call PaymentComponent's listener: identifier must be set before showing the PaymentComponentView")
+                LOG.warn("Cannot call PaymentComponent's listener: documentId must be set before showing the PaymentComponentView")
             }
         }
     }


### PR DESCRIPTION
…umentId`

Using `documentId` conveys the purpose better, because the string identifier is meant for linking the `PaymentComponentView` with a document using and identifier.

IPC-157