### PR TITLE
Pp 2078 provide color keys per element

### DIFF
--- a/bank-sdk/example-app/src/main/res/values/colors.xml
+++ b/bank-sdk/example-app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <color name="gc_camera_title_color">#006ECF</color>
+    <color name="skonto_section_title_text_color">#006ECF</color>
 
     <color name="gc_color_01">@color/gc_light_01</color>
     <color name="gc_color_02">@color/gc_light_02</color>

--- a/bank-sdk/example-app/src/main/res/values/colors.xml
+++ b/bank-sdk/example-app/src/main/res/values/colors.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <color name="gc_camera_title_color">#006ECF</color>
+
     <color name="gc_color_01">@color/gc_light_01</color>
     <color name="gc_color_02">@color/gc_light_02</color>
     <color name="gc_color_03">@color/gc_light_03</color>

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/skonto/colors/section/SkontoSectionColors.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/skonto/colors/section/SkontoSectionColors.kt
@@ -24,7 +24,7 @@ data class SkontoSectionColors(
 
         @Composable
         fun colors(
-            titleTextColor: Color = GiniTheme.colorScheme.text.primary,
+            titleTextColor: Color = GiniTheme.colorScheme.skontoSection.skontoSectionTitleTextColor,
             switchColors: GiniSwitchColors = GiniSwitchColors.colors(),
             cardBackgroundColor: Color = GiniTheme.colorScheme.card.container,
             enabledHintTextColor: Color = GiniTheme.colorScheme.text.success,

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/GiniTheme.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/GiniTheme.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import net.gini.android.capture.ui.theme.colors.GiniColorElementsPrimitives
 import net.gini.android.capture.ui.theme.colors.GiniColorPrimitives
 import net.gini.android.capture.ui.theme.colors.GiniColorScheme
 import net.gini.android.capture.ui.theme.colors.giniDarkColorScheme
@@ -31,11 +32,13 @@ fun GiniTheme(
     val context = LocalContext.current
     val giniPrimitives =
         remember { GiniColorPrimitives.buildColorPrimitivesBasedOnResources(context) }
+    val giniElementPrimitives =
+        remember { GiniColorElementsPrimitives.buildColorPrimitivesBasedOnResources(context) }
 
     val colors = if (darkMode) {
-        giniDarkColorScheme(giniPrimitives)
+        giniDarkColorScheme(giniPrimitives, giniElementPrimitives)
     } else {
-        giniLightColorScheme(giniPrimitives)
+        giniLightColorScheme(giniPrimitives, giniElementPrimitives)
     }
 
     val typography = extractGiniTypography()

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/colors/GiniColorElementsPrimitives.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/colors/GiniColorElementsPrimitives.kt
@@ -1,0 +1,21 @@
+package net.gini.android.capture.ui.theme.colors
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import net.gini.android.capture.R
+
+data class GiniColorElementsPrimitives(
+    val skontoSectionTitleTextColor: Color = Color(0xFF161616),
+
+) {
+    companion object {
+        /**
+         * Bridge between old way of defining colors by overridden resources and Compose
+         *
+         * This function will define color primitives based on resources value at res/colors.xml
+         */
+        internal fun buildColorPrimitivesBasedOnResources(context: Context) = GiniColorElementsPrimitives(
+            skontoSectionTitleTextColor = Color(context.getColor(R.color.skonto_section_title_text_color)),
+        )
+    }
+}

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/colors/GiniColorPalette.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ui/theme/colors/GiniColorPalette.kt
@@ -30,6 +30,8 @@ data class GiniColorScheme(
     val checkbox: Checkbox = Checkbox(),
     val contextMenu: ContextMenu = ContextMenu(),
     val logo: Logo = Logo(),
+    val skontoSection: SkontoSection = SkontoSection()
+
 ) {
 
     @Immutable
@@ -234,6 +236,10 @@ data class GiniColorScheme(
             val contentOutlined: Color = Color.Unspecified,
         )
     }
+    @Immutable
+    data class SkontoSection(
+        val skontoSectionTitleTextColor: Color = Color.Unspecified,
+    )
 
     @Immutable
     data class Logo(
@@ -245,7 +251,8 @@ data class GiniColorScheme(
  * Created a light color scheme based on primitives.
  */
 internal fun giniLightColorScheme(
-    giniColorPrimitives: GiniColorPrimitives = GiniColorPrimitives()
+    giniColorPrimitives: GiniColorPrimitives = GiniColorPrimitives(),
+    giniColorElementsPrimitives: GiniColorElementsPrimitives = GiniColorElementsPrimitives()
 ) = with(giniColorPrimitives) {
     GiniColorScheme(
         background = GiniColorScheme.Background(primary = light02),
@@ -373,6 +380,9 @@ internal fun giniLightColorScheme(
         ),
         logo = GiniColorScheme.Logo(
             tint = accent01
+        ),
+        skontoSection = GiniColorScheme.SkontoSection(
+            skontoSectionTitleTextColor = giniColorElementsPrimitives.skontoSectionTitleTextColor
         )
     )
 }
@@ -381,7 +391,8 @@ internal fun giniLightColorScheme(
  * Created a dark color scheme based on primitives.
  */
 internal fun giniDarkColorScheme(
-    giniColorPrimitives: GiniColorPrimitives = GiniColorPrimitives()
+    giniColorPrimitives: GiniColorPrimitives = GiniColorPrimitives(),
+    giniColorElementsPrimitives: GiniColorElementsPrimitives = GiniColorElementsPrimitives()
 ) = with(giniColorPrimitives) {
     GiniColorScheme(
         background = GiniColorScheme.Background(primary = dark01),
@@ -513,6 +524,9 @@ internal fun giniDarkColorScheme(
         ),
         logo = GiniColorScheme.Logo(
             tint = accent01
+        ),
+        skontoSection = GiniColorScheme.SkontoSection(
+            skontoSectionTitleTextColor = giniColorElementsPrimitives.skontoSectionTitleTextColor
         )
     )
 }

--- a/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
+++ b/capture-sdk/sdk/src/main/res/layout/gc_fragment_camera.xml
@@ -76,7 +76,7 @@
             android:layout_marginBottom="@dimen/gc_large"
             android:paddingTop="@dimen/gc_large"
             android:text="@string/gc_camera_info_label_invoice_and_qr"
-            android:textColor="@color/gc_light_01"
+            android:textColor="@color/gc_camera_title_color"
             app:layout_constraintBottom_toTopOf="@id/gc_button_camera_trigger"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/capture-sdk/sdk/src/main/res/values/element_colors.xml
+++ b/capture-sdk/sdk/src/main/res/values/element_colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <color name="gc_camera_title_color">@color/gc_light_01</color>
+
+</resources>

--- a/capture-sdk/sdk/src/main/res/values/element_colors.xml
+++ b/capture-sdk/sdk/src/main/res/values/element_colors.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <color name="gc_camera_title_color">@color/gc_light_01</color>
+    <color name="skonto_section_title_text_color">@color/gc_dark_02</color>
 
 </resources>


### PR DESCRIPTION
Atruvia supports 25–30 color themes for their banking customers. They currently manually override colors for multiple UI components. They requested more (ideally all) components be color-customizable to speed up publishing the photo payment module.


This is my proposal for providing color keys per element. 

Transition to Element-Specific Color Keys (XML)
In commit c0e5abe12, the project moved away from using generic color primitives directly in layouts. Previously, UI elements like the camera title in gc_fragment_camera.xml were hardcoded to use general colors like @color/gc_light_01.
The update introduced element_colors.xml, which defines semantic color keys such as gc_camera_title_color. This allows developers to theme specific UI elements without affecting others that might share the same base color. For example, changing the camera title color no longer requires changing the global gc_light_01 value, providing much better flexibility for white-labeling and customization.

Integration with Jetpack Compose
In commit 76943d8e9, this semantic approach was extended to the Compose-based elements. A new class, GiniColorElementsPrimitives, was introduced to act as a bridge. It reads these new semantic XML color keys and maps them into the Compose GiniColorScheme.
Key technical changes include:
• GiniColorElementsPrimitives: A new data class that holds element-specific colors (e.g., skontoSectionTitleTextColor) and initializes them from Android resources.
• Theme Expansion: The GiniColorScheme and GiniTheme were updated to include a SkontoSection color group. This ensures that even the most specific UI components (like the Skonto section titles) are now part of the unified theme state.
• Dynamic Updating: The giniLightColorScheme and giniDarkColorScheme functions now accept these element primitives, ensuring that both light and dark modes respect the new specific color overrides.

How the clients can use:

For clients who are used to the old color mapping: no changes will happen. They can still override our color palette and customize our SDK.

For clients who need more detailed and customizable SDK, they need to override the elements that they need. This still uses our color palette and if clients don’t override some colors, we’ll use the colors from our color palette.