### PR TITLE
Pp 2377 add product tag config

### DIFF
--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationViewModel.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationViewModel.kt
@@ -136,6 +136,9 @@ class ConfigurationViewModel @Inject constructor(
 
             // enables saving invoices locally after analysis
             saveInvoicesLocallyEnabled = configuration.saveInvoicesLocallyEnabled,
+
+            // product tag
+            productTag = configuration.productTag,
         )
 
         // enable image picker screens custom bottom navigation bar -> was implemented on iOS, not needed for Android

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
@@ -7,6 +7,7 @@ import net.gini.android.capture.DocumentImportEnabledFileTypes
 import net.gini.android.capture.EntryPoint
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.internal.util.FileImportValidator
+import net.gini.android.capture.ProductTag
 
 
 @Parcelize
@@ -153,6 +154,9 @@ data class ExampleAppBankConfiguration(
 
     // enable/disable custom HTTP client provider (for testing network customization)
     val isCustomHttpClientEnabled: Boolean = false,
+
+    // product tag
+    val productTag: ProductTag = ProductTag.SepaExtractions,
 
 ) : Parcelable {
 

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
@@ -18,6 +18,7 @@ import net.gini.android.capture.ui.components.GiniComposableStyleProvider
 import net.gini.android.capture.view.CustomLoadingIndicatorAdapter
 import net.gini.android.capture.view.NavigationBarTopAdapter
 import net.gini.android.capture.view.OnButtonLoadingIndicatorAdapter
+import net.gini.android.capture.ProductTag
 
 /**
  * Configuration class for Capture feature.
@@ -219,6 +220,19 @@ data class CaptureConfiguration(
      * Enable/disable the save invoices locally feature
      */
     val saveInvoicesLocallyEnabled: Boolean = true,
+
+    /**
+     * Product tag to identify which extraction type the app uses.
+     *
+     * - [ProductTag.SepaExtractions]: Show normal extractions
+     * - [ProductTag.CxExtractions]: Show compound extractions
+     * - [ProductTag.AutoDetectExtractions]: Auto-detect (not yet available)
+     *
+     * Default is [ProductTag.SepaExtractions] for backward compatibility.
+     *
+     * Access this value anywhere via [GiniBank.getCaptureConfiguration]?.productTag
+     */
+    val productTag: ProductTag = ProductTag.SepaExtractions,
 )
 
 internal fun GiniCapture.Builder.applyConfiguration(configuration: CaptureConfiguration): GiniCapture.Builder {
@@ -242,6 +256,7 @@ internal fun GiniCapture.Builder.applyConfiguration(configuration: CaptureConfig
         .setEntryPoint(configuration.entryPoint)
         .setAllowScreenshots(configuration.allowScreenshots)
         .setSaveInvoicesLocallyEnabled(configuration.saveInvoicesLocallyEnabled)
+        .setProductTag(configuration.productTag)
         .addCustomUploadMetadata(GiniBank.USER_COMMENT_GINI_BANK_VERSION, BuildConfig.VERSION_NAME)
         .apply {
             configuration.eventTracker?.let { setEventTracker(it) }

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/Configuration.kt
@@ -230,7 +230,6 @@ data class CaptureConfiguration(
      *
      * Default is [ProductTag.SepaExtractions] for backward compatibility.
      *
-     * Access this value anywhere via [GiniBank.getCaptureConfiguration]?.productTag
      */
     val productTag: ProductTag = ProductTag.SepaExtractions,
 )

--- a/bank-sdk/sdk/src/test/java/net/gini/android/bank/sdk/capture/CaptureConfigurationTest.kt
+++ b/bank-sdk/sdk/src/test/java/net/gini/android/bank/sdk/capture/CaptureConfigurationTest.kt
@@ -1,0 +1,55 @@
+package net.gini.android.bank.sdk.capture
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.mockk
+import net.gini.android.bank.sdk.GiniBank
+import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
+import net.gini.android.capture.network.GiniCaptureNetworkService
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Tests that verify [CaptureConfiguration] properties are correctly forwarded to [GiniCapture]
+ * when [GiniBank.setCaptureConfiguration] is called.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class CaptureConfigurationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val mockNetworkService = mockk<GiniCaptureNetworkService>(relaxed = true)
+
+    @After
+    fun tearDown() {
+        GiniBank.cleanupCapture(context)
+    }
+
+    @Test
+    fun `productTag defaults to SepaExtractions`() {
+        GiniBank.setCaptureConfiguration(
+            context,
+            CaptureConfiguration(networkService = mockNetworkService)
+        )
+
+        assertEquals(ProductTag.SepaExtractions, GiniCapture.getInstance().productTag)
+    }
+
+    @Test
+    fun `productTag CxExtractions is forwarded to GiniCapture`() {
+        GiniBank.setCaptureConfiguration(
+            context,
+            CaptureConfiguration(
+                networkService = mockNetworkService,
+                productTag = ProductTag.CxExtractions
+            )
+        )
+
+        assertEquals(ProductTag.CxExtractions, GiniCapture.getInstance().productTag)
+    }
+}

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
@@ -136,6 +136,7 @@ public class GiniCapture {
     private final boolean saveInvoicesLocallyEnabled;
 
     private final Map<String, String> mCustomUploadMetadata;
+    private final ProductTag mProductTag;
 
 
     /**
@@ -402,6 +403,7 @@ public class GiniCapture {
         allowScreenshots = builder.getAllowScreenshots();
         saveInvoicesLocallyEnabled = builder.getSaveInvoicesLocallyEnabled();
         mCustomUploadMetadata = builder.getCustomUploadMetadata();
+        mProductTag = builder.getProductTag();
         mGiniComposableStyleProvider = builder.getGiniComposableStyleProvider();
     }
 
@@ -480,6 +482,16 @@ public class GiniCapture {
     @Nullable
     public ArrayList<OnboardingPage> getCustomOnboardingPages() { // NOPMD - ArrayList required (Bundle)
         return mCustomOnboardingPages;
+    }
+
+    /**
+     * Returns the configured product tag.
+     *
+     * @return the {@link ProductTag}
+     */
+    @NonNull
+    public ProductTag getProductTag() {
+        return mProductTag;
     }
 
     /**

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCapture.java
@@ -918,6 +918,8 @@ public class GiniCapture {
         private boolean allowScreenshots = true;
         private boolean savingInvoicesLocallyEnabled = true;
 
+        private ProductTag mProductTag = ProductTag.SepaExtractions.INSTANCE;
+
         private Map<String, String> customUploadMetadata;
         private GiniComposableStyleProvider giniComposableStyleProvider;
 
@@ -1457,6 +1459,23 @@ public class GiniCapture {
 
         private GiniComposableStyleProvider getGiniComposableStyleProvider() {
             return giniComposableStyleProvider;
+        }
+
+        /**
+         * Set the product tag to identify which extraction type to use.
+         *
+         * Default is {@link ProductTag.SepaExtractions}.
+         *
+         * @param productTag the {@link ProductTag} to use
+         * @return the {@link Builder} instance
+         */
+        public Builder setProductTag(@NonNull final ProductTag productTag) {
+            mProductTag = productTag;
+            return this;
+        }
+
+        private ProductTag getProductTag() {
+            return mProductTag;
         }
     }
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
@@ -1,0 +1,35 @@
+package net.gini.android.capture
+
+/**
+ * Product tag to identify which extraction type to use.
+ *
+ *
+ * @property value The string value of the product tag
+ */
+sealed class ProductTag(val value: String) {
+
+    /**
+     * SEPA extractions - shows normal extractions.
+     * This is the default behavior.
+     */
+    object SepaExtractions : ProductTag("sepa-extractions")
+
+    /**
+     * Cross-border extractions - shows compound extractions.
+     */
+    object CxExtractions : ProductTag("cx-extractions")
+
+    /**
+     * Auto-detect extractions.
+     *
+     * Note: This option is reserved for future use and is not yet available for customer use.
+     */
+    object AutoDetectExtractions : ProductTag("auto-detect-extractions")
+
+    /**
+     * Custom product tag for extensibility.
+     *
+     * @property customValue The custom product tag value
+     */
+    data class OtherProductTag(val customValue: String) : ProductTag(customValue)
+}

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
@@ -1,12 +1,16 @@
 package net.gini.android.capture
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Product tag to identify which extraction type to use.
  *
  *
  * @property value The string value of the product tag
  */
-sealed class ProductTag(val value: String) {
+@Parcelize
+sealed class ProductTag(val value: String) : Parcelable {
 
     /**
      * SEPA extractions - shows normal extractions.
@@ -31,5 +35,6 @@ sealed class ProductTag(val value: String) {
      *
      * @property customValue The custom product tag value
      */
+    @Parcelize
     data class OtherProductTag(val customValue: String) : ProductTag(customValue)
 }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
@@ -16,11 +16,13 @@ sealed class ProductTag(val value: String) : Parcelable {
      * SEPA extractions - shows normal extractions.
      * This is the default behavior.
      */
+    @Parcelize
     object SepaExtractions : ProductTag("sepa-extractions")
 
     /**
      * Cross-border extractions - shows compound extractions.
      */
+    @Parcelize
     object CxExtractions : ProductTag("cx-extractions")
 
     /**
@@ -28,6 +30,7 @@ sealed class ProductTag(val value: String) : Parcelable {
      *
      * Note: This option is reserved for future use and is not yet available for customer use.
      */
+    @Parcelize
     object AutoDetectExtractions : ProductTag("auto-detect-extractions")
 
     /**


### PR DESCRIPTION
## Pull Request Description

Adds a “product tag” configuration knob to the Capture/Bank SDKs to let integrators specify which extraction type should be used (e.g., SEPA vs cross-border), and wires it through the Bank SDK configuration layers.

## Notes for Developers

- Introduces a new ProductTag type in Capture SDK.
- Adds setProductTag() to GiniCapture.Builder and threads the value from Bank SDK CaptureConfiguration.
- Propagates the new setting into the Bank SDK example app configuration/state.