### PR TITLE
ci: Log-in to Maven Central with user token

### DIFF
--- a/.github/workflows/bank-api-library.release.yml
+++ b/.github/workflows/bank-api-library.release.yml
@@ -39,8 +39,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "bank-api-library",
               "module_id": "library",
               "build_number": "${{ github.run_number }}",

--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -40,8 +40,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "bank-sdk",
               "module_id": "sdk",
               "build_number": "${{ github.run_number }}",

--- a/.github/workflows/capture-sdk.release.yml
+++ b/.github/workflows/capture-sdk.release.yml
@@ -43,8 +43,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "capture-sdk",
               "module_id": "${{ matrix.module-id }}",
               "build_number": "${{ github.run_number }}",

--- a/.github/workflows/core-api-library.release.yml
+++ b/.github/workflows/core-api-library.release.yml
@@ -37,8 +37,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "core-api-library",
               "module_id": "library",
               "build_number": "${{ github.run_number }}",

--- a/.github/workflows/health-api-library.release.yml
+++ b/.github/workflows/health-api-library.release.yml
@@ -39,8 +39,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "health-api-library",
               "module_id": "library",
               "build_number": "${{ github.run_number }}",

--- a/.github/workflows/health-sdk.release.yml
+++ b/.github/workflows/health-sdk.release.yml
@@ -40,8 +40,8 @@ jobs:
           options: >
             {
               "repo_url": "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
-              "repo_user": "alpar.gini",
-              "repo_password": "${{ secrets.MAVEN_CENTRAL_PASSWORD }}",
+              "repo_user": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_USERNAME }}",
+              "repo_password": "${{ secrets.MAVEN_CENTRAL_USER_TOKEN_PASSWORD }}",
               "project_id": "health-sdk",
               "module_id": "sdk",
               "build_number": "${{ github.run_number }}",


### PR DESCRIPTION
Since beginning of June 2024 a user token is required for publishing to Maven Central: https://central.sonatype.org/publish/generate-token/

I have already added the user token to the GitHub Action [secrets](https://github.com/gini/gini-mobile-android/settings/secrets/actions).

This is an email from Sonatype informing me about the user token:
![Screenshot 2024-06-24 at 19 14 57](https://github.com/gini/gini-mobile-android/assets/13149498/f4019c47-90de-4cf9-9dfc-576793507018)
