### PR TITLE
Fix failing test cases

### DIFF
--- a/bank-sdk/example-app/src/androidTest/java/net/gini/android/bank/sdk/exampleapp/ui/testcases/DigitalInvoiceEditButtonTests.kt
+++ b/bank-sdk/example-app/src/androidTest/java/net/gini/android/bank/sdk/exampleapp/ui/testcases/DigitalInvoiceEditButtonTests.kt
@@ -48,7 +48,6 @@ class DigitalInvoiceEditButtonTests {
     private fun clickPhotoPaymentAndUploadFile() {
         mainScreen.clickPhotoPaymentButton()
         onboardingScreen.clickSkipButton()
-        Thread.sleep(6000)
         captureScreen.clickFilesButton()
         captureScreen.clickFiles()
         pdfUploader.uploadPdfFromFiles("Testrechnung-RA-1.pdf")
@@ -296,7 +295,7 @@ class DigitalInvoiceEditButtonTests {
     @Test
     fun test9_verifyInlineErrorWhenNameFieldIsEmpty() {
         clickPhotoPaymentAndUploadFile()
-
+        idlingResource.waitForIdle()
         val isOnboardingScreenTextVisible =
             digitalInvoiceScreen.checkDigitalInvoiceTextOnOnboardingScreenIsDisplayed()
         assertEquals(true, isOnboardingScreenTextVisible)

--- a/bank-sdk/example-app/src/androidTest/java/net/gini/android/bank/sdk/exampleapp/ui/testcases/ErrorScreenTests.kt
+++ b/bank-sdk/example-app/src/androidTest/java/net/gini/android/bank/sdk/exampleapp/ui/testcases/ErrorScreenTests.kt
@@ -62,7 +62,7 @@ class ErrorScreenTests {
     fun test2_verifyNetworkErrorScreen() {
         errorScreen.disconnectTheInternetConnection()
         clickPhotoPaymentButtonAndSkipOnboarding()
-
+        idlingResource.waitForIdle()
         val errorTextVisible = errorScreen.checkErrorTextDisplayed()
         assertEquals(true, errorTextVisible)
         val errorHeaderVisible = errorScreen.checkErrorHeaderTextDisplayed( "There was a problem connecting to the internet")


### PR DESCRIPTION
Fix failing for the assertions of following test-cases:

- DigitalInvoiceEditButtonTests > test9_verifyInlineErrorWhenNameFieldIsEmpty 
- ErrorScreenTests > test2_verifyNetworkErrorScreen

