### PR TITLE
fix(capture-sdk): Fix Handler delayed call

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/FileImportHelpFragment.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/help/FileImportHelpFragment.kt
@@ -90,7 +90,10 @@ class FileImportHelpFragment : Fragment() {
     }
 
     private fun waitForHalfSecondAndShowSnackBar() {
-        Handler(Looper.getMainLooper()).postDelayed({ this.showCustomSnackBar() }, 500)
+        Handler(Looper.getMainLooper()).postDelayed(
+            { if (isVisible) this.showCustomSnackBar() },
+            500
+        )
     }
 
     private fun showCustomSnackBar() {


### PR DESCRIPTION
   We need to check if fragment visible, if not we don't need to show snackBar, it cause a crash
PM-91