### PR TITLE
Ipc 240 data flow refactor

### DIFF
--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -115,6 +115,7 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
 
                 val paymentProviders = paymentProviderAppsState.paymentProviderApps.map { it.paymentProvider }
                 val paymentProviderApps = getPaymentProviderAppsSorted(paymentProviders)
+                updateSelectedPaymentProviderApp(paymentProviderApps)
                 _paymentProviderAppsFlow.value = PaymentProviderAppsState.Success(paymentProviderApps)
             }
 
@@ -162,6 +163,17 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
             _selectedPaymentProviderAppFlow.value = SelectedPaymentProviderAppState.NothingSelected
 
             paymentComponentPreferences.deleteSelectedPaymentProviderId()
+        }
+    }
+
+    private fun updateSelectedPaymentProviderApp(paymentProviderApps: List<PaymentProviderApp>) {
+        if (_selectedPaymentProviderAppFlow.value is SelectedPaymentProviderAppState.AppSelected) {
+            val selectedPaymentProviderApp =
+                (_selectedPaymentProviderAppFlow.value as SelectedPaymentProviderAppState.AppSelected).paymentProviderApp
+            paymentProviderApps.firstOrNull { it.hasSamePaymentProviderId(selectedPaymentProviderApp) }
+                ?.let {
+                    _selectedPaymentProviderAppFlow.value = SelectedPaymentProviderAppState.AppSelected(it)
+                }
         }
     }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -223,12 +223,11 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
 
         when (val selectedPaymentProviderAppState = _selectedPaymentProviderAppFlow.value) {
             is SelectedPaymentProviderAppState.AppSelected -> {
-                LOG.debug("Creating ReviewFragment with selected payment provider app: {}", selectedPaymentProviderAppState.paymentProviderApp.name)
+                LOG.debug("Creating ReviewFragment for selected payment provider app: {}", selectedPaymentProviderAppState.paymentProviderApp.name)
 
                 return ReviewFragment.newInstance(
                     giniHealth,
                     configuration = configuration,
-                    paymentProviderApp = selectedPaymentProviderAppState.paymentProviderApp,
                     paymentComponent = this@PaymentComponent
                 )
             }
@@ -241,16 +240,6 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
                 throw exception
             }
         }
-    }
-
-    /**
-     * Checks if a given payment provider is installed.
-     *
-     * @param paymentProviderAppId the app id of the payment provider
-     */
-    internal fun isPaymentProviderAppInstalled(paymentProviderAppId: String): Boolean {
-        if (_paymentProviderAppsFlow.value is PaymentProviderAppsState.Success) return (_paymentProviderAppsFlow.value as PaymentProviderAppsState.Success).paymentProviderApps.any { it.paymentProvider.id == paymentProviderAppId && it.installedPaymentProviderApp != null }
-        return false
     }
 
     private companion object {

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/installApp/InstallAppViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/installApp/InstallAppViewModel.kt
@@ -2,14 +2,45 @@ package net.gini.android.health.sdk.review.installApp
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import net.gini.android.health.sdk.paymentcomponent.PaymentComponent
+import net.gini.android.health.sdk.paymentcomponent.SelectedPaymentProviderAppState
 import net.gini.android.health.sdk.paymentprovider.PaymentProviderApp
+import net.gini.android.health.sdk.review.ReviewViewModel
 import org.slf4j.LoggerFactory
 
-internal class InstallAppViewModel(val paymentProviderApp: PaymentProviderApp?) : ViewModel() {
-    class Factory(private val paymentProviderApp: PaymentProviderApp?) : ViewModelProvider.Factory {
+internal class InstallAppViewModel(private val paymentComponent: PaymentComponent?) : ViewModel() {
+
+    private val _paymentProviderApp = MutableStateFlow<PaymentProviderApp?>(null)
+    val paymentProviderApp: StateFlow<PaymentProviderApp?> = _paymentProviderApp
+
+    init {
+        viewModelScope.launch {
+            paymentComponent?.selectedPaymentProviderAppFlow?.collect { selectedPaymentProviderAppState ->
+                when (selectedPaymentProviderAppState) {
+                    is SelectedPaymentProviderAppState.AppSelected -> {
+                        _paymentProviderApp.value = selectedPaymentProviderAppState.paymentProviderApp
+                    }
+
+                    SelectedPaymentProviderAppState.NothingSelected -> {
+                        LOG.error("No selected payment provider app")
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(InstallAppViewModel::class.java)
+    }
+
+    class Factory(private val paymentComponent: PaymentComponent?) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return InstallAppViewModel(paymentProviderApp) as T
+            return InstallAppViewModel(paymentComponent) as T
         }
     }
 }

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/ReviewFragmentTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/ReviewFragmentTest.kt
@@ -18,11 +18,13 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import net.gini.android.health.sdk.GiniHealth
 import net.gini.android.health.sdk.R
 import net.gini.android.health.sdk.paymentcomponent.PaymentComponent
+import net.gini.android.health.sdk.paymentcomponent.SelectedPaymentProviderAppState
 import net.gini.android.health.sdk.paymentprovider.PaymentProviderApp
 import org.junit.Before
 import org.junit.Test
@@ -75,11 +77,13 @@ class ReviewFragmentTest {
     fun `calls onNextClicked() listener when 'Next' ('Pay') button is clicked`() {
         // Given
         every { viewModel.isPaymentButtonEnabled } returns flowOf(true)
-        every { viewModel.getPaymentProviderApp() } returns mockk(relaxed = true)
-        every { viewModel.getPaymentProviderApp().isInstalled() } returns true
 
         val paymentComponent = mockk<PaymentComponent>(relaxed = true)
         every { paymentComponent.recheckWhichPaymentProviderAppsAreInstalled() } returns mockk(relaxed = true)
+
+        val paymentProviderApp: PaymentProviderApp = mockk(relaxed = true)
+        every { paymentProviderApp.isInstalled() } returns true
+        every { viewModel.paymentProviderApp } returns MutableStateFlow(paymentProviderApp)
 
         val listener = mockk<ReviewFragmentListener>(relaxed = true)
         launchFragmentInContainer(themeResId = R.style.GiniHealthTheme) {
@@ -87,7 +91,6 @@ class ReviewFragmentTest {
                 giniHealth = mockk(relaxed = true),
                 listener = listener,
                 viewModelFactory = viewModelFactory,
-                paymentProviderApp = mockk(),
                 paymentComponent = paymentComponent
             )
         }
@@ -112,13 +115,12 @@ class ReviewFragmentTest {
 
         val paymentComponent = mockk<PaymentComponent>()
         every { paymentComponent.recheckWhichPaymentProviderAppsAreInstalled() } returns Unit
-        every { paymentComponent.isPaymentProviderAppInstalled(any()) } returns true
 
         viewModel = mockk(relaxed = true)
         configureMockViewModel(viewModel)
         every { viewModel.paymentComponent } returns paymentComponent
-        every { viewModel.getPaymentProviderApp() } returns paymentProviderApp
         every { viewModel.isPaymentButtonEnabled } returns flowOf(true)
+        every { viewModel.paymentProviderApp } returns MutableStateFlow(paymentProviderApp)
 
         val listener = mockk<ReviewFragmentListener>(relaxed = true)
 
@@ -127,7 +129,6 @@ class ReviewFragmentTest {
                 giniHealth = mockk(relaxed = true),
                 listener = listener,
                 viewModelFactory = viewModelFactory,
-                paymentProviderApp = paymentProviderApp,
                 paymentComponent = paymentComponent
             )
         }
@@ -152,20 +153,21 @@ class ReviewFragmentTest {
 
         val paymentComponent = mockk<PaymentComponent>()
         every { paymentComponent.recheckWhichPaymentProviderAppsAreInstalled() } returns Unit
-        every { paymentComponent.isPaymentProviderAppInstalled(any()) } returns false
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(
+            SelectedPaymentProviderAppState.AppSelected(paymentProviderApp)
+        )
 
         viewModel = mockk(relaxed = true)
         configureMockViewModel(viewModel)
         every { viewModel.paymentComponent } returns paymentComponent
-        every { viewModel.getPaymentProviderApp() } returns paymentProviderApp
         every { viewModel.isPaymentButtonEnabled } returns flowOf(true)
+        every { viewModel.paymentProviderApp } returns MutableStateFlow(paymentProviderApp)
 
         val listener = mockk<ReviewFragmentListener>(relaxed = true)
         val fragment = ReviewFragment.newInstance(
             giniHealth = mockk(relaxed = true),
             listener = listener,
             viewModelFactory = viewModelFactory,
-            paymentProviderApp = paymentProviderApp,
             paymentComponent = paymentComponent
         )
 

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/ReviewViewModelTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/ReviewViewModelTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import net.gini.android.health.sdk.GiniHealth
 import net.gini.android.health.sdk.paymentcomponent.PaymentComponent
 import net.gini.android.health.sdk.paymentcomponent.PaymentProviderAppsState
+import net.gini.android.health.sdk.paymentcomponent.SelectedPaymentProviderAppState
 import net.gini.android.health.sdk.paymentprovider.PaymentProviderApp
 import net.gini.android.health.sdk.preferences.UserPreferences
 import net.gini.android.health.sdk.review.model.PaymentDetails
@@ -59,11 +60,9 @@ class ReviewViewModelTest {
     @Test
     fun `shows info bar on launch`() = runTest {
         val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-        every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-            listOf()
-        ))
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
         // Given
-        val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent).apply {
+        val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent).apply {
             userPreferences = this@ReviewViewModelTest.userPreferences!!
         }
 
@@ -77,12 +76,10 @@ class ReviewViewModelTest {
     @Test
     fun `hides info bar after a delay`() = runTest {
         val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-        every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-            listOf()
-        ))
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
         // Given
-        val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent).apply {
+        val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent).apply {
             userPreferences = this@ReviewViewModelTest.userPreferences!!
         }
 
@@ -111,11 +108,9 @@ class ReviewViewModelTest {
         )
 
         val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-        every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-            listOf()
-        ))
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-        val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+        val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
         val validationsAsync = async { viewModel.paymentValidation.take(1).toList() }
 
@@ -142,11 +137,9 @@ class ReviewViewModelTest {
         )
 
         val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-        every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-            listOf()
-        ))
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-        val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+        val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
         viewModel.paymentValidation.test {
             // Precondition
@@ -192,11 +185,9 @@ class ReviewViewModelTest {
             )
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-            val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             val validationsAsync = async { viewModel.paymentValidation.take(1).toList() }
 
@@ -226,11 +217,9 @@ class ReviewViewModelTest {
             )
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-            val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             viewModel.paymentValidation.test {
                 // Precondition
@@ -265,11 +254,9 @@ class ReviewViewModelTest {
             )
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-            val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             viewModel.paymentValidation.test {
                 // Precondition
@@ -304,11 +291,9 @@ class ReviewViewModelTest {
             )
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-            val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             viewModel.paymentValidation.test {
                 // When
@@ -341,11 +326,9 @@ class ReviewViewModelTest {
             )
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(mockk()))
 
-            val viewModel = ReviewViewModel(giniHealth!!, mockk(), mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             viewModel.paymentValidation.test {
                 // When
@@ -381,11 +364,10 @@ class ReviewViewModelTest {
             every { paymentProviderApp.installedPaymentProviderApp } returns mockk()
 
             val paymentComponent = mockk<PaymentComponent>(relaxed = true)
-            every { paymentComponent.paymentProviderAppsFlow } returns MutableStateFlow(PaymentProviderAppsState.Success(
-                listOf()
-            ))
+            every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(
+                SelectedPaymentProviderAppState.AppSelected(paymentProviderApp))
 
-            val viewModel = ReviewViewModel(giniHealth!!, paymentProviderApp, mockk(), paymentComponent)
+            val viewModel = ReviewViewModel(giniHealth!!, mockk(), paymentComponent)
 
             // Validate all fields to also get an invalid iban validation message
             viewModel.onPayment()

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/installApp/InstallAppBottomSheetTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/installApp/InstallAppBottomSheetTest.kt
@@ -10,9 +10,11 @@ import com.google.common.truth.Truth
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import net.gini.android.health.sdk.R
 import net.gini.android.health.sdk.paymentcomponent.PaymentComponent
+import net.gini.android.health.sdk.paymentcomponent.SelectedPaymentProviderAppState
 import net.gini.android.health.sdk.paymentprovider.PaymentProviderApp
 import org.junit.Before
 import org.junit.Test
@@ -37,12 +39,12 @@ class InstallAppBottomSheetTest {
     @Test
     fun `get it on play store button visible if bank app not installed`() = runTest {
         every { paymentProviderApp.isInstalled() } returns false
-        every { paymentComponent.isPaymentProviderAppInstalled(any()) } returns false
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(
+            SelectedPaymentProviderAppState.AppSelected(paymentProviderApp))
 
         // Given
         val bottomSheet = InstallAppBottomSheet.newInstance(
             paymentComponent,
-            paymentProviderApp,
             mockk()
         )
 
@@ -59,11 +61,10 @@ class InstallAppBottomSheetTest {
     fun `forward button visible if bank app not installed`() = runTest {
         // Given
         every { paymentProviderApp.isInstalled() } returns true
-        every { paymentComponent.isPaymentProviderAppInstalled(any()) } returns true
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(paymentProviderApp))
 
         val bottomSheet = InstallAppBottomSheet.newInstance(
             paymentComponent,
-            paymentProviderApp,
             mockk()
         )
 
@@ -80,14 +81,13 @@ class InstallAppBottomSheetTest {
     fun `redirect to bank called when tapping on forward button`() = runTest {
         // Given
         every { paymentProviderApp.isInstalled() } returns true
-        every { paymentComponent.isPaymentProviderAppInstalled(any()) } returns true
+        every { paymentComponent.selectedPaymentProviderAppFlow } returns MutableStateFlow(SelectedPaymentProviderAppState.AppSelected(paymentProviderApp))
 
         val listener: InstallAppForwardListener = mockk()
         every { listener.onForwardToBankSelected() } returns mockk()
 
         val bottomSheet = InstallAppBottomSheet.newInstance(
             paymentComponent,
-            paymentProviderApp,
             listener
         )
 


### PR DESCRIPTION
Refactors the data flow of the selected payment provider app by modifying:
- the PaymentComponent to update the selected app when rechecking the installed state
- the review fragment and the "install app bottom sheet" to use PaymentComponent's `selectedPaymentProviderAppFlow` as the source of truth for the payment provider app

This way the data flow is reactive: "recheck installed state" event is sent to PaymentComponent which then emits an updated selected payment provider app downstream to the review fragment and the "install app bottom sheet". These then update their UI and state accordingly.