### PR TITLE
refactor(health-sdk): Use `async` in example app to parallelize test invoice uploads and refresh requests

### DIFF
--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/data/InvoicesRepository.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/data/InvoicesRepository.kt
@@ -1,8 +1,12 @@
 package net.gini.android.health.sdk.exampleapp.invoices.data
 
 import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 import net.gini.android.core.api.MediaTypes
 import net.gini.android.core.api.Resource
 import net.gini.android.core.api.models.Document
@@ -11,12 +15,14 @@ import net.gini.android.health.api.GiniHealthAPI
 import net.gini.android.health.sdk.GiniHealth
 import net.gini.android.health.sdk.exampleapp.invoices.data.model.DocumentWithExtractions
 import java.util.Date
+import kotlin.coroutines.CoroutineContext
 
 class InvoicesRepository(
     private val giniHealthAPI: GiniHealthAPI,
     val giniHealth: GiniHealth,
     private val hardcodedInvoicesLocalDataSource: HardcodedInvoicesLocalDataSource,
-    private val invoicesLocalDataSource: InvoicesLocalDataSource
+    private val invoicesLocalDataSource: InvoicesLocalDataSource,
+    val coroutineContext: CoroutineContext = Dispatchers.IO
 ) {
 
     private val _uploadHardcodedInvoicesStateFlow: MutableStateFlow<UploadHardcodedInvoicesState> = MutableStateFlow(
@@ -30,30 +36,32 @@ class InvoicesRepository(
         invoicesLocalDataSource.loadInvoicesWithExtractions()
     }
 
-    suspend fun uploadHardcodedInvoices() {
+    suspend fun uploadHardcodedInvoices() = withContext(coroutineContext) {
         _uploadHardcodedInvoicesStateFlow.value = UploadHardcodedInvoicesState.Loading
 
         val documentsWithExtractions = mutableListOf<DocumentWithExtractions>()
 
         val hardcodedInvoices = hardcodedInvoicesLocalDataSource.getHardcodedInvoices()
         val createdResources = hardcodedInvoices.map { invoiceBytes ->
-            giniHealthAPI.documentManager.createPartialDocument(
-                invoiceBytes,
-                MediaTypes.IMAGE_JPEG
-            ).mapSuccess { partialDocumentResource ->
-                giniHealthAPI.documentManager.createCompositeDocument(listOf(partialDocumentResource.data))
-            }.mapSuccess { compositeDocumentResource ->
-                val documentWithExtractions = getDocumentWithExtraction(compositeDocumentResource.data)
-                documentWithExtractions.first?.let { doc ->
-                    documentsWithExtractions.add(doc)
+            async {
+                giniHealthAPI.documentManager.createPartialDocument(
+                    invoiceBytes,
+                    MediaTypes.IMAGE_JPEG
+                ).mapSuccess { partialDocumentResource ->
+                    giniHealthAPI.documentManager.createCompositeDocument(listOf(partialDocumentResource.data))
+                }.mapSuccess { compositeDocumentResource ->
+                    val documentWithExtractions = getDocumentWithExtraction(compositeDocumentResource.data)
+                    documentWithExtractions.first?.let { doc ->
+                        documentsWithExtractions.add(doc)
+                    }
+                    documentWithExtractions.second
                 }
-                documentWithExtractions.second
             }
         }
 
         invoicesLocalDataSource.appendInvoicesWithExtractions(documentsWithExtractions)
 
-        val errors = createdResources.mapNotNull { resource ->
+        val errors = createdResources.awaitAll().mapNotNull { resource ->
             if (resource is Resource.Error) {
                 resource.message
             } else {
@@ -70,22 +78,26 @@ class InvoicesRepository(
         _uploadHardcodedInvoicesStateFlow.value = UploadHardcodedInvoicesState.Idle
     }
 
-    suspend fun refreshInvoices() {
+    suspend fun refreshInvoices() = withContext(coroutineContext) {
         _uploadHardcodedInvoicesStateFlow.value = UploadHardcodedInvoicesState.Loading
         val documentsWithExtractions = mutableListOf<DocumentWithExtractions>()
-        invoicesFlow.value.forEach { document ->
-            val emptyDocument = createEmptyDocument(document.documentId)
-            giniHealthAPI.documentManager.getAllExtractions(createEmptyDocument(documentId = document.documentId)).mapSuccess {
-                val isPayable = giniHealth.checkIfDocumentIsPayable(emptyDocument.id)
-                val documentWithExtractions = DocumentWithExtractions.fromDocumentAndExtractions(
-                    emptyDocument,
-                    it.data,
-                    isPayable
-                )
-                documentsWithExtractions.add(documentWithExtractions)
-                it
+        val jobs = invoicesFlow.value.map { document ->
+            async {
+                val emptyDocument = createEmptyDocument(document.documentId)
+                giniHealthAPI.documentManager.getAllExtractions(createEmptyDocument(documentId = document.documentId))
+                    .mapSuccess {
+                        val isPayable = giniHealth.checkIfDocumentIsPayable(emptyDocument.id)
+                        val documentWithExtractions = DocumentWithExtractions.fromDocumentAndExtractions(
+                            emptyDocument,
+                            it.data,
+                            isPayable
+                        )
+                        documentsWithExtractions.add(documentWithExtractions)
+                        it
+                    }
             }
         }
+        jobs.awaitAll()
         invoicesLocalDataSource.refreshInvoices(documentsWithExtractions)
         _uploadHardcodedInvoicesStateFlow.value = UploadHardcodedInvoicesState.Success
     }


### PR DESCRIPTION
I applied a learning from a coroutines talk to use `map { async {} }` to make test invoice uploads and refreshes faster.