### PR TITLE
Pp 2362 rc bank sdk 4.1.0

### DIFF
--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -4,42 +4,42 @@ Automatically created by the updateReleaseOrderFile task.
 Release order for :capture-sdk:sdk 4.0.1:
  1. :capture-sdk:sdk 4.0.1
 
-Release order for :core-api-library:library 3.0.0:
- 1. :core-api-library:library 3.0.0
+Release order for :core-api-library:library 3.1.0:
+ 1. :core-api-library:library 3.1.0
 
 Release order for :bank-api-library:library 4.0.0:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.0.0
 
 Release order for :health-api-library:library 5.4.0:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :health-api-library:library 5.4.0
 
 Release order for :internal-payment-sdk:sdk 1.5.1:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :health-api-library:library 5.4.0
  3. :internal-payment-sdk:sdk 1.5.1
 
 Release order for :health-sdk:sdk 5.5.1:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :health-api-library:library 5.4.0
  3. :internal-payment-sdk:sdk 1.5.1
  4. :health-sdk:sdk 5.5.1
 
 Release order for :capture-sdk:default-network 4.0.1:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.0.0
  3. :capture-sdk:sdk 4.0.1
  4. :capture-sdk:default-network 4.0.1
 
 Release order for :merchant-sdk:sdk 1.0.0:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :health-api-library:library 5.4.0
  3. :internal-payment-sdk:sdk 1.5.1
  4. :merchant-sdk:sdk 1.0.0
 
 Release order for :bank-sdk:sdk 4.0.1:
- 1. :core-api-library:library 3.0.0
+ 1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.0.0
  3. :capture-sdk:sdk 4.0.1
  4. :capture-sdk:default-network 4.0.1

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -7,9 +7,9 @@ Release order for :capture-sdk:sdk 4.0.1:
 Release order for :core-api-library:library 3.1.0:
  1. :core-api-library:library 3.1.0
 
-Release order for :bank-api-library:library 4.0.0:
+Release order for :bank-api-library:library 4.1.0:
  1. :core-api-library:library 3.1.0
- 2. :bank-api-library:library 4.0.0
+ 2. :bank-api-library:library 4.1.0
 
 Release order for :health-api-library:library 5.4.0:
  1. :core-api-library:library 3.1.0
@@ -28,7 +28,7 @@ Release order for :health-sdk:sdk 5.5.1:
 
 Release order for :capture-sdk:default-network 4.0.1:
  1. :core-api-library:library 3.1.0
- 2. :bank-api-library:library 4.0.0
+ 2. :bank-api-library:library 4.1.0
  3. :capture-sdk:sdk 4.0.1
  4. :capture-sdk:default-network 4.0.1
 
@@ -40,7 +40,7 @@ Release order for :merchant-sdk:sdk 1.0.0:
 
 Release order for :bank-sdk:sdk 4.0.1:
  1. :core-api-library:library 3.1.0
- 2. :bank-api-library:library 4.0.0
+ 2. :bank-api-library:library 4.1.0
  3. :capture-sdk:sdk 4.0.1
  4. :capture-sdk:default-network 4.0.1
  5. :bank-sdk:sdk 4.0.1

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -1,8 +1,8 @@
 DO NOT EDIT MANUALLY!
 Automatically created by the updateReleaseOrderFile task.
 
-Release order for :capture-sdk:sdk 4.0.1:
- 1. :capture-sdk:sdk 4.0.1
+Release order for :capture-sdk:sdk 4.1.0:
+ 1. :capture-sdk:sdk 4.1.0
 
 Release order for :core-api-library:library 3.1.0:
  1. :core-api-library:library 3.1.0
@@ -29,7 +29,7 @@ Release order for :health-sdk:sdk 5.5.1:
 Release order for :capture-sdk:default-network 4.0.1:
  1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.1.0
- 3. :capture-sdk:sdk 4.0.1
+ 3. :capture-sdk:sdk 4.1.0
  4. :capture-sdk:default-network 4.0.1
 
 Release order for :merchant-sdk:sdk 1.0.0:
@@ -41,7 +41,7 @@ Release order for :merchant-sdk:sdk 1.0.0:
 Release order for :bank-sdk:sdk 4.0.1:
  1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.1.0
- 3. :capture-sdk:sdk 4.0.1
+ 3. :capture-sdk:sdk 4.1.0
  4. :capture-sdk:default-network 4.0.1
  5. :bank-sdk:sdk 4.0.1
 

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -26,11 +26,11 @@ Release order for :health-sdk:sdk 5.5.1:
  3. :internal-payment-sdk:sdk 1.5.1
  4. :health-sdk:sdk 5.5.1
 
-Release order for :capture-sdk:default-network 4.0.1:
+Release order for :capture-sdk:default-network 4.1.0:
  1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.1.0
  3. :capture-sdk:sdk 4.1.0
- 4. :capture-sdk:default-network 4.0.1
+ 4. :capture-sdk:default-network 4.1.0
 
 Release order for :merchant-sdk:sdk 1.0.0:
  1. :core-api-library:library 3.1.0
@@ -42,6 +42,6 @@ Release order for :bank-sdk:sdk 4.0.1:
  1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.1.0
  3. :capture-sdk:sdk 4.1.0
- 4. :capture-sdk:default-network 4.0.1
+ 4. :capture-sdk:default-network 4.1.0
  5. :bank-sdk:sdk 4.0.1
 

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -38,10 +38,10 @@ Release order for :merchant-sdk:sdk 1.0.0:
  3. :internal-payment-sdk:sdk 1.5.1
  4. :merchant-sdk:sdk 1.0.0
 
-Release order for :bank-sdk:sdk 4.0.1:
+Release order for :bank-sdk:sdk 4.1.0:
  1. :core-api-library:library 3.1.0
  2. :bank-api-library:library 4.1.0
  3. :capture-sdk:sdk 4.1.0
  4. :capture-sdk:default-network 4.1.0
- 5. :bank-sdk:sdk 4.0.1
+ 5. :bank-sdk:sdk 4.1.0
 

--- a/bank-api-library/library/gradle.properties
+++ b/bank-api-library/library/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-bank-api-lib
-version=4.0.0
+version=4.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 

--- a/bank-api-library/library/src/doc/source/guides/getting-started.rst
+++ b/bank-api-library/library/src/doc/source/guides/getting-started.rst
@@ -13,7 +13,7 @@ build.gradle:
 .. code-block:: groovy
 
     dependencies {
-        implementation 'net.gini.android:gini-bank-api-lib:4.0.0'
+        implementation 'net.gini.android:gini-bank-api-lib:4.1.0'
     }
 
 Integrating the Gini Bank API Library

--- a/bank-sdk/sdk/gradle.properties
+++ b/bank-sdk/sdk/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-bank-sdk
-version=4.0.1
+version=4.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 

--- a/capture-sdk/default-network/gradle.properties
+++ b/capture-sdk/default-network/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-capture-sdk-default-network
-version=4.0.1
+version=4.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 

--- a/capture-sdk/sdk/gradle.properties
+++ b/capture-sdk/sdk/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-capture-sdk
-version=4.0.1
+version=4.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 

--- a/core-api-library/library/gradle.properties
+++ b/core-api-library/library/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-internal-core-api-lib
-version=3.0.0
+version=3.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 


### PR DESCRIPTION
This pull request updates the version numbers for several libraries and SDKs in the project, reflecting a coordinated release upgrade across the codebase. The changes ensure that all dependent modules reference the new versions, and the release order documentation is updated accordingly.

Version upgrades:

* Bumped the version of `gini-capture-sdk`, `gini-capture-sdk-default-network`, `gini-bank-api-lib`, `gini-bank-sdk`, and `gini-internal-core-api-lib` to their respective new major or minor versions in their `gradle.properties` files. [[1]](diffhunk://#diff-27967e420ef3fb37aa2b3bb374d32b1803338a1a2359696e1f636facfd154d72L4-R4) [[2]](diffhunk://#diff-6cafe03f1c8c3b45c2d83bd763c2aa97e1eaa7bfd667b977682f59c285ed4766L4-R4) [[3]](diffhunk://#diff-efcbc230837814c649fd814ebdbd3edab608ea60763ef374a14857a4df852ef3L4-R4) [[4]](diffhunk://#diff-30799a4e6e1f377278574bfe9a76ac6b41af75dcdd4af2f51f3c2aa635c6be11L4-R4) [[5]](diffhunk://#diff-4ce0303decbebae53bb2ccd59cb76a4619fa7b42b7e629e3793025e76a01668eL4-R4)

Documentation updates:

* Updated the version in the Gradle dependency example in `getting-started.rst` to reference `gini-bank-api-lib:4.1.0`.
* Updated `RELEASE-ORDER.md` to reflect the new versions and correct dependency order for the release process.