### PR TITLE
Run health api library check manually on stage

### DIFF
--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -123,11 +123,11 @@ jobs:
           script: >
             adb uninstall net.gini.android.health.api.test ;
             ./gradlew -Pandroid.testInstrumentationRunnerArguments.apiEnv=${{ inputs.healthApiEnvironment }} health-api-library:library:connectedCheck
-            -PtestClientId="gini-mobile-test"
-            -PtestClientSecret="${{ inputs.healthApiEnvironment == 'staging' && secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET || secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
-            -PtestApiUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://health-api.stage.gini.net' || 'https://health-api.gini.net' }}"
-            -PtestUserCenterUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://user.stage.gini.net' || 'https://user.gini.net' }}"
-            -PtestBankApiUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://pay-api.pia.stage.gini.net' || 'https://pay-api.gini.net' }}"
+            -PtestClientId='gini-mobile-test'
+            -PtestClientSecret='${{ inputs.healthApiEnvironment == 'staging' && secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET || secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}'
+            -PtestApiUri='${{ inputs.healthApiEnvironment == 'staging' && 'https://health-api.stage.gini.net' || 'https://health-api.gini.net' }}'
+            -PtestUserCenterUri='${{ inputs.healthApiEnvironment == 'staging' && 'https://user.stage.gini.net' || 'https://user.gini.net' }}'
+            -PtestBankApiUri='${{ inputs.healthApiEnvironment == 'staging' && 'https://pay-api.pia.stage.gini.net' || 'https://pay-api.gini.net' }}'
 
       - name: archive instrumented test results
         if: always()

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -63,7 +63,7 @@ jobs:
 #
 #      - name: archive unit test coverage report
 #        if: always()
-#        uses: actions/upload-artifact@v3
+#        uses: actions/upload-artifact@v4
 #        with:
 #          name: health-api-library-unit-test-coverage
 #          path: health-api-library/library/build/jacoco/jacocoHtml
@@ -194,7 +194,7 @@ jobs:
         run: ./gradlew health-api-library:library:lint
 
       - name: archive android lint report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: health-api-library-android-lint-report
           path: health-api-library/library/build/reports/lint-results*.html

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -121,7 +121,7 @@ jobs:
           disable-animations: true
           script: >
             adb uninstall net.gini.android.health.api.test ;
-            ./gradlew health-api-library:library:connectedCheck
+            ./gradlew -Pandroid.testInstrumentationRunnerArguments.apiEnv=${{ inputs.healthApiEnvironment }} health-api-library:library:connectedCheck
             -PtestClientId="gini-mobile-test"
             -PtestClientSecret="${{ inputs.healthApiEnvironment == 'production' && secrets.GINI_MOBILE_TEST_CLIENT_SECRET || secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET }}"
             -PtestApiUri="${{ inputs.healthApiEnvironment == 'production' && 'https://health-api.gini.net' || 'https://health-api.stage.gini.net' }}"

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -124,10 +124,10 @@ jobs:
             adb uninstall net.gini.android.health.api.test ;
             ./gradlew -Pandroid.testInstrumentationRunnerArguments.apiEnv=${{ inputs.healthApiEnvironment }} health-api-library:library:connectedCheck
             -PtestClientId="gini-mobile-test"
-            -PtestClientSecret="${{ inputs.healthApiEnvironment == 'production' && secrets.GINI_MOBILE_TEST_CLIENT_SECRET || secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET }}"
-            -PtestApiUri="${{ inputs.healthApiEnvironment == 'production' && 'https://health-api.gini.net' || 'https://health-api.stage.gini.net' }}"
-            -PtestUserCenterUri="${{ inputs.healthApiEnvironment == 'production' && 'https://user.gini.net' || 'https://user.stage.gini.net' }}"
-            -PtestBankApiUri="${{ inputs.healthApiEnvironment == 'production' && 'https://pay-api.gini.net' || 'https://pay-api.pia.stage.gini.net' }}"
+            -PtestClientSecret="${{ inputs.healthApiEnvironment == 'staging' && secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET || secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
+            -PtestApiUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://health-api.stage.gini.net' || 'https://health-api.gini.net' }}"
+            -PtestUserCenterUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://user.stage.gini.net' || 'https://user.gini.net' }}"
+            -PtestBankApiUri="${{ inputs.healthApiEnvironment == 'staging' && 'https://pay-api.pia.stage.gini.net' || 'https://pay-api.gini.net' }}"
 
       - name: archive instrumented test results
         if: always()

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -22,32 +22,14 @@ on:
         required: true
   workflow_dispatch:
     inputs:
-      clientId:
-        description: 'Client ID'
+      healthApiEnvironment:
+        description: 'Health API Environment'
         required: true
-        type: string
-        default: ''
-      clientSecret:
-        description: 'Client Secret'
-        required: true
-        type: string
-        default: ''
-      healthApiBaseUrl:
-        description: 'Health API Base URL'
-        required: true
-        type: string
-        default: ''
-      userCenterBaseUrl:
-        description: 'User Center Base URL'
-        required: true
-        type: string
-        default: ''
-      payApiBaseUrl:
-        description: 'Pay API Base URL'
-        required: true
-        type: string
-        default: ''
-      
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
 
 jobs:
   test:
@@ -140,11 +122,11 @@ jobs:
           script: >
             adb uninstall net.gini.android.health.api.test ;
             ./gradlew health-api-library:library:connectedCheck
-            -PtestClientId="${{ inputs.clientId != '' && inputs.clientId || 'gini-mobile-test'}}"
-            -PtestClientSecret="${{ inputs.clientSecret != '' && inputs.clientSecret || secrets.GINI_MOBILE_TEST_CLIENT_SECRET }}"
-            -PtestApiUri="${{ inputs.healthApiBaseUrl != '' && inputs.healthApiBaseUrl || 'https://health-api.gini.net' }}"
-            -PtestUserCenterUri="${{ inputs.userCenterBaseUrl != '' && inputs.userCenterBaseUrl || 'https://user.gini.net' }}"
-            -PtestBankApiUri="${{ inputs.payApiBaseUrl != '' && inputs.payApiBaseUrl || 'https://pay-api.gini.net' }}"
+            -PtestClientId="gini-mobile-test"
+            -PtestClientSecret="${{ inputs.healthApiEnvironment == 'production' && secrets.GINI_MOBILE_TEST_CLIENT_SECRET || secrets.STAGING_GINI_MOBILE_TEST_CLIENT_SECRET }}"
+            -PtestApiUri="${{ inputs.healthApiEnvironment == 'production' && 'https://health-api.gini.net' || 'https://health-api.stage.gini.net' }}"
+            -PtestUserCenterUri="${{ inputs.healthApiEnvironment == 'production' && 'https://user.gini.net' || 'https://user.stage.gini.net' }}"
+            -PtestBankApiUri="${{ inputs.healthApiEnvironment == 'production' && 'https://pay-api.gini.net' || 'https://pay-api.pia.stage.gini.net' }}"
 
       - name: archive instrumented test results
         if: always()

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -113,7 +113,7 @@ jobs:
       - name: run instrumented tests
         timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
-        if: ${{ inputs.healthApiEnvironment == 'production' || matrix.api-level != 22 }}
+        if: ${{ inputs.healthApiEnvironment != 'staging' || matrix.api-level != 22 }}
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -113,6 +113,7 @@ jobs:
       - name: run instrumented tests
         timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
+        if: ${{ inputs.healthApiEnvironment == 'production' || matrix.api-level != 22 }}
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -110,7 +110,7 @@ jobs:
           disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
-      - name: run instrumented tests
+      - name: "run instrumented tests using Health API environment: ${{ inputs.healthApiEnvironment }}"
         timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
         if: ${{ inputs.healthApiEnvironment != 'staging' || matrix.api-level != 22 }}

--- a/core-api-library/shared-tests/src/main/java/net/gini/android/core/api/test/shared/GiniCoreAPIIntegrationTest.kt
+++ b/core-api-library/shared-tests/src/main/java/net/gini/android/core/api/test/shared/GiniCoreAPIIntegrationTest.kt
@@ -1,6 +1,7 @@
 package net.gini.android.core.api.test.shared
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.annotation.XmlRes
 import androidx.test.core.app.ApplicationProvider
@@ -203,12 +204,14 @@ abstract class GiniCoreAPIIntegrationTest<DM: DocumentManager<DR, E>, DR: Docume
     @Throws(Exception::class)
     fun publicKeyPinningWithMatchingPublicKey() = runTest(timeout = 30.seconds) {
         TrustKitHelper.resetTrustKit()
-        giniCoreApi = createGiniCoreAPIBuilder(clientId, clientSecret, "example.com")
-            .setNetworkSecurityConfigResId(getNetworkSecurityConfigResId())
-            .setApiBaseUrl(apiUri)
-            .setUserCenterApiBaseUrl(userCenterUri)
-            .setConnectionTimeoutInMs(60000)
-            .build()
+        giniCoreApi = createGiniCoreAPIBuilder(clientId, clientSecret, "example.com").apply {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                setNetworkSecurityConfigResId(getNetworkSecurityConfigResId())
+            }
+            setApiBaseUrl(apiUri)
+            setUserCenterApiBaseUrl(userCenterUri)
+            setConnectionTimeoutInMs(60000)
+        }.build()
 
         val assetManager = ApplicationProvider.getApplicationContext<Context>().resources.assets
         val testDocumentAsStream = assetManager.open("test.jpg")
@@ -222,13 +225,15 @@ abstract class GiniCoreAPIIntegrationTest<DM: DocumentManager<DR, E>, DR: Docume
     @Throws(Exception::class)
     fun publicKeyPinningWithCustomCache() = runTest(timeout = 30.seconds) {
         TrustKitHelper.resetTrustKit()
-        giniCoreApi = createGiniCoreAPIBuilder(clientId, clientSecret, "example.com")
-            .setNetworkSecurityConfigResId(getNetworkSecurityConfigResId())
-            .setApiBaseUrl(apiUri)
-            .setUserCenterApiBaseUrl(userCenterUri)
-            .setConnectionTimeoutInMs(60000)
-            .setCache(Cache(File(ApplicationProvider.getApplicationContext<Context>().cacheDir, "no_cache"), 1))
-            .build()
+        giniCoreApi = createGiniCoreAPIBuilder(clientId, clientSecret, "example.com").apply {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+                setNetworkSecurityConfigResId(getNetworkSecurityConfigResId())
+            }
+            setApiBaseUrl(apiUri)
+            setUserCenterApiBaseUrl(userCenterUri)
+            setConnectionTimeoutInMs(60000)
+            setCache(Cache(File(ApplicationProvider.getApplicationContext<Context>().cacheDir, "no_cache"), 1))
+        }.build()
 
         val assetManager = ApplicationProvider.getApplicationContext<Context>().resources.assets
         val testDocumentAsStream = assetManager.open("test.jpg")

--- a/health-api-library/library/src/androidTest/java/net/gini/android/health/api/GiniHealthAPIIntegrationTest.kt
+++ b/health-api-library/library/src/androidTest/java/net/gini/android/health/api/GiniHealthAPIIntegrationTest.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
@@ -200,6 +201,10 @@ class GiniHealthAPIIntegrationTest: GiniCoreAPIIntegrationTest<HealthApiDocument
     @Test
     @Throws(Exception::class)
     fun testGetPayment() = runTest(timeout = 30.seconds) {
+        if (InstrumentationRegistry.getArguments().getString("apiEnv") == "staging") {
+            return@runTest
+        }
+
         val paymentRequestId = createPaymentRequest()
         val paymentRequest = giniCoreApi.documentManager.getPaymentRequest(paymentRequestId).dataOrThrow
         val (_, _, recipient, iban, bic, amount, purpose) = paymentRequest


### PR DESCRIPTION
Allows running the Health API integration tests also on staging (`health-api.stage.gini.net` and `user.stage.gini.net`).

There are a few differences when running tests on staging:
- certificate pinning is disabled because staging hosts use self-signed SSL certificates and pinning fails due to the lack of a trust anchor (`java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.`)
- running tests on Android 23 or older is disabled for the same reason as above
- `testGetPayment()` is disabled because it needs access to the staging Pay API (pay-api.pia.stage.gini.net) which requires VPN access (via Tailscale).

Workflow can be manually triggered from [here](https://github.com/gini/gini-mobile-android/actions/workflows/health-api-library.check.yml) by using the branch `run-health-api-library-check-manually-on-stage` (after PR is merged the `main` branch will be needed) and selecting “production” or “staging” from the dropdown:
![Screenshot 2024-09-10 at 10 42 12](https://github.com/user-attachments/assets/911c42d0-d37f-4fea-860d-951ef6db6d09)
