### PR TITLE
Ipc 215 more information screen UI customization guide

### DIFF
--- a/health-sdk/sdk/src/doc/source/customization.rst
+++ b/health-sdk/sdk/src/doc/source/customization.rst
@@ -181,3 +181,22 @@ You can also view the UI customisation guide in Figma `here
     <iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="600" height="450"
     src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FAJTss4k0M6R2OxH0VQepdP%2FAndroid-Gini-Health-SDK-4.0.0-UI-Customisation%3Ftype%3Ddesign%26node-id%3D8794%253A1437%26mode%3Ddesign%26t%3Dosss80Nvdttp8opj-1"
     allowfullscreen></iframe>
+
+|
+
+Payment Feature Info Screen
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can also view the UI customisation guide in Figma `here
+<https://www.figma.com/file/AJTss4k0M6R2OxH0VQepdP/Android-Gini-Health-SDK-4.0.0-UI-Customisation?type=design&node-id=8865%3A1784&mode=design&t=K7YqsQfoIezyUS7U-1>`_.
+
+.. note::
+
+    To copy text from Figma you need to have a Figma account. If you don't have one, you can create one for free.
+
+.. raw:: html
+
+    <iframe style="border: 1px solid rgba(0, 0, 0, 0.1);" width="600" height="450"
+    src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FAJTss4k0M6R2OxH0VQepdP%2FAndroid-Gini-Health-SDK-4.0.0-UI-Customisation%3Ftype%3Ddesign%26node-id%3D8865%253A1784%26mode%3Ddesign%26t%3DK7YqsQfoIezyUS7U-1"
+    allowfullscreen></iframe>
+

--- a/health-sdk/sdk/src/main/res/layout/ghs_fragment_payment_more_information.xml
+++ b/health-sdk/sdk/src/main/res/layout/ghs_fragment_payment_more_information.xml
@@ -97,7 +97,7 @@
                 android:layout_marginHorizontal="@dimen/ghs_large"
                 android:layoutDirection="rtl"
                 android:nestedScrollingEnabled="false"
-                android:divider="@color/ghs_dark_05"
+                android:divider="@color/ghs_faq_divider"
                 android:dividerHeight="@dimen/ghs_small_1"
                 android:groupIndicator="@drawable/ghs_expandable_list_icon"
                 android:scrollbars="none"

--- a/health-sdk/sdk/src/main/res/layout/ghs_item_faq_answer.xml
+++ b/health-sdk/sdk/src/main/res/layout/ghs_item_faq_answer.xml
@@ -14,5 +14,5 @@
         android:id="@+id/divider2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:dividerColor="@color/ghs_dark_05"/>
+        app:dividerColor="@color/ghs_faq_divider"/>
 </LinearLayout>

--- a/health-sdk/sdk/src/main/res/values-night/colors.xml
+++ b/health-sdk/sdk/src/main/res/values-night/colors.xml
@@ -11,5 +11,6 @@
     <color name="ghs_bank_selector_button_color">@color/ghs_light_01</color>
     <color name="ghs_payment_details_background_color">@color/ghs_light_07</color>
     <color name="ghs_payment_input_border_color">@color/ghs_light_06</color>
+    <color name="ghs_faq_divider">@color/ghs_light_05</color>
 
 </resources>

--- a/health-sdk/sdk/src/main/res/values/colors.xml
+++ b/health-sdk/sdk/src/main/res/values/colors.xml
@@ -43,5 +43,6 @@
     <color name="ghs_payment_provider_border_color">@color/ghs_dark_05</color>
     <color name="ghs_bordered_background_color">@color/ghs_dark_06</color>
     <color name="ghs_bank_selector_button_color">@color/ghs_dark_01</color>
+    <color name="ghs_faq_divider">@color/ghs_dark_05</color>
 
 </resources>


### PR DESCRIPTION
- Adds customization guide for the Payment Feature Info Screen.
- Adds dark mode color for the FAQ list divider.

You can download the rendered integration guide from the Checks tab -> Build docs for Health SDK -> Click on the "health-sdk-documentation" artifact. This will download the `health-sdk-documentation.zip`. 

Extract the zip, and open `html/index.html` to view the integration guide.