### PR TITLE
refactor(bank-sdk): Remove resloveViewModel function from AndroidFrag…

### DIFF
--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/di/koin/AndroidFragmentExt.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/di/koin/AndroidFragmentExt.kt
@@ -3,40 +3,42 @@ package net.gini.android.bank.sdk.di.koin
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import net.gini.android.bank.sdk.di.getGiniBankKoin
-import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.qualifier.Qualifier
-import org.koin.viewmodel.resolveViewModel
 
 @MainThread
 inline fun <reified T : ViewModel> Fragment.giniBankViewModel(
     qualifier: Qualifier? = null,
     noinline ownerProducer: () -> ViewModelStoreOwner = { this },
-    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline parameters: (() -> ParametersHolder)? = null,
 ): Lazy<T> {
     return lazy(LazyThreadSafetyMode.NONE) {
-        getGiniBankViewModel(qualifier, ownerProducer, extrasProducer, parameters)
+        getGiniBankViewModel(qualifier, ownerProducer, parameters)
     }
 }
 
-@OptIn(KoinInternalApi::class)
 @MainThread
 inline fun <reified T : ViewModel> Fragment.getGiniBankViewModel(
     qualifier: Qualifier? = null,
     noinline ownerProducer: () -> ViewModelStoreOwner = { this },
-    noinline extrasProducer: (() -> CreationExtras)? = null,
     noinline parameters: (() -> ParametersHolder)? = null,
 ): T {
-    return resolveViewModel(
-        T::class,
-        ownerProducer().viewModelStore,
-        extras = extrasProducer?.invoke() ?: this.defaultViewModelCreationExtras,
-        qualifier = qualifier,
-        parameters = parameters,
-        scope = getGiniBankKoin().scopeRegistry.rootScope
-    )
+    val owner = ownerProducer()
+
+    val factory = object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            return getGiniBankKoin().get<T>(
+                clazz = modelClass.kotlin,
+                qualifier = qualifier,
+                parameters = parameters
+            )
+        }
+    }
+
+    return ViewModelProvider(owner, factory)[T::class.java]
 }


### PR DESCRIPTION
This is a request by Atruvia. We were using a Koin API, which required us to use @OptIn(KoinInternalApi::class)
 which is not recommended to do, especially when developing an SDK. I resolved the issue by using a Factory method to provide the ViewModel for dependency injection.  


Ticket: https://ginis.atlassian.net/browse/PP-1725