### PR TITLE
PP-1480: Integration of Capture SDK

### DIFF
--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/CaptureSdkStandAloneActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/CaptureSdkStandAloneActivity.kt
@@ -4,39 +4,83 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
 import dagger.hilt.android.AndroidEntryPoint
-import net.gini.android.bank.sdk.di.BankSdkIsolatedKoinContext
 import net.gini.android.bank.sdk.exampleapp.R
 import net.gini.android.bank.sdk.exampleapp.core.ExampleUtil.isIntentActionViewOrSend
 import net.gini.android.bank.sdk.exampleapp.ui.util.CaptureResultListener
+import net.gini.android.capture.Document
+import net.gini.android.capture.GiniCaptureFragment
+import net.gini.android.capture.GiniCaptureFragmentListener
 
 @AndroidEntryPoint
 class CaptureSdkStandAloneActivity : AppCompatActivity() {
 
+    private var listener: CaptureResultListener? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
-        BankSdkIsolatedKoinContext.init(this)
+        listener = CaptureResultListener(this)
+        supportFragmentManager.fragmentFactory =
+            ClientCaptureSDKFragmentFactory(listener!!, null)
         super.onCreate(savedInstanceState)
-        // same view is required for both Bank SDK and Capture SDK, no need to create a separate xml
-        setContentView(R.layout.activity_capture_flow_host)
+        setContentView(R.layout.activity_stand_alone_capture_flow)
         if (savedInstanceState == null) {
             if (intent != null && isIntentActionViewOrSend(intent)) {
                 ClientCaptureSDKFragment().startCaptureSDKForIntent(
                     this,
                     intent,
-                    CaptureResultListener(this)
+                    listener!!
                 )
-
             } else {
-                // start simple capture SDK
-                val giniCaptureFragment = ClientCaptureSDKFragment()
-                this.supportFragmentManager.beginTransaction()
-                    .replace(R.id.fragment_host, giniCaptureFragment, "fragment_host")
-                    .addToBackStack(null).commit()
+                val clientCaptureSDK = ClientCaptureSDKFragment()
+                supportFragmentManager.beginTransaction()
+                    .replace(
+                        R.id.fragment_host,
+                        clientCaptureSDK,
+                        ClientCaptureSDKFragment::class.java.name
+                    )
+                    .addToBackStack(null)
+                    .commit()
+                clientCaptureSDK.setListener(listener = listener!!)
             }
+        } else {
+            restoreFragmentListener()
         }
     }
 
     companion object {
         fun newIntent(context: Context) = Intent(context, CaptureSdkStandAloneActivity::class.java)
+    }
+
+    private fun restoreFragmentListener() {
+        val fragment =
+            supportFragmentManager.findFragmentByTag(ClientCaptureSDKFragment::class.java.name) as ClientCaptureSDKFragment?
+        fragment?.setListener(listener!!)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        listener = null
+    }
+}
+
+class ClientCaptureSDKFragmentFactory(
+    private val giniCaptureFragmentListener: GiniCaptureFragmentListener,
+    private var openWithDocument: Document? = null
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return when (className) {
+            GiniCaptureFragment::class.java.name -> GiniCaptureFragment.createInstance(
+                openWithDocument
+            ) { openWithDocument = null }
+                .apply {
+                    setListener(
+                        giniCaptureFragmentListener
+                    )
+                }
+
+            else -> super.instantiate(classLoader, className)
+        }
     }
 }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
@@ -46,7 +46,8 @@ class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener
                 context.startActivity(
                     ExtractionsActivity.getStartIntent(
                         context,
-                        result.specificExtractions
+                        result.specificExtractions,
+                        true
                     )
                 )
                 context.finish()

--- a/bank-sdk/example-app/src/main/res/layout/activity_stand_alone_capture_flow.xml
+++ b/bank-sdk/example-app/src/main/res/layout/activity_stand_alone_capture_flow.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/GiniCaptureTheme"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_host"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureFragment.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureFragment.kt
@@ -49,7 +49,7 @@ class GiniCaptureFragment(
     CancelListener {
 
     private lateinit var navController: NavController
-    private lateinit var giniCaptureFragmentListener: GiniCaptureFragmentListener
+    private var giniCaptureFragmentListener: GiniCaptureFragmentListener? = null
     private lateinit var oncePerInstallEventStore: OncePerInstallEventStore
 
     /**
@@ -207,8 +207,9 @@ class GiniCaptureFragment(
     override fun onDestroy() {
         super.onDestroy()
         if (!didFinishWithResult && !willBeRestored) {
-            giniCaptureFragmentListener.onFinishedWithResult(CaptureSDKResult.Cancel)
+            giniCaptureFragmentListener?.onFinishedWithResult(CaptureSDKResult.Cancel)
         }
+        giniCaptureFragmentListener = null
         if (willBeRestored) {
             UserAnalytics.flushEvents()
         }
@@ -242,12 +243,12 @@ class GiniCaptureFragment(
         document: Document,
         callback: CameraFragmentListener.DocumentCheckResultCallback
     ) {
-        giniCaptureFragmentListener.onCheckImportedDocument(document, callback)
+        giniCaptureFragmentListener?.onCheckImportedDocument(document, callback)
     }
 
     override fun onError(error: GiniCaptureError) {
         didFinishWithResult = true
-        giniCaptureFragmentListener.onFinishedWithResult(CaptureSDKResult.Error(error))
+        giniCaptureFragmentListener?.onFinishedWithResult(CaptureSDKResult.Error(error))
     }
 
     override fun onExtractionsAvailable(
@@ -257,7 +258,7 @@ class GiniCaptureFragment(
     ) {
         didFinishWithResult = true
         lastExtractionsProvider.update(extractions)
-        giniCaptureFragmentListener.onFinishedWithResult(
+        giniCaptureFragmentListener?.onFinishedWithResult(
             CaptureSDKResult.Success(
                 extractions,
                 compoundExtractions,
@@ -280,7 +281,7 @@ class GiniCaptureFragment(
     override fun onExtractionsAvailable(extractions: MutableMap<String, GiniCaptureSpecificExtraction>) {
         didFinishWithResult = true
         lastExtractionsProvider.update(extractions)
-        giniCaptureFragmentListener.onFinishedWithResult(
+        giniCaptureFragmentListener?.onFinishedWithResult(
             CaptureSDKResult.Success(
                 extractions,
                 emptyMap(),
@@ -291,7 +292,7 @@ class GiniCaptureFragment(
 
     override fun onEnterManuallyPressed() {
         didFinishWithResult = true
-        giniCaptureFragmentListener.onFinishedWithResult(CaptureSDKResult.EnterManually)
+        giniCaptureFragmentListener?.onFinishedWithResult(CaptureSDKResult.EnterManually)
     }
 
     override fun onCancelFlow() {
@@ -300,7 +301,7 @@ class GiniCaptureFragment(
 
     private fun finishWithCancel() {
         didFinishWithResult = true
-        giniCaptureFragmentListener.onFinishedWithResult(CaptureSDKResult.Cancel)
+        giniCaptureFragmentListener?.onFinishedWithResult(CaptureSDKResult.Cancel)
     }
 
     private fun setAnalyticsEntryPointProperty(isOpenWithDocumentExists: Boolean) {


### PR DESCRIPTION
### Description

Here is the [Jira Ticket Link](https://ginis.atlassian.net/browse/PP-1480)

### Notes for reviewer

Fixes crash in the example app, when GiniCapture SDK is started.

**Reason detected:** 
Android system was not able to create GiniCaptureFragment because this class have parameterized constructor, So fragment factory is provided in the example app, which Android system will use to construct the fragment in case of orientation change.

Also, changed the `lateinit giniCaptureFragmentListener` property of `GiniCaptureFragment` to nullable, so it can be marked as null when the `onDestroy` is called, and it can be collected by GC.
Because we are setting the listener again in the event of orientation change through `ClientCaptureSDKFragmentFactory`, so we will keep getting the updates.

Thank you.