### PR TITLE
fix(capture-sdk): Remove button in description

### DIFF
--- a/capture-sdk/sdk/src/main/res/values-en/strings.xml
+++ b/capture-sdk/sdk/src/main/res/values-en/strings.xml
@@ -11,7 +11,7 @@
     <string name="gc_title_no_results">No results</string>
     <string name="gc_title_error">Error</string>
     <string name="gc_help">Help</string>
-    <string name="gc_menu_item_help_button_content_description">Help, button</string>
+    <string name="gc_menu_item_help_button_content_description">Help</string>
     <string name="gc_menu_item_close_button_content_description">Close, button</string>
     <string name="gc_camera_error_no_permission">We need access to your camera to enable you to capture your invoices</string>
     <string name="gc_camera_error_no_permission_button_title">Give Access</string>

--- a/capture-sdk/sdk/src/main/res/values/strings.xml
+++ b/capture-sdk/sdk/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="gc_delete_page">Seite löschen</string>
     <string name="gc_document_page">Dokumentenseite</string>
     <string name="gc_useful_tips">Nützliche Tipps</string>
-    <string name="gc_menu_item_help_button_content_description">Hilfe, Schaltfläche</string>
+    <string name="gc_menu_item_help_button_content_description">Hilfe</string>
     <string name="gc_menu_item_close_button_content_description">Schließen, Schaltfläche</string>
     <string name="gc_iban_detected_please_take_picture">\n\nMachen Sie ein Foto</string>
     <string name="gc_iban_detected">IBAN erkannt</string>


### PR DESCRIPTION
Left only name of the button, without "button" word, because talkback pronounce button twice PP-220