### PR TITLE
fix(capture-sdk): Fix a crash with navigation.

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -1277,7 +1277,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             mFragment.getParentFragmentManager().setFragmentResult(REQUEST_KEY, resultBundle);
             mFragment.findNavController().popBackStack();
         } else {
-            mFragment.findNavController().navigate(CameraFragmentDirections.toReviewFragment(shouldScrollToLastPage));
+            mFragment.safeNavigate(CameraFragmentDirections.toReviewFragment(shouldScrollToLastPage));
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/FragmentImplCallback.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/ui/FragmentImplCallback.java
@@ -1,6 +1,5 @@
 package net.gini.android.capture.internal.ui;
 
-import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.view.View;
@@ -13,6 +12,10 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.navigation.NavController;
+import androidx.navigation.NavDirections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Internal use only.
@@ -54,4 +57,13 @@ public interface FragmentImplCallback {
     @NonNull
     NavController findNavController();
 
+    @NonNull
+    default void safeNavigate(@NonNull final NavDirections navDirections) {
+        try {
+            findNavController().navigate(navDirections);
+        } catch (Exception exception) {
+            Logger logger = LoggerFactory.getLogger(FragmentImplCallback.class);
+            logger.error("Navigation exception " + exception.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
If we close fragment before photo recognition finished, it cause a crash. This happens because we try to navigate from wrong location. That's why I have added safeNavigation function PP-496