### PR TITLE
Ipc 556 reload payment providers if gini health sdk was instantiated without credentials or session manager

### DIFF
--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -24,8 +24,12 @@ After that you can create an instance of ``GiniHealth``:
 
 .. note::
 
-    ``GiniHealth`` exposes a method for loading payment providers manually: ``giniHealth.loadPaymentProviders()``. It can be used if there was an error
-when loading the payment providers, as a manual retry mechanism. 
+    ``GiniHealth`` exposes a method for loading payment providers manually: ``giniHealth.loadPaymentProviders()``.
+
+    Although ``GiniHealth`` loads the payment providers when it is instantiated, this method can be used if there was an error when loading the payment providers, as a manual retry mechanism. If ``GiniHealth`` does not have internet access when instantiated, or if it was instantiated
+    with a session manager without credentials, this method should be called when the SDK gains internet access (or session manager receives credentials).
+
+    The ``trustMarkersFlow`` depends on the loaded payment providers, so please make sure you call this method manually if your SDK instantiation is similar to the cases described above.
 
 
 Upload documents

--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -22,6 +22,12 @@ After that you can create an instance of ``GiniHealth``:
 
     val giniHealth = GiniHealth(giniHealthApi)
 
+.. note::
+
+    ``GiniHealth`` exposes a method for loading payment providers manually: ``giniHealth.loadPaymentProviders()``. It can be used if there was an error
+when loading the payment providers, as a manual retry mechanism. 
+
+
 Upload documents
 ----------------
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/GiniHealth.kt
@@ -357,6 +357,11 @@ class GiniHealth(
         return paymentFragment
     }
 
+    /**
+     * Manually load payment provider apps, in case there was an error when trying to load them automatically.
+     */
+    suspend fun loadPaymentProviders() = giniInternalPaymentModule.paymentComponent.loadPaymentProviderApps()
+
     private val savedStateProvider = SavedStateRegistry.SavedStateProvider {
         Bundle().apply {
             when (capturedArguments) {

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
@@ -3,7 +3,6 @@ package net.gini.android.health.sdk.integratedFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -55,15 +54,6 @@ internal class PaymentFlowViewModel(
     private var externalCacheDir: File? = null
 
     init {
-        viewModelScope.launch {
-            paymentComponent.paymentProviderAppsFlow.collect {
-                if (it is PaymentProviderAppsState.Error) {
-                    giniInternalPaymentModule.emitSdkEvent(GiniInternalPaymentModule.InternalPaymentEvents.OnErrorOccurred(it.throwable))
-                    delay(50)
-                    giniInternalPaymentModule.emitSdkEvent(GiniInternalPaymentModule.InternalPaymentEvents.OnCancelled)
-                }
-            }
-        }
         viewModelScope.launch {
             giniInternalPaymentModule.eventsFlow.collect { event ->
                 handleInternalEvents(event)


### PR DESCRIPTION
- Made `loadPaymentProviders` a public method again. Although when starting the payment fragment a call to this method is made, perhaps it will be safer to allow the developer to manually trigger this if any error occurs, or somehow their flow is different. Also useful because the `trustMarkers` flow depends on this call, and the trust markers may be needed before entering the payment flow.
- Removed exiting the payment flow if status of loading payment providers is `Error` or `Canceled`.
- Updated docs to mention `loadPaymentProviders` is a public method, and some context for when it should be manually triggered.

The `PaymentFragment` makes a call to `loadPaymentProviders` when it is started, so I think this will fix IBM's issue without them having to call the method manually.

@zladzeyka , I added you as well so double check if the updated info in the docs makes sense 🤔