### PR TITLE
Pp 2381 cx extraction support example app

### DIFF
--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
@@ -20,7 +20,6 @@ import net.gini.android.bank.sdk.exampleapp.R
 import net.gini.android.bank.sdk.exampleapp.core.PermissionHandler
 import net.gini.android.capture.DocumentImportEnabledFileTypes
 import net.gini.android.capture.GiniCapture
-import net.gini.android.capture.ProductTag
 import net.gini.android.capture.network.GiniCaptureDefaultNetworkService
 import net.gini.android.core.api.DocumentMetadata
 

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
@@ -145,7 +145,8 @@ class ClientBankSDKFragment :
                     ExtractionsActivity.getStartIntent(
                         requireContext(),
                         result.specificExtractions,
-                        GiniCapture.getInstance().productTag
+                        result.compoundExtractions,
+                        GiniCapture.getInstance().productTag,
                     )
                 )
                 activity?.finish()

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
@@ -20,6 +20,7 @@ import net.gini.android.bank.sdk.exampleapp.R
 import net.gini.android.bank.sdk.exampleapp.core.PermissionHandler
 import net.gini.android.capture.DocumentImportEnabledFileTypes
 import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.network.GiniCaptureDefaultNetworkService
 import net.gini.android.core.api.DocumentMetadata
 
@@ -145,7 +146,7 @@ class ClientBankSDKFragment :
                         requireContext(),
                         result.specificExtractions,
                         result.compoundExtractions,
-                        GiniCapture.getInstance().productTag,
+                        GiniCapture.getInstance().productTag == ProductTag.CxExtractions,
                     )
                 )
                 activity?.finish()

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ClientBankSDKFragment.kt
@@ -19,6 +19,8 @@ import net.gini.android.bank.sdk.capture.ResultError
 import net.gini.android.bank.sdk.exampleapp.R
 import net.gini.android.bank.sdk.exampleapp.core.PermissionHandler
 import net.gini.android.capture.DocumentImportEnabledFileTypes
+import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.network.GiniCaptureDefaultNetworkService
 import net.gini.android.core.api.DocumentMetadata
 
@@ -142,7 +144,8 @@ class ClientBankSDKFragment :
                 startActivity(
                     ExtractionsActivity.getStartIntent(
                         requireContext(),
-                        result.specificExtractions
+                        result.specificExtractions,
+                        GiniCapture.getInstance().productTag
                     )
                 )
                 activity?.finish()

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
@@ -24,6 +24,7 @@ import net.gini.android.capture.internal.util.ActivityHelper.interceptOnBackPres
 import net.gini.android.capture.util.SharedPreferenceHelper
 import net.gini.android.capture.util.SharedPreferenceHelper.SAF_STORAGE_URI_KEY
 import javax.inject.Inject
+import net.gini.android.capture.ProductTag
 
 @AndroidEntryPoint
 class ConfigurationActivity : AppCompatActivity() {
@@ -239,6 +240,10 @@ class ConfigurationActivity : AppCompatActivity() {
         // Custom HTTP client toggle
         binding.layoutDebugDevelopmentOptionsToggles.switchCustomHttpClient.isChecked =
             configuration.isCustomHttpClientEnabled
+
+        // Enable product tag CxExtractions toggle
+        binding.layoutFeatureToggle.switchProductTagCx.isChecked =
+            configuration.productTag == ProductTag.CxExtractions
     }
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -677,6 +682,16 @@ class ConfigurationActivity : AppCompatActivity() {
         // Transaction docs always attach checked
         binding.layoutTransactionDocsToggles.switchAlwaysAttachDocs.setOnCheckedChangeListener { _, isChecked ->
             configurationViewModel.setAlwaysAttachSetting(this, isChecked)
+        }
+
+        // Product Tag switch - OFF = SEPA, ON = CX
+        binding.layoutFeatureToggle.switchProductTagCx.setOnCheckedChangeListener { _, isChecked ->
+            val productTag = if (isChecked) ProductTag.CxExtractions else ProductTag.SepaExtractions
+            configurationViewModel.setConfiguration(
+                configurationViewModel.configurationFlow.value.copy(
+                    productTag = productTag
+                )
+            )
         }
     }
 

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -136,12 +136,10 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 getParcelable<GiniCaptureCompoundExtraction>(name)?.let { tempMap[name] = it }
             }
             mCompoundExtractions = tempMap
-            android.util.Log.d("ExtractionsActivity", "📥 Received ${tempMap.size} compound extractions")
         }
         
         // Read productTag
         mProductTag = intent.getParcelableExtra(EXTRA_IN_PRODUCT_TAG) ?: ProductTag.SepaExtractions
-        android.util.Log.d("ExtractionsActivity", "📥 Received ProductTag: ${mProductTag.value}")
     }
 
     /**
@@ -152,20 +150,16 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
         val flattened = mutableMapOf<String, GiniCaptureSpecificExtraction>()
         
         mCompoundExtractions.forEach { (compoundName, compoundExtraction) ->
-            android.util.Log.d("ExtractionsActivity", "📦 Compound: $compoundName has ${compoundExtraction.specificExtractionMaps.size} options")
-            
             // Take first payment option (index 0)
             if (compoundExtraction.specificExtractionMaps.isNotEmpty()) {
                 val firstOption = compoundExtraction.specificExtractionMaps[0]
                 
                 firstOption.forEach { (fieldName, specificExtraction) ->
-                    android.util.Log.d("ExtractionsActivity", "  → Field: $fieldName = ${specificExtraction.value}")
                     flattened[fieldName] = specificExtraction
                 }
             }
         }
         
-        android.util.Log.d("ExtractionsActivity", "→ Total flattened CX fields: ${flattened.size}")
         return flattened
     }
 
@@ -175,15 +169,10 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             layoutManager = LinearLayoutManager(this@ExtractionsActivity)
 
             // Check productTag to determine which extractions to show
-            android.util.Log.d("ExtractionsActivity", "🏷️ Checking ProductTag: ${mProductTag.value}")
-            
             val fieldsToDisplay = when (mProductTag) {
                 is ProductTag.CxExtractions -> {
-                    android.util.Log.d("ExtractionsActivity", "→ Using CX extraction fields (READONLY)")
-                    
                     // For CX: Clear specific extractions and ONLY use compound extractions
                     mExtractions.clear()
-                    android.util.Log.d("ExtractionsActivity", "→ CX: Cleared specific extractions, using only compound")
                     
                     // Flatten compound extractions into mExtractions
                     val cxFields = flattenCompoundExtractions()
@@ -194,7 +183,6 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                     cxExtractionFields // Use CX field mapping
                 }
                 else -> {
-                    android.util.Log.d("ExtractionsActivity", "→ Using SEPA extraction fields (default)")
                     editableSpecificExtractions // Use SEPA field mapping (default)
                 }
             }
@@ -220,7 +208,6 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                     val nonEmptyExtractions = mExtractions.filter { (_, extraction) ->
                         extraction.value.isNotBlank()
                     }
-                    android.util.Log.d("ExtractionsActivity", "→ CX: Showing ${nonEmptyExtractions.size} non-empty fields (out of ${mExtractions.size})")
                     nonEmptyExtractions
                 }
                 else -> {
@@ -347,8 +334,6 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             isCaptureSdkExtractions: Boolean = false
         ): Intent {
             isCaptureSDKExtractions = isCaptureSdkExtractions
-            android.util.Log.d("ExtractionsActivity", "📤 Sending ProductTag: ${productTag.value}")
-            android.util.Log.d("ExtractionsActivity", "📤 Sending ${compoundExtractions.size} compound extractions")
             return Intent(context, ExtractionsActivity::class.java).apply {
                 putExtra(EXTRA_IN_EXTRACTIONS, Bundle().apply {
                     extractionsBundle.map { putParcelable(it.key, it.value) }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -143,7 +143,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
         // Filter to ONLY crossBorderPayment compound extraction (exclude line items)
         mCompoundExtractions.entries
             .filter { (compoundName, _) -> compoundName == "crossBorderPayment" }
-            .forEach { (compoundName, compoundExtraction) ->
+            .forEach { (_, compoundExtraction) ->
                 // Take first payment option (index 0)
                 if (compoundExtraction.specificExtractionMaps.isNotEmpty()) {
                     val firstOption = compoundExtraction.specificExtractionMaps[0]

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -29,6 +29,7 @@ import net.gini.android.capture.Amount
 import net.gini.android.capture.AmountCurrency
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.ProductTag
+import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
 import net.gini.android.capture.util.protectViewFromInsets
 import java.math.BigDecimal
@@ -46,6 +47,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
     private lateinit var binding: ActivityExtractionsBinding
 
     private var mExtractions: MutableMap<String, GiniCaptureSpecificExtraction> = hashMapOf()
+    private var mCompoundExtractions: Map<String, GiniCaptureCompoundExtraction> = emptyMap()
     private lateinit var mExtractionsAdapter: ExtractionsAdapter
     private var mProductTag: ProductTag = ProductTag.SepaExtractions
 
@@ -63,6 +65,15 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
         "bic" to "bic",
         "amountToPay" to "amount",
         "instantPayment" to "text"
+    )
+
+    // CX (cross-border) extraction fields
+    private val cxExtractionFields = hashMapOf(
+        "paymentRecipient" to "companyname",
+        "paymentPurpose" to "text",
+        "iban" to "iban",
+        "bic" to "bic",
+        "amountToPay" to "amount"
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -118,9 +129,54 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             }
         }
         
+        // Read compound extractions
+        intent.extras?.getParcelable<Bundle>(EXTRA_IN_COMPOUND_EXTRACTIONS)?.run {
+            val tempMap = mutableMapOf<String, GiniCaptureCompoundExtraction>()
+            keySet().forEach { name ->
+                getParcelable<GiniCaptureCompoundExtraction>(name)?.let { tempMap[name] = it }
+            }
+            mCompoundExtractions = tempMap
+            android.util.Log.d("ExtractionsActivity", "📥 Received ${tempMap.size} compound extractions")
+        }
+        
         // Read productTag
         mProductTag = intent.getParcelableExtra(EXTRA_IN_PRODUCT_TAG) ?: ProductTag.SepaExtractions
         android.util.Log.d("ExtractionsActivity", "📥 Received ProductTag: ${mProductTag.value}")
+        
+        // Log exact JSON toString
+        android.util.Log.d("ExtractionsActivity", "═══════════════════════════════════════")
+        android.util.Log.d("ExtractionsActivity", "📋 SPECIFIC EXTRACTIONS JSON:")
+        android.util.Log.d("ExtractionsActivity", mExtractions.toString())
+        
+        android.util.Log.d("ExtractionsActivity", "")
+        android.util.Log.d("ExtractionsActivity", "📦 COMPOUND EXTRACTIONS JSON:")
+        android.util.Log.d("ExtractionsActivity", mCompoundExtractions.toString())
+        android.util.Log.d("ExtractionsActivity", "═══════════════════════════════════════")
+    }
+
+    /**
+     * Converts compound extractions to flat specific extractions for CX payments.
+     * Takes the first payment option from compound extraction and flattens it.
+     */
+    private fun flattenCompoundExtractions(): Map<String, GiniCaptureSpecificExtraction> {
+        val flattened = mutableMapOf<String, GiniCaptureSpecificExtraction>()
+        
+        mCompoundExtractions.forEach { (compoundName, compoundExtraction) ->
+            android.util.Log.d("ExtractionsActivity", "📦 Compound: $compoundName has ${compoundExtraction.specificExtractionMaps.size} options")
+            
+            // Take first payment option (index 0)
+            if (compoundExtraction.specificExtractionMaps.isNotEmpty()) {
+                val firstOption = compoundExtraction.specificExtractionMaps[0]
+                
+                firstOption.forEach { (fieldName, specificExtraction) ->
+                    android.util.Log.d("ExtractionsActivity", "  → Field: $fieldName = ${specificExtraction.value}")
+                    flattened[fieldName] = specificExtraction
+                }
+            }
+        }
+        
+        android.util.Log.d("ExtractionsActivity", "→ Total flattened CX fields: ${flattened.size}")
+        return flattened
     }
 
     private fun setUpRecyclerView(binding: ActivityExtractionsBinding) {
@@ -128,10 +184,32 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(this@ExtractionsActivity)
 
-            editableSpecificExtractions.forEach {
-                if (!mExtractions.containsKey(it.key)) {
-                    mExtractions[it.key] = GiniCaptureSpecificExtraction(
-                        it.key, "", it.value, null, emptyList()
+            // Check productTag to determine which extractions to show
+            android.util.Log.d("ExtractionsActivity", "🏷️ Checking ProductTag: ${mProductTag.value}")
+            
+            val fieldsToDisplay = when (mProductTag) {
+                is ProductTag.CxExtractions -> {
+                    android.util.Log.d("ExtractionsActivity", "→ Using CX extraction fields")
+                    
+                    // Flatten compound extractions into mExtractions
+                    val cxFields = flattenCompoundExtractions()
+                    
+                    // Merge CX fields into mExtractions
+                    mExtractions.putAll(cxFields)
+                    
+                    cxExtractionFields // Use CX field mapping
+                }
+                else -> {
+                    android.util.Log.d("ExtractionsActivity", "→ Using SEPA extraction fields (default)")
+                    editableSpecificExtractions // Use SEPA field mapping (default)
+                }
+            }
+            
+            // Ensure all expected fields exist (populate missing ones with empty values)
+            fieldsToDisplay.forEach { (extractionName, entityName) ->
+                if (!mExtractions.containsKey(extractionName)) {
+                    mExtractions[extractionName] = GiniCaptureSpecificExtraction(
+                        extractionName, "", entityName, null, emptyList()
                     )
                 }
             }
@@ -139,7 +217,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             adapter = ExtractionsAdapter(
                 getSortedExtractions(mExtractions),
                 this@ExtractionsActivity,
-                editableSpecificExtractions.keys.toList()
+                fieldsToDisplay.keys.toList()
             ).also {
                 mExtractionsAdapter = it
             }
@@ -243,19 +321,25 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
 
     companion object {
         const val EXTRA_IN_EXTRACTIONS = "EXTRA_IN_EXTRACTIONS"
+        const val EXTRA_IN_COMPOUND_EXTRACTIONS = "EXTRA_IN_COMPOUND_EXTRACTIONS"
         const val EXTRA_IN_PRODUCT_TAG = "EXTRA_IN_PRODUCT_TAG"
         var isCaptureSDKExtractions : Boolean = false
         fun getStartIntent(
             context: Context, 
             extractionsBundle: Map<String, GiniCaptureSpecificExtraction>,
+            compoundExtractions: Map<String, GiniCaptureCompoundExtraction> = emptyMap(),
             productTag: ProductTag = ProductTag.SepaExtractions,
             isCaptureSdkExtractions: Boolean = false
         ): Intent {
             isCaptureSDKExtractions = isCaptureSdkExtractions
             android.util.Log.d("ExtractionsActivity", "📤 Sending ProductTag: ${productTag.value}")
+            android.util.Log.d("ExtractionsActivity", "📤 Sending ${compoundExtractions.size} compound extractions")
             return Intent(context, ExtractionsActivity::class.java).apply {
                 putExtra(EXTRA_IN_EXTRACTIONS, Bundle().apply {
                     extractionsBundle.map { putParcelable(it.key, it.value) }
+                })
+                putExtra(EXTRA_IN_COMPOUND_EXTRACTIONS, Bundle().apply {
+                    compoundExtractions.map { putParcelable(it.key, it.value) }
                 })
                 putExtra(EXTRA_IN_PRODUCT_TAG, productTag)
             }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -28,6 +28,7 @@ import net.gini.android.bank.sdk.transactiondocs.ui.extractions.view.Transaction
 import net.gini.android.capture.Amount
 import net.gini.android.capture.AmountCurrency
 import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
 import net.gini.android.capture.util.protectViewFromInsets
 import java.math.BigDecimal
@@ -46,6 +47,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
 
     private var mExtractions: MutableMap<String, GiniCaptureSpecificExtraction> = hashMapOf()
     private lateinit var mExtractionsAdapter: ExtractionsAdapter
+    private var mProductTag: ProductTag = ProductTag.SepaExtractions
 
     @Inject
     internal lateinit var defaultNetworkServicesProvider: DefaultNetworkServicesProvider
@@ -115,6 +117,10 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 getParcelable<GiniCaptureSpecificExtraction>(name)?.let { mExtractions[name] = it }
             }
         }
+        
+        // Read productTag
+        mProductTag = intent.getParcelableExtra(EXTRA_IN_PRODUCT_TAG) ?: ProductTag.SepaExtractions
+        android.util.Log.d("ExtractionsActivity", "📥 Received ProductTag: ${mProductTag.value}")
     }
 
     private fun setUpRecyclerView(binding: ActivityExtractionsBinding) {
@@ -237,16 +243,21 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
 
     companion object {
         const val EXTRA_IN_EXTRACTIONS = "EXTRA_IN_EXTRACTIONS"
+        const val EXTRA_IN_PRODUCT_TAG = "EXTRA_IN_PRODUCT_TAG"
         var isCaptureSDKExtractions : Boolean = false
         fun getStartIntent(
-            context: Context, extractionsBundle: Map<String, GiniCaptureSpecificExtraction>,
+            context: Context, 
+            extractionsBundle: Map<String, GiniCaptureSpecificExtraction>,
+            productTag: ProductTag = ProductTag.SepaExtractions,
             isCaptureSdkExtractions: Boolean = false
         ): Intent {
             isCaptureSDKExtractions = isCaptureSdkExtractions
+            android.util.Log.d("ExtractionsActivity", "📤 Sending ProductTag: ${productTag.value}")
             return Intent(context, ExtractionsActivity::class.java).apply {
                 putExtra(EXTRA_IN_EXTRACTIONS, Bundle().apply {
                     extractionsBundle.map { putParcelable(it.key, it.value) }
                 })
+                putExtra(EXTRA_IN_PRODUCT_TAG, productTag)
             }
         }
     }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -162,21 +162,17 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(this@ExtractionsActivity)
 
-            // Check isCxExtractions to determine which extractions to show
+            // For CX: replace mExtractions with flattened compound extractions
+            if (isCxExtractions) {
+                mExtractions.clear()
+                mExtractions.putAll(flattenCompoundExtractions())
+            }
+
             val fieldsToDisplay = if (isCxExtractions) {
-                    // For CX: Clear specific extractions and ONLY use compound extractions
-                    mExtractions.clear()
-                    
-                    // Flatten compound extractions into mExtractions
-                    val cxFields = flattenCompoundExtractions()
-                    
-                    // Replace with CX fields
-                    mExtractions.putAll(cxFields)
-                    
-                    emptyMap() // No schema needed for CX; fields come directly from compound extractions
-                } else {
-                    editableSpecificExtractions // Use SEPA field mapping (default)
-                }
+                emptyMap() // No schema needed for CX; fields come directly from compound extractions
+            } else {
+                editableSpecificExtractions // Use SEPA field mapping (default)
+            }
             
             // Determine editable fields based on isCxExtractions
             val editableFields = if (isCxExtractions) {

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -219,9 +219,24 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                     )
                 }
             }
+            
+            // For CX: filter out empty fields (only show fields with values)
+            val extractionsToShow = when (mProductTag) {
+                is ProductTag.CxExtractions -> {
+                    val nonEmptyExtractions = mExtractions.filter { (_, extraction) ->
+                        extraction.value.isNotBlank()
+                    }
+                    android.util.Log.d("ExtractionsActivity", "→ CX: Showing ${nonEmptyExtractions.size} non-empty fields (out of ${mExtractions.size})")
+                    nonEmptyExtractions
+                }
+                else -> {
+                    // SEPA: show all fields (including empty ones) - UNCHANGED
+                    mExtractions
+                }
+            }
 
             adapter = ExtractionsAdapter(
-                getSortedExtractions(mExtractions),
+                getSortedExtractions(extractionsToShow),
                 this@ExtractionsActivity,
                 editableFields
             ).also {

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -66,15 +66,6 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
         "instantPayment" to "text"
     )
 
-    // CX (cross-border) extraction fields
-    private val cxExtractionFields = hashMapOf(
-        "paymentRecipient" to "companyname",
-        "paymentPurpose" to "text",
-        "iban" to "iban",
-        "bic" to "bic",
-        "amountToPay" to "amount"
-    )
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityExtractionsBinding.inflate(layoutInflater)
@@ -182,7 +173,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                     // Replace with CX fields
                     mExtractions.putAll(cxFields)
                     
-                    cxExtractionFields // Use CX field mapping
+                    emptyMap() // No schema needed for CX; fields come directly from compound extractions
                 } else {
                     editableSpecificExtractions // Use SEPA field mapping (default)
                 }
@@ -194,7 +185,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 editableSpecificExtractions.keys.toList() // SEPA = only these 7 editable (UNCHANGED)
             }
             
-            // Ensure all expected fields exist (populate missing ones with empty values)
+            // Ensure all expected SEPA fields exist (populate missing ones with empty values)
             fieldsToDisplay.forEach { (extractionName, entityName) ->
                 if (!mExtractions.containsKey(extractionName)) {
                     mExtractions[extractionName] = GiniCaptureSpecificExtraction(

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -189,7 +189,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             
             val fieldsToDisplay = when (mProductTag) {
                 is ProductTag.CxExtractions -> {
-                    android.util.Log.d("ExtractionsActivity", "→ Using CX extraction fields")
+                    android.util.Log.d("ExtractionsActivity", "→ Using CX extraction fields (READONLY)")
                     
                     // Flatten compound extractions into mExtractions
                     val cxFields = flattenCompoundExtractions()
@@ -205,6 +205,12 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 }
             }
             
+            // Determine editable fields based on productTag
+            val editableFields = when (mProductTag) {
+                is ProductTag.CxExtractions -> emptyList() // CX = all fields readonly
+                else -> editableSpecificExtractions.keys.toList() // SEPA = only these 7 editable (UNCHANGED)
+            }
+            
             // Ensure all expected fields exist (populate missing ones with empty values)
             fieldsToDisplay.forEach { (extractionName, entityName) ->
                 if (!mExtractions.containsKey(extractionName)) {
@@ -217,7 +223,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             adapter = ExtractionsAdapter(
                 getSortedExtractions(mExtractions),
                 this@ExtractionsActivity,
-                fieldsToDisplay.keys.toList()
+                editableFields
             ).also {
                 mExtractionsAdapter = it
             }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -191,10 +191,14 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 is ProductTag.CxExtractions -> {
                     android.util.Log.d("ExtractionsActivity", "→ Using CX extraction fields (READONLY)")
                     
+                    // For CX: Clear specific extractions and ONLY use compound extractions
+                    mExtractions.clear()
+                    android.util.Log.d("ExtractionsActivity", "→ CX: Cleared specific extractions, using only compound")
+                    
                     // Flatten compound extractions into mExtractions
                     val cxFields = flattenCompoundExtractions()
                     
-                    // Merge CX fields into mExtractions
+                    // Replace with CX fields
                     mExtractions.putAll(cxFields)
                     
                     cxExtractionFields // Use CX field mapping

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -142,16 +142,6 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
         // Read productTag
         mProductTag = intent.getParcelableExtra(EXTRA_IN_PRODUCT_TAG) ?: ProductTag.SepaExtractions
         android.util.Log.d("ExtractionsActivity", "📥 Received ProductTag: ${mProductTag.value}")
-        
-        // Log exact JSON toString
-        android.util.Log.d("ExtractionsActivity", "═══════════════════════════════════════")
-        android.util.Log.d("ExtractionsActivity", "📋 SPECIFIC EXTRACTIONS JSON:")
-        android.util.Log.d("ExtractionsActivity", mExtractions.toString())
-        
-        android.util.Log.d("ExtractionsActivity", "")
-        android.util.Log.d("ExtractionsActivity", "📦 COMPOUND EXTRACTIONS JSON:")
-        android.util.Log.d("ExtractionsActivity", mCompoundExtractions.toString())
-        android.util.Log.d("ExtractionsActivity", "═══════════════════════════════════════")
     }
 
     /**

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -28,7 +28,6 @@ import net.gini.android.bank.sdk.transactiondocs.ui.extractions.view.Transaction
 import net.gini.android.capture.Amount
 import net.gini.android.capture.AmountCurrency
 import net.gini.android.capture.GiniCapture
-import net.gini.android.capture.ProductTag
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
 import net.gini.android.capture.util.protectViewFromInsets
@@ -49,7 +48,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
     private var mExtractions: MutableMap<String, GiniCaptureSpecificExtraction> = hashMapOf()
     private var mCompoundExtractions: Map<String, GiniCaptureCompoundExtraction> = emptyMap()
     private lateinit var mExtractionsAdapter: ExtractionsAdapter
-    private var mProductTag: ProductTag = ProductTag.SepaExtractions
+    private var isCxExtractions: Boolean = false
 
     @Inject
     internal lateinit var defaultNetworkServicesProvider: DefaultNetworkServicesProvider
@@ -138,8 +137,8 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             mCompoundExtractions = tempMap
         }
         
-        // Read productTag
-        mProductTag = intent.getParcelableExtra(EXTRA_IN_PRODUCT_TAG) ?: ProductTag.SepaExtractions
+        // Read isCxExtractions
+        isCxExtractions = intent.getBooleanExtra(EXTRA_IN_IS_CX_EXTRACTIONS, false)
     }
 
     /**
@@ -172,9 +171,8 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(this@ExtractionsActivity)
 
-            // Check productTag to determine which extractions to show
-            val fieldsToDisplay = when (mProductTag) {
-                is ProductTag.CxExtractions -> {
+            // Check isCxExtractions to determine which extractions to show
+            val fieldsToDisplay = if (isCxExtractions) {
                     // For CX: Clear specific extractions and ONLY use compound extractions
                     mExtractions.clear()
                     
@@ -185,16 +183,15 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                     mExtractions.putAll(cxFields)
                     
                     cxExtractionFields // Use CX field mapping
-                }
-                else -> {
+                } else {
                     editableSpecificExtractions // Use SEPA field mapping (default)
                 }
-            }
             
-            // Determine editable fields based on productTag
-            val editableFields = when (mProductTag) {
-                is ProductTag.CxExtractions -> emptyList() // CX = all fields readonly
-                else -> editableSpecificExtractions.keys.toList() // SEPA = only these 7 editable (UNCHANGED)
+            // Determine editable fields based on isCxExtractions
+            val editableFields = if (isCxExtractions) {
+                emptyList() // CX = all fields readonly
+            } else {
+                editableSpecificExtractions.keys.toList() // SEPA = only these 7 editable (UNCHANGED)
             }
             
             // Ensure all expected fields exist (populate missing ones with empty values)
@@ -207,18 +204,14 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
             }
             
             // For CX: filter out empty fields (only show fields with values)
-            val extractionsToShow = when (mProductTag) {
-                is ProductTag.CxExtractions -> {
-                    val nonEmptyExtractions = mExtractions.filter { (_, extraction) ->
+            val extractionsToShow = if (isCxExtractions) {
+                    mExtractions.filter { (_, extraction) ->
                         extraction.value.isNotBlank()
                     }
-                    nonEmptyExtractions
-                }
-                else -> {
+                } else {
                     // SEPA: show all fields (including empty ones) - UNCHANGED
                     mExtractions
                 }
-            }
 
             adapter = ExtractionsAdapter(
                 getSortedExtractions(extractionsToShow),
@@ -328,13 +321,13 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
     companion object {
         const val EXTRA_IN_EXTRACTIONS = "EXTRA_IN_EXTRACTIONS"
         const val EXTRA_IN_COMPOUND_EXTRACTIONS = "EXTRA_IN_COMPOUND_EXTRACTIONS"
-        const val EXTRA_IN_PRODUCT_TAG = "EXTRA_IN_PRODUCT_TAG"
+        const val EXTRA_IN_IS_CX_EXTRACTIONS = "EXTRA_IN_IS_CX_EXTRACTIONS"
         var isCaptureSDKExtractions : Boolean = false
         fun getStartIntent(
             context: Context, 
             extractionsBundle: Map<String, GiniCaptureSpecificExtraction>,
             compoundExtractions: Map<String, GiniCaptureCompoundExtraction> = emptyMap(),
-            productTag: ProductTag = ProductTag.SepaExtractions,
+            isCxExtractions: Boolean = false,
             isCaptureSdkExtractions: Boolean = false
         ): Intent {
             isCaptureSDKExtractions = isCaptureSdkExtractions
@@ -345,7 +338,7 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
                 putExtra(EXTRA_IN_COMPOUND_EXTRACTIONS, Bundle().apply {
                     compoundExtractions.map { putParcelable(it.key, it.value) }
                 })
-                putExtra(EXTRA_IN_PRODUCT_TAG, productTag)
+                putExtra(EXTRA_IN_IS_CX_EXTRACTIONS, isCxExtractions)
             }
         }
     }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ExtractionsActivity.kt
@@ -145,20 +145,24 @@ class ExtractionsActivity : AppCompatActivity(), ExtractionsAdapter.ExtractionsA
     /**
      * Converts compound extractions to flat specific extractions for CX payments.
      * Takes the first payment option from compound extraction and flattens it.
+     * ONLY processes crossBorderPayment compound extraction, ignores line items.
      */
     private fun flattenCompoundExtractions(): Map<String, GiniCaptureSpecificExtraction> {
         val flattened = mutableMapOf<String, GiniCaptureSpecificExtraction>()
         
-        mCompoundExtractions.forEach { (compoundName, compoundExtraction) ->
-            // Take first payment option (index 0)
-            if (compoundExtraction.specificExtractionMaps.isNotEmpty()) {
-                val firstOption = compoundExtraction.specificExtractionMaps[0]
-                
-                firstOption.forEach { (fieldName, specificExtraction) ->
-                    flattened[fieldName] = specificExtraction
+        // Filter to ONLY crossBorderPayment compound extraction (exclude line items)
+        mCompoundExtractions.entries
+            .filter { (compoundName, _) -> compoundName == "crossBorderPayment" }
+            .forEach { (compoundName, compoundExtraction) ->
+                // Take first payment option (index 0)
+                if (compoundExtraction.specificExtractionMaps.isNotEmpty()) {
+                    val firstOption = compoundExtraction.specificExtractionMaps[0]
+                    
+                    firstOption.forEach { (fieldName, specificExtraction) ->
+                        flattened[fieldName] = specificExtraction
+                    }
                 }
             }
-        }
         
         return flattened
     }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -29,7 +29,6 @@ import net.gini.android.bank.sdk.exampleapp.ui.transactiondocs.TransactionDocsAc
 import net.gini.android.capture.Document
 import net.gini.android.capture.EntryPoint
 import net.gini.android.capture.GiniCapture
-import net.gini.android.capture.ProductTag
 import net.gini.android.capture.util.CancellationToken
 
 /**

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -215,6 +215,7 @@ class MainActivity : AppCompatActivity() {
                 startActivity(ExtractionsActivity.getStartIntent(
                     this,
                     result.specificExtractions,
+                    result.compoundExtractions,
                     GiniCapture.getInstance().productTag)
                 )
             }

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -28,6 +28,8 @@ import net.gini.android.bank.sdk.exampleapp.ui.data.ExampleAppBankConfiguration
 import net.gini.android.bank.sdk.exampleapp.ui.transactiondocs.TransactionDocsActivity
 import net.gini.android.capture.Document
 import net.gini.android.capture.EntryPoint
+import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.util.CancellationToken
 
 /**
@@ -210,7 +212,11 @@ class MainActivity : AppCompatActivity() {
     private fun onCaptureResult(result: CaptureResult) {
         when (result) {
             is CaptureResult.Success -> {
-                startActivity(ExtractionsActivity.getStartIntent(this, result.specificExtractions))
+                startActivity(ExtractionsActivity.getStartIntent(
+                    this,
+                    result.specificExtractions,
+                    GiniCapture.getInstance().productTag)
+                )
             }
 
             is CaptureResult.Error -> {

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -29,6 +29,7 @@ import net.gini.android.bank.sdk.exampleapp.ui.transactiondocs.TransactionDocsAc
 import net.gini.android.capture.Document
 import net.gini.android.capture.EntryPoint
 import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.util.CancellationToken
 
 /**
@@ -215,7 +216,7 @@ class MainActivity : AppCompatActivity() {
                     this,
                     result.specificExtractions,
                     result.compoundExtractions,
-                    GiniCapture.getInstance().productTag)
+                    GiniCapture.getInstance().productTag == ProductTag.CxExtractions)
                 )
             }
 

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
@@ -48,6 +48,7 @@ class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener
                     ExtractionsActivity.getStartIntent(
                         context,
                         result.specificExtractions,
+                        result.compoundExtractions,
                         GiniCapture.getInstance().productTag,
                         true
                     )

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
@@ -5,6 +5,7 @@ import android.widget.Toast
 import net.gini.android.bank.sdk.capture.ResultError
 import net.gini.android.bank.sdk.exampleapp.ui.ExtractionsActivity
 import net.gini.android.capture.CaptureSDKResult
+import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.GiniCaptureFragmentListener
 
 class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener {
@@ -47,6 +48,7 @@ class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener
                     ExtractionsActivity.getStartIntent(
                         context,
                         result.specificExtractions,
+                        GiniCapture.getInstance().productTag,
                         true
                     )
                 )

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/util/CaptureResultListener.kt
@@ -7,6 +7,7 @@ import net.gini.android.bank.sdk.exampleapp.ui.ExtractionsActivity
 import net.gini.android.capture.CaptureSDKResult
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.GiniCaptureFragmentListener
+import net.gini.android.capture.ProductTag
 
 class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener {
     override fun onFinishedWithResult(result: CaptureSDKResult) {
@@ -49,7 +50,7 @@ class CaptureResultListener(val context: Activity) : GiniCaptureFragmentListener
                         context,
                         result.specificExtractions,
                         result.compoundExtractions,
-                        GiniCapture.getInstance().productTag,
+                        GiniCapture.getInstance().productTag == ProductTag.CxExtractions,
                         true
                     )
                 )

--- a/bank-sdk/example-app/src/main/res/layout/layout_feature_toggles.xml
+++ b/bank-sdk/example-app/src/main/res/layout/layout_feature_toggles.xml
@@ -155,6 +155,21 @@
         android:layout_marginTop="@dimen/gc_medium_12"
         android:text="@string/save_invoices_feature_label" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_product_tag_cx"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/product_tag_cx_switch_label" />
+
+    <TextView
+        android:id="@+id/tv_productTagDescription"
+        style="@style/TextAppearance.MaterialComponents.Caption"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/product_tag_cx_switch_description" />
+
     <com.google.android.material.button.MaterialButton
         android:layout_width="match_parent"
         android:id="@+id/btn_remove_saf_data"

--- a/bank-sdk/example-app/src/main/res/values/strings.xml
+++ b/bank-sdk/example-app/src/main/res/values/strings.xml
@@ -151,4 +151,7 @@
 
     <string name="configuration_transaction_docs_enabled">Transaction Docs enabled</string>
     <string name="configuration_transaction_docs_always_attach_docs">Always attach invoices</string>
+
+    <string name="product_tag_cx_switch_label">Enable CX Extractions</string>
+    <string name="product_tag_cx_switch_description">Turn on for CX (compound) extractions. Turn off for SEPA (standard) extractions.</string>
 </resources>

--- a/capture-sdk/sdk/consumer-rules.pro
+++ b/capture-sdk/sdk/consumer-rules.pro
@@ -2,3 +2,6 @@
 -keep class net.gini.android.capture.Document
 -keep class net.gini.android.capture.error.ErrorType
 -keep class net.gini.android.capture.DocumentImportEnabledFileTypes
+
+# Keep BundleHelper for compound extraction serialization (used by GiniCaptureCompoundExtraction Parcelable)
+-keep class net.gini.android.capture.internal.util.BundleHelperKt { *; }

--- a/capture-sdk/sdk/consumer-rules.pro
+++ b/capture-sdk/sdk/consumer-rules.pro
@@ -3,5 +3,6 @@
 -keep class net.gini.android.capture.error.ErrorType
 -keep class net.gini.android.capture.DocumentImportEnabledFileTypes
 
-# Keep BundleHelper for compound extraction serialization (used by GiniCaptureCompoundExtraction Parcelable)
+# Keep compound extraction and its serialization helpers for CX payments
+-keep class net.gini.android.capture.network.model.GiniCaptureCompoundExtraction { *; }
 -keep class net.gini.android.capture.internal.util.BundleHelperKt { *; }

--- a/capture-sdk/sdk/consumer-rules.pro
+++ b/capture-sdk/sdk/consumer-rules.pro
@@ -2,7 +2,3 @@
 -keep class net.gini.android.capture.Document
 -keep class net.gini.android.capture.error.ErrorType
 -keep class net.gini.android.capture.DocumentImportEnabledFileTypes
-
-# Keep compound extraction and its serialization helpers for CX payments
--keep class net.gini.android.capture.network.model.GiniCaptureCompoundExtraction { *; }
--keep class net.gini.android.capture.internal.util.BundleHelperKt { *; }


### PR DESCRIPTION
## PR Description

Adds CX (cross-border / compound) extraction support to the Bank SDK example app by introducing a configuration toggle for the Capture SDK ProductTag and adapting the extractions screen to display compound extractions when CX is enabled.

## Notes for Developer

Add UI copy and a feature-toggle switch to enable/disable CX extractions (via ProductTag).
Pass compoundExtractions + productTag through to ExtractionsActivity from the different capture entry points.
Update ExtractionsActivity to read compound extractions and display either SEPA (specific) or CX (flattened compound) extractions based on ProductTag.