### PR TITLE
Ipc 260 show only android specific payment providers on android

### DIFF
--- a/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
+++ b/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
@@ -1,6 +1,7 @@
 package net.gini.android.health.api
 
 import android.net.Uri
+import android.util.Log
 import android.util.Size
 import net.gini.android.core.api.DocumentRepository
 import net.gini.android.core.api.Resource
@@ -71,7 +72,7 @@ class HealthApiDocumentRepository(
         documentRemoteSource.getPages(accessToken, documentId)
             .toPageList(documentRemoteSource.baseUri)
 
-    // TODO remove mock payment provider when backend ready
+    // TODO remove mock payment provider when backend ready and move fitering before mapping
     suspend fun getPaymentProviders(): Resource<List<PaymentProvider>> {
         return withAccessToken { accessToken ->
             wrapInResource {
@@ -111,7 +112,7 @@ class HealthApiDocumentRepository(
 
                     add(0, PaymentProviderResponse(
                         id = "com.gini.android.fake.openWith",
-                        name = "Open With Tester Supported",
+                        name = "Open With Supported Tester",
                         gpcSupportedPlatforms = listOf(),
                         minAppVersion = AppVersionResponse(
                             android = "1.0.0"
@@ -129,7 +130,8 @@ class HealthApiDocumentRepository(
                     .map { paymentProviderResponse ->
                     val icon = documentRemoteSource.getFile(accessToken, paymentProviderResponse.iconLocation)
                     paymentProviderResponse.toPaymentProvider(icon)
-                }
+                    }
+                    .filter { it.gpcSupportedPlatforms.contains("android") || it.openWithSupportedPlatforms.contains("android") }
             }
         }
     }

--- a/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
+++ b/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
@@ -1,16 +1,11 @@
 package net.gini.android.health.api
 
-import android.net.Uri
-import android.util.Log
 import android.util.Size
 import net.gini.android.core.api.DocumentRepository
 import net.gini.android.core.api.Resource
 import net.gini.android.core.api.Resource.Companion.wrapInResource
 import net.gini.android.core.api.authorization.SessionManager
-import net.gini.android.core.api.authorization.apimodels.SessionToken
 import net.gini.android.core.api.models.CompoundExtraction
-import net.gini.android.core.api.models.Document
-import net.gini.android.core.api.models.Extraction
 import net.gini.android.core.api.models.ExtractionsContainer
 import net.gini.android.core.api.models.SpecificExtraction
 import net.gini.android.health.api.models.Page
@@ -22,11 +17,6 @@ import net.gini.android.health.api.models.toPaymentProvider
 import net.gini.android.health.api.response.AppVersionResponse
 import net.gini.android.health.api.response.Colors
 import net.gini.android.health.api.response.PaymentProviderResponse
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
 
 /**

--- a/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
+++ b/health-api-library/library/src/main/java/net/gini/android/health/api/HealthApiDocumentRepository.kt
@@ -76,7 +76,7 @@ class HealthApiDocumentRepository(
         return withAccessToken { accessToken ->
             wrapInResource {
                 documentRemoteSource.getPaymentProviders(accessToken).toMutableList().apply { add(0, PaymentProviderResponse(
-                    id = "com.gini.android.fake",
+                    id = "com.gini.android.fake.notSupported",
                     name = "Open With Tester",
                     gpcSupportedPlatforms = listOf(),
                     minAppVersion = AppVersionResponse(
@@ -88,12 +88,13 @@ class HealthApiDocumentRepository(
                     ),
                     iconLocation = "https://health-api.gini.net/paymentProviders/f7d06ee0-51fd-11ec-8216-97f0937beb16/icon",
                     playStoreUrl = "https://play.google.com/store/apps/details?id=net.gini.android.fake",
-                    packageNameAndroid = ""
+                    packageNameAndroid = "",
+                    openWithSupportedPlatforms = listOf()
                 ))
 
                     add(0, PaymentProviderResponse(
                         id = "com.gini.android.fake.supported",
-                        name = "Open With Tester Supported",
+                        name = "GPC Supported Tester",
                         gpcSupportedPlatforms = listOf("android"),
                         minAppVersion = AppVersionResponse(
                             android = "1.0.0"
@@ -104,7 +105,25 @@ class HealthApiDocumentRepository(
                         ),
                         iconLocation = "https://health-api.gini.net/paymentProviders/f7d06ee0-51fd-11ec-8216-97f0937beb16/icon",
                         playStoreUrl = "https://play.google.com/store/apps/details?id=net.gini.android.fake",
-                        packageNameAndroid = ""
+                        packageNameAndroid = "",
+                        openWithSupportedPlatforms = listOf("android")
+                    ))
+
+                    add(0, PaymentProviderResponse(
+                        id = "com.gini.android.fake.openWith",
+                        name = "Open With Tester Supported",
+                        gpcSupportedPlatforms = listOf(),
+                        minAppVersion = AppVersionResponse(
+                            android = "1.0.0"
+                        ),
+                        colors = Colors(
+                            background = "D9B965",
+                            text = "FFFFFF"
+                        ),
+                        iconLocation = "https://health-api.gini.net/paymentProviders/f7d06ee0-51fd-11ec-8216-97f0937beb16/icon",
+                        playStoreUrl = "https://play.google.com/store/apps/details?id=net.gini.android.fake",
+                        packageNameAndroid = "",
+                        openWithSupportedPlatforms = listOf("android")
                     ))
                 }
                     .map { paymentProviderResponse ->

--- a/health-api-library/library/src/main/java/net/gini/android/health/api/models/PaymentProvider.kt
+++ b/health-api-library/library/src/main/java/net/gini/android/health/api/models/PaymentProvider.kt
@@ -31,7 +31,11 @@ data class PaymentProvider(
     /**
      * If the payment provider supports Gini Pay Connect integration
      */
-    val gpcSupportedPlatforms: List<String>
+    val gpcSupportedPlatforms: List<String>,
+    /**
+     * If the payment provider supports PDF sharing
+     */
+    val openWithSupportedPlatforms: List<String>
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -83,4 +87,5 @@ internal fun PaymentProviderResponse.toPaymentProvider(icon: ByteArray) = Paymen
     icon = icon,
     playStoreUrl = playStoreUrl,
     gpcSupportedPlatforms = gpcSupportedPlatforms ?: listOf("android"),
+    openWithSupportedPlatforms = openWithSupportedPlatforms ?: listOf("android")
 )

--- a/health-api-library/library/src/main/java/net/gini/android/health/api/response/PaymentProviderResponse.kt
+++ b/health-api-library/library/src/main/java/net/gini/android/health/api/response/PaymentProviderResponse.kt
@@ -13,6 +13,7 @@ internal data class PaymentProviderResponse(
     @Json(name = "iconLocation") val iconLocation: String,
     @Json(name = "playStoreUrlAndroid") val playStoreUrl: String?,
     @Json(name = "gpcSupportedPlatforms") val gpcSupportedPlatforms: List<String>?,
+    @Json(name = "openWithSupportedPlatforms") val openWithSupportedPlatforms: List<String>?
 )
 
 @JsonClass(generateAdapter = true)

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -1,7 +1,6 @@
 package net.gini.android.health.sdk.paymentcomponent
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -90,6 +89,7 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
                     LOG.debug("Loading installed payment provider apps")
 
                     val paymentProviderApps = getPaymentProviderAppsSorted(paymentProvidersResource.data)
+
                     selectPaymentProviderApp(paymentProviderApps)
 
                     PaymentProviderAppsState.Success(paymentProviderApps)

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -88,7 +88,8 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
                     LOG.debug("Loaded payment providers")
                     LOG.debug("Loading installed payment provider apps")
 
-                    val paymentProviderApps = getPaymentProviderAppsSorted(paymentProvidersResource.data)
+                    val supportedPaymentProviderApps = paymentProvidersResource.data.filter { it.gpcSupportedPlatforms?.contains("android") == true || it.openWithSupportedPlatforms?.contains("android") == true }
+                    val paymentProviderApps = getPaymentProviderAppsSorted(supportedPaymentProviderApps)
 
                     selectPaymentProviderApp(paymentProviderApps)
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/paymentcomponent/PaymentComponent.kt
@@ -1,6 +1,7 @@
 package net.gini.android.health.sdk.paymentcomponent
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -88,9 +89,7 @@ class PaymentComponent(private val context: Context, private val giniHealth: Gin
                     LOG.debug("Loaded payment providers")
                     LOG.debug("Loading installed payment provider apps")
 
-                    val supportedPaymentProviderApps = paymentProvidersResource.data.filter { it.gpcSupportedPlatforms?.contains("android") == true || it.openWithSupportedPlatforms?.contains("android") == true }
-                    val paymentProviderApps = getPaymentProviderAppsSorted(supportedPaymentProviderApps)
-
+                    val paymentProviderApps = getPaymentProviderAppsSorted(paymentProvidersResource.data)
                     selectPaymentProviderApp(paymentProviderApps)
 
                     PaymentProviderAppsState.Success(paymentProviderApps)

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/bankselectionbottomsheet/BankSelectionBottomSheetTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/bankselectionbottomsheet/BankSelectionBottomSheetTest.kt
@@ -40,7 +40,8 @@ class BankSelectionBottomSheetTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf("android")
+            gpcSupportedPlatforms = listOf("android"),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 
@@ -55,7 +56,8 @@ class BankSelectionBottomSheetTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf("android")
+            gpcSupportedPlatforms = listOf("android"),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 
@@ -70,7 +72,8 @@ class BankSelectionBottomSheetTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf()
+            gpcSupportedPlatforms = listOf(),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/bankselectionbottomsheet/BankSelectionViewModelTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/bankselectionbottomsheet/BankSelectionViewModelTest.kt
@@ -58,7 +58,8 @@ class BankSelectionViewModelTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf("android")
+            gpcSupportedPlatforms = listOf("android"),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 
@@ -73,7 +74,8 @@ class BankSelectionViewModelTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf("android")
+            gpcSupportedPlatforms = listOf("android"),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 
@@ -88,7 +90,8 @@ class BankSelectionViewModelTest {
             appVersion = "appVersion",
             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
             icon = ByteArray(0),
-            gpcSupportedPlatforms = listOf("android")
+            gpcSupportedPlatforms = listOf("android"),
+            openWithSupportedPlatforms = listOf("android")
         )
     )
 

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/moreinformation/MoreInformationTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/moreinformation/MoreInformationTest.kt
@@ -51,6 +51,7 @@ class MoreInformationTest {
                             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
                             icon = ByteArray(0),
                             gpcSupportedPlatforms = listOf("android"),
+                            openWithSupportedPlatforms = listOf("android")
                         )
                     ),
                     PaymentProviderApp(
@@ -65,6 +66,7 @@ class MoreInformationTest {
                             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
                             icon = ByteArray(0),
                             gpcSupportedPlatforms = listOf("android"),
+                            openWithSupportedPlatforms = listOf("android")
                         )
                     ),
                     PaymentProviderApp(
@@ -78,7 +80,8 @@ class MoreInformationTest {
                             appVersion = "appVersion",
                             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
                             icon = ByteArray(0),
-                            gpcSupportedPlatforms = listOf("android")
+                            gpcSupportedPlatforms = listOf("android"),
+                            openWithSupportedPlatforms = listOf("android")
                         )
                     )
                 )

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/moreinformation/MoreInformationViewModelTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/moreinformation/MoreInformationViewModelTest.kt
@@ -58,7 +58,8 @@ class MoreInformationViewModelTest {
                             appVersion = "appVersion",
                             colors = PaymentProvider.Colors(backgroundColorRGBHex = "", textColoRGBHex = ""),
                             icon = ByteArray(0),
-                            gpcSupportedPlatforms = listOf("android")
+                            gpcSupportedPlatforms = listOf("android"),
+                            openWithSupportedPlatforms = listOf("android")
                         )
                     )
                 )

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/paymentComponent/PaymentComponentTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/paymentComponent/PaymentComponentTest.kt
@@ -62,7 +62,8 @@ class PaymentComponentTest {
         ),
         icon = byteArrayOf(),
         playStoreUrl = "",
-        gpcSupportedPlatforms = listOf("android")
+        gpcSupportedPlatforms = listOf("android"),
+        openWithSupportedPlatforms = listOf("android")
         )
 
     private val paymentProvider1 = PaymentProvider(
@@ -76,7 +77,8 @@ class PaymentComponentTest {
         ),
         icon = byteArrayOf(),
         playStoreUrl = "",
-        gpcSupportedPlatforms = listOf("android")
+        gpcSupportedPlatforms = listOf("android"),
+        openWithSupportedPlatforms = listOf("android")
         )
 
     private val paymentProvider2 = PaymentProvider(
@@ -90,7 +92,8 @@ class PaymentComponentTest {
         ),
         icon = byteArrayOf(),
         playStoreUrl = "",
-        gpcSupportedPlatforms = listOf("android")
+        gpcSupportedPlatforms = listOf("android"),
+        openWithSupportedPlatforms = listOf("android")
     )
 
     private val noPlayStoreUrlPaymentProvider = PaymentProvider(
@@ -103,7 +106,8 @@ class PaymentComponentTest {
             textColoRGBHex = "ffffff"
         ),
         icon = byteArrayOf(),
-        gpcSupportedPlatforms = listOf("android")
+        gpcSupportedPlatforms = listOf("android"),
+        openWithSupportedPlatforms = listOf("android")
     )
 
     @Before

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/paymentprovider/PaymentProviderAppTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/paymentprovider/PaymentProviderAppTest.kt
@@ -70,7 +70,8 @@ val paymentProvidersFixture = installedPaymentProviderAppsFixture.map { installe
             textColoRGBHex = "ffffff"
         ),
         icon = byteArrayOf(),
-        gpcSupportedPlatforms = listOf("android")
+        gpcSupportedPlatforms = listOf("android"),
+        openWithSupportedPlatforms = listOf("android")
     )
 }
 


### PR DESCRIPTION
Add support for `openWithSupportedPlatform` and filter `paymentProviders` based on it and `gpcSupported`.