### PR TITLE
feat(health-sdk): Fixed error not showing in 'share with' scenario

### DIFF
--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -143,9 +144,12 @@ class GiniHealth(
         }
     }
 
-    internal fun setOpenBankState(state: PaymentState) {
+    internal fun setOpenBankState(state: PaymentState, scope: CoroutineScope) {
         _openBankState.value = state
-        _openBankState.value = PaymentState.NoAction
+        scope.launch {
+            delay(50)
+            _openBankState.value = PaymentState.NoAction
+        }
     }
 
     internal suspend fun retryDocumentReview() {

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -127,6 +127,7 @@ class ReviewFragment private constructor(
     private var binding: GhsFragmentReviewBinding by autoCleared()
     private var documentPageAdapter: DocumentPageAdapter by autoCleared()
     private var isKeyboardShown = false
+    private var errorSnackbar: Snackbar? = null
 
     override fun onGetLayoutInflater(savedInstanceState: Bundle?): LayoutInflater {
         val inflater = super.onGetLayoutInflater(savedInstanceState)
@@ -374,12 +375,15 @@ class ReviewFragment private constructor(
 
     private fun GhsFragmentReviewBinding.showSnackbar(text: String, onRetry: () -> Unit) {
         val context = requireContext().wrappedWithGiniHealthTheme()
-        Snackbar.make(context, root, text, Snackbar.LENGTH_INDEFINITE).apply {
+        errorSnackbar?.dismiss()
+        errorSnackbar = Snackbar.make(context, root, text, Snackbar.LENGTH_INDEFINITE).apply {
             if (context.getFontScale() < 1.5) {
                 anchorView = paymentDetailsScrollview
             }
             setTextMaxLines(2)
-            setAction(getString(R.string.ghs_snackbar_retry)) { onRetry() }
+            setAction(getString(R.string.ghs_snackbar_retry)) {
+                onRetry()
+            }
             show()
         }
     }
@@ -538,6 +542,7 @@ class ReviewFragment private constructor(
     }
 
     private fun showInstallAppDialog(paymentProviderApp: PaymentProviderApp) {
+        errorSnackbar?.dismiss()
         val dialog = InstallAppBottomSheet.newInstance(viewModel.paymentComponent, object : InstallAppForwardListener {
             override fun onForwardToBankSelected() {
                 redirectToBankApp(paymentProviderApp)
@@ -552,6 +557,7 @@ class ReviewFragment private constructor(
     }
 
     private fun showOpenWithDialog(paymentProviderApp: PaymentProviderApp) {
+        errorSnackbar?.dismiss()
         OpenWithBottomSheet.newInstance(paymentProviderApp, object: OpenWithForwardListener {
             override fun onForwardSelected() {
                 viewModel.onForwardToSharePdfTapped(requireContext().externalCacheDir)
@@ -563,6 +569,7 @@ class ReviewFragment private constructor(
     }
 
     private fun startSharePdfIntent(paymentRequestFile: File) {
+        errorSnackbar?.dismiss()
         val uriForFile = FileProvider.getUriForFile(
             requireContext(),
             requireContext().packageName+".health.sdk.fileprovider",
@@ -579,7 +586,7 @@ class ReviewFragment private constructor(
     private fun handlePaymentNextStep(paymentNextStep: ReviewViewModel.PaymentNextStep) {
         when (paymentNextStep) {
             is ReviewViewModel.PaymentNextStep.SetLoadingVisibility -> {
-                binding.loading.isVisible = paymentNextStep.isVisible
+                errorSnackbar?.dismiss()
             }
             ReviewViewModel.PaymentNextStep.RedirectToBank -> {
                 viewModel.paymentProviderApp.value?.name?.let {

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -336,12 +336,7 @@ class ReviewFragment private constructor(
 
     private fun GhsFragmentReviewBinding.handlePaymentState(paymentState: GiniHealth.PaymentState) {
         (paymentState is GiniHealth.PaymentState.Loading).let { isLoading ->
-            paymentProgress.isVisible = isLoading
-            recipientLayout.isEnabled = !isLoading
-            ibanLayout.isEnabled = !isLoading
-            amountLayout.isEnabled = !isLoading
-            purposeLayout.isEnabled = !isLoading
-            payment.text = if (isLoading) "" else getString(R.string.ghs_pay_button)
+            handleLoading(isLoading)
         }
         when (paymentState) {
             is GiniHealth.PaymentState.Success -> {
@@ -367,7 +362,17 @@ class ReviewFragment private constructor(
         }
     }
 
+    private fun GhsFragmentReviewBinding.handleLoading(isLoading: Boolean) {
+        paymentProgress.isVisible = isLoading
+        recipientLayout.isEnabled = !isLoading
+        ibanLayout.isEnabled = !isLoading
+        amountLayout.isEnabled = !isLoading
+        purposeLayout.isEnabled = !isLoading
+        payment.text = if (isLoading) "" else getString(R.string.ghs_pay_button)
+    }
+
     private fun GhsFragmentReviewBinding.handleError(text: String, onRetry: () -> Unit) {
+        handleLoading(false)
         if (viewModel.configuration.handleErrorsInternally) {
             showSnackbar(text, onRetry)
         }
@@ -586,6 +591,7 @@ class ReviewFragment private constructor(
     private fun handlePaymentNextStep(paymentNextStep: ReviewViewModel.PaymentNextStep) {
         when (paymentNextStep) {
             is ReviewViewModel.PaymentNextStep.SetLoadingVisibility -> {
+                binding.handleLoading(paymentNextStep.isVisible)
                 errorSnackbar?.dismiss()
             }
             ReviewViewModel.PaymentNextStep.RedirectToBank -> {


### PR DESCRIPTION
IPC-279

I opted not to change `StateFlow` to `SharedFlow` as I found that adding an imperceptible delay when emitting 2 consecutive events fixed the issue. It's a smaller change in my opinion, with less impact on the codebase. I'm open to discussions if switching to `SharedFlow` is the preferred route.

Please note: when tapping on `Retry`, the snackbar flickers when being dismissed. It **might** be related to [this](https://github.com/material-components/material-components-android/issues/648) bug that has apparently been fixed. I say **might** because we're not using `animateLayoutChanges` anywhere. 

It's happening on `main` branch as well, and in all cases when the snackbar is shown - I haven't figured out a solution...