### PR TITLE
feat(health-sdk):change orientation from landscape to portrait the cl…

### DIFF
--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -13,7 +13,6 @@ import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.ViewTreeObserver
 import android.widget.EditText
-import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.ViewCompat
@@ -230,29 +229,52 @@ class ReviewFragment private constructor(
             constrainHeight(binding.pager.id, h)
             clear(binding.pager.id, ConstraintSet.BOTTOM)
             
-            // For Android 15+: Explicitly preserve close button constraints
-            // to prevent it from moving when applyTo() recalculates all constraints
-            if (Build.VERSION.SDK_INT >= 35) {
-                val closeButtonId = binding.close.id
-                
+            // HEAL-139: Apply Android 15+ close button position fix
+            applyAndroid15CloseButtonFix(this, binding.close.id)
+            
+            applyTo(binding.constraintRoot)
+        }
+    }
+
+    /**
+     * Applies Android 15+ specific constraint fixes to lock the close button position.
+     * 
+     * On API 35+ (Android 15/16), ConstraintSet.applyTo() recalculates all constraints,
+     * causing the close button to shift during device rotation. This method adds a
+     * BOTTOM constraint and vertical bias (not present in the original XML layout) to
+     * create a "locked" position that keeps the button anchored to the top-right corner
+     * even during constraint recalculation.
+     * 
+     * This workaround should be removed if/when Android fixes the underlying constraint
+     * calculation issue in future API levels.
+     * 
+     * @param constraintSet The ConstraintSet to apply the close button fixes to
+     * @param closeButtonId The view ID of the close button
+     */
+    private fun applyAndroid15CloseButtonFix(constraintSet: ConstraintSet, closeButtonId: Int) {
+        if (Build.VERSION.SDK_INT >= 35) {
+            constraintSet.apply {
                 // Clear any potentially stale constraints
                 clear(closeButtonId, ConstraintSet.START)
                 clear(closeButtonId, ConstraintSet.BOTTOM)
                 
-                // Re-establish the correct constraints
+                // Re-establish constraints: END+TOP from XML, plus BOTTOM+bias for position locking
                 connect(closeButtonId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
                 connect(closeButtonId, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
-                connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
-                setVerticalBias(closeButtonId, 0.0f)
+                connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)  // Added: locks vertical position
+                setVerticalBias(closeButtonId, 0.0f)  // Added: 0.0 = top, 1.0 = bottom
                 
-                // Preserve margins
-                val marginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
-                val marginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
-                setMargin(closeButtonId, ConstraintSet.TOP, marginTop)
-                setMargin(closeButtonId, ConstraintSet.END, marginEnd)
+                // Calculate margins: base margin + status bar inset
+                // This ensures proper spacing without relying on potentially incorrect current state
+                val baseMarginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
+                val baseMarginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
+                
+                val windowInsets = ViewCompat.getRootWindowInsets(binding.root)
+                val statusBarInset = windowInsets?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+                
+                setMargin(closeButtonId, ConstraintSet.TOP, baseMarginTop + statusBarInset)
+                setMargin(closeButtonId, ConstraintSet.END, baseMarginEnd)
             }
-            
-            applyTo(binding.constraintRoot)
         }
     }
 
@@ -582,27 +604,8 @@ class ReviewFragment private constructor(
                     )
                 )
                 
-                // For Android 15+: Explicitly preserve close button constraints in landscape
-                // to prevent it from moving when applyTo() recalculates all constraints
-                if (Build.VERSION.SDK_INT >= 35) {
-                    val closeButtonId = binding.close.id
-                    
-                    // Clear any potentially stale constraints
-                    clear(closeButtonId, ConstraintSet.START)
-                    clear(closeButtonId, ConstraintSet.BOTTOM)
-                    
-                    // Re-establish the correct constraints
-                    connect(closeButtonId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
-                    connect(closeButtonId, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
-                    connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
-                    setVerticalBias(closeButtonId, 0.0f)
-                    
-                    // Preserve margins
-                    val marginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
-                    val marginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
-                    setMargin(closeButtonId, ConstraintSet.TOP, marginTop)
-                    setMargin(closeButtonId, ConstraintSet.END, marginEnd)
-                }
+                // Apply Android 15+ close button position fix in landscape
+                applyAndroid15CloseButtonFix(this, binding.close.id)
                 
                 applyTo(binding.constraintRoot)
             }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.ViewTreeObserver
 import android.widget.EditText
+import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.ViewCompat
@@ -227,7 +228,30 @@ class ReviewFragment private constructor(
         ConstraintSet().apply {
             clone(binding.constraintRoot)
             constrainHeight(binding.pager.id, h)
-            clear(binding.pager.id, ConstraintSet.BOTTOM) // if that’s part of your logic
+            clear(binding.pager.id, ConstraintSet.BOTTOM)
+            
+            // For Android 15+: Explicitly preserve close button constraints
+            // to prevent it from moving when applyTo() recalculates all constraints
+            if (Build.VERSION.SDK_INT >= 35) {
+                val closeButtonId = binding.close.id
+                
+                // Clear any potentially stale constraints
+                clear(closeButtonId, ConstraintSet.START)
+                clear(closeButtonId, ConstraintSet.BOTTOM)
+                
+                // Re-establish the correct constraints
+                connect(closeButtonId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+                connect(closeButtonId, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+                connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+                setVerticalBias(closeButtonId, 0.0f)
+                
+                // Preserve margins
+                val marginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
+                val marginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
+                setMargin(closeButtonId, ConstraintSet.TOP, marginTop)
+                setMargin(closeButtonId, ConstraintSet.END, marginEnd)
+            }
+            
             applyTo(binding.constraintRoot)
         }
     }
@@ -391,6 +415,15 @@ class ReviewFragment private constructor(
                 margin(top = true)
             }
         }
+        
+        // For Android 15+, force the close button to stay at a fixed position
+        // by resetting any translation that might have been applied
+        if (Build.VERSION.SDK_INT >= 35) {
+            close.post {
+                close.translationX = 0f
+                close.translationY = 0f
+            }
+        }
     }
 
 
@@ -548,6 +581,29 @@ class ReviewFragment private constructor(
                             ?: 0) + bottomLayout.height)
                     )
                 )
+                
+                // For Android 15+: Explicitly preserve close button constraints in landscape
+                // to prevent it from moving when applyTo() recalculates all constraints
+                if (Build.VERSION.SDK_INT >= 35) {
+                    val closeButtonId = binding.close.id
+                    
+                    // Clear any potentially stale constraints
+                    clear(closeButtonId, ConstraintSet.START)
+                    clear(closeButtonId, ConstraintSet.BOTTOM)
+                    
+                    // Re-establish the correct constraints
+                    connect(closeButtonId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+                    connect(closeButtonId, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+                    connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+                    setVerticalBias(closeButtonId, 0.0f)
+                    
+                    // Preserve margins
+                    val marginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
+                    val marginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
+                    setMargin(closeButtonId, ConstraintSet.TOP, marginTop)
+                    setMargin(closeButtonId, ConstraintSet.END, marginEnd)
+                }
+                
                 applyTo(binding.constraintRoot)
             }
         }


### PR DESCRIPTION
This pull request addresses layout issues with the close button in the `ReviewFragment` on Android 15 and above. It ensures that the close button remains correctly positioned when constraints are recalculated, both in portrait and landscape modes, and resets any translations that might cause it to move unexpectedly. Additionally, it introduces a minor import change.

**Android 15+ close button layout fixes:**

* Explicitly re-establishes and preserves all constraints for the close button in both portrait and landscape layouts to prevent it from shifting when `applyTo()` is called, including clearing stale constraints, reconnecting to the parent, setting vertical bias, and preserving margins. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L230-R254) [[2]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6R584-R606)
* Adds logic to reset the close button’s `translationX` and `translationY` to zero after layout, ensuring it stays at a fixed position on Android 15+.

**Other changes:**

* Adds an import for `FrameLayout` in `ReviewFragment.kt`