### PR TITLE
fix(health-sdk): Fix `Share With` flow broken when clients pop backst…

### DIFF
--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesActivity.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesActivity.kt
@@ -104,6 +104,7 @@ open class InvoicesActivity : AppCompatActivity() {
                         when (paymentState) {
                             is GiniHealth.PaymentState.Success -> {
                                 viewModel.updateDocument()
+                                supportFragmentManager.popBackStack()
                             }
                             else -> {}
                         }

--- a/health-sdk/sdk/src/main/AndroidManifest.xml
+++ b/health-sdk/sdk/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+        <receiver android:name=".review.ReviewFragment$ShareWithBroadcastReceiver" android:exported="false"/>
     </application>
 
     <queries>

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
@@ -7,10 +7,12 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import net.gini.android.core.api.Resource
 import net.gini.android.core.api.models.Document
@@ -147,8 +149,10 @@ class GiniHealth(
     internal fun setOpenBankState(state: PaymentState, scope: CoroutineScope) {
         _openBankState.value = state
         scope.launch {
-            delay(50)
-            _openBankState.value = PaymentState.NoAction
+            withContext(NonCancellable) {
+                delay(50)
+                _openBankState.value = PaymentState.NoAction
+            }
         }
     }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -626,7 +626,7 @@ class ReviewFragment private constructor(
     private fun createSharePendingIntent() =  PendingIntent.getBroadcast(
         requireContext(), CHOOSER_REQUEST_ID,
         Intent(requireContext(), ShareWithBroadcastReceiver::class.java),
-        PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_IMMUTABLE
     )
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
…ack after getting payment request callback

- Added a broadcast receiver to intercept taps on the system share sheet
- Move sending of `OpenBankState.Success` to after user picks an external app to share to
- Drawback is that the `OpenBankState.Success` event is not emitted if the user dismisses the share sheet - but then I guess it's not of interest to the client to know that the `paymentRequest` was created, but not finalised

IPC-290