### PR TITLE
HEAL 36 remove unnecessary close button position and pager

### DIFF
--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -402,7 +402,7 @@ class ReviewFragment private constructor(
             if (context.getFontScale() < 1.5) {
                 anchorView = paymentDetailsScrollview
             }
-            setTextMaxLines(if (resources.isLandscapeOrientation()) 1 else 3)
+            setTextMaxLines(if (resources.isLandscapeOrientation()) 2 else 3)
             setAction(getLocaleStringResource(net.gini.android.internal.payment.R.string.gps_snackbar_retry)) {
                 onRetry()
             }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -206,6 +206,8 @@ class ReviewFragment private constructor(
             startKeyboardTracker(view)
             restoreImeIfNeeded(view, savedInstanceState)
         }
+
+        applyCloseButtonStatusBarInsetOnce()
     }
 
     private fun restorePagerAndImeAfterRotation() {
@@ -227,6 +229,41 @@ class ReviewFragment private constructor(
             constrainHeight(binding.pager.id, h)
             clear(binding.pager.id, ConstraintSet.BOTTOM)
             applyTo(binding.constraintRoot)
+        }
+    }
+
+    /**
+     * Shifts the close button down by the status-bar height exactly once, using [View.post].
+     *
+     * Why NOT [ViewCompat.setOnApplyWindowInsetsListener] + [View.updateLayoutParams]:
+     *  - [ViewCompat.setOnApplyWindowInsetsListener] is dispatched by ViewRootImpl
+     *    **before** the measure/layout phase in every traversal.  On API 35+ (Android 15/16)
+     *    the IME open/close also triggers a new traversal, so the callback would fire again
+     *    (or, if already removed, a stale [View.requestLayout] call from [updateLayoutParams]
+     *    could still be in-flight and processed mid-animation), causing the close button to
+     *    jump downward — the exact regression reported in HEAL-36.
+     *
+     * Why [View.translationY] instead of [View.updateLayoutParams]:
+     *  - [View.translationY] is a rendering transform; it calls [View.invalidate] only —
+     *    **no [View.requestLayout], no layout-traversal disruption**.
+     *  - [androidx.constraintlayout.widget.ConstraintSet.applyTo] only updates layout params;
+     *    it does **not** reset [View.translationY], so the offset survives every
+     *    [applyPagerConstraintFromCurrentSize] / [setupLandscapeBehavior] call.
+     *
+     * Why [View.post]:
+     *  - Defers to after the first drawn frame, when [ViewCompat.getRootWindowInsets] is
+     *    guaranteed non-null and the status-bar height is stable.
+     *  - Runs in a quiet period (between frames) — not during any IME animation.
+     */
+    private fun applyCloseButtonStatusBarInsetOnce() {
+        binding.close.post {
+            if (!isAdded) return@post
+            val statusBarTop = ViewCompat.getRootWindowInsets(binding.root)
+                ?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
+            // translationY shifts the button visually without calling requestLayout().
+            // The XML already provides the base top margin (gps_small); we only add the
+            // status-bar height on top of that visual position.
+            binding.close.translationY = statusBarTop.toFloat()
         }
     }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -207,7 +207,7 @@ class ReviewFragment private constructor(
             restoreImeIfNeeded(view, savedInstanceState)
         }
 
-        applyCloseButtonStatusBarInsetOnce()
+        applyCloseButtonStatusBarInset()
     }
 
     private fun restorePagerAndImeAfterRotation() {
@@ -233,15 +233,30 @@ class ReviewFragment private constructor(
     }
 
     /**
-     * Shifts the close button down by the status-bar height exactly once, using [View.post].
+     * Applies the status-bar inset to the close button via [View.translationY], once.
      *
-     * Why NOT [ViewCompat.setOnApplyWindowInsetsListener] + [View.updateLayoutParams]:
-     *  - [ViewCompat.setOnApplyWindowInsetsListener] is dispatched by ViewRootImpl
-     *    **before** the measure/layout phase in every traversal.  On API 35+ (Android 15/16)
-     *    the IME open/close also triggers a new traversal, so the callback would fire again
-     *    (or, if already removed, a stale [View.requestLayout] call from [updateLayoutParams]
-     *    could still be in-flight and processed mid-animation), causing the close button to
-     *    jump downward — the exact regression reported in HEAL-36.
+     * Uses [View.doOnPreDraw] so the computation runs **after the first layout pass** —
+     * at that point [View.getLocationInWindow] accurately reflects any padding already
+     * applied by the host to the fragment container.
+     *
+     * Why [View.doOnPreDraw] instead of [ViewCompat.setOnApplyWindowInsetsListener]:
+     *  - [ViewCompat.setOnApplyWindowInsetsListener] fires **before** measure/layout in
+     *    every traversal.  On Android 15+ (API 35) the system dispatches insets to all views
+     *    (bypassing the older [androidx.coordinatorlayout.widget.CoordinatorLayout] filter),
+     *    so the callback fires again when the IME opens/closes.  At that moment
+     *    [View.getLocationInWindow] still returns the **pre-layout** root position, so the
+     *    effective-inset calculation would be wrong and cause a double-shift downward.
+     *  - [View.doOnPreDraw] fires after layout, giving an accurate [View.getLocationInWindow]
+     *    value, and the one-shot nature of [View.doOnPreDraw] means the IME never re-triggers
+     *    this code.
+     *
+     * Why [View.getLocationInWindow] (effective-inset approach):
+     *  - If the host has already offset the fragment container below the status bar
+     *    (e.g. by applying `paddingTop = statusBarHeight` to the content view),
+     *    `rootTopInWindow` will equal `statusBarTop` and the effective inset will be **zero**
+     *    — no extra [View.translationY] is needed and no double-shift occurs.
+     *  - If the host has not applied any inset, `rootTopInWindow` will be 0 and
+     *    [View.translationY] will equal the full status-bar height.
      *
      * Why [View.translationY] instead of [View.updateLayoutParams]:
      *  - [View.translationY] is a rendering transform; it calls [View.invalidate] only —
@@ -249,24 +264,23 @@ class ReviewFragment private constructor(
      *  - [androidx.constraintlayout.widget.ConstraintSet.applyTo] only updates layout params;
      *    it does **not** reset [View.translationY], so the offset survives every
      *    [applyPagerConstraintFromCurrentSize] / [setupLandscapeBehavior] call.
-     *
-     * Why [View.post]:
-     *  - Defers to after the first drawn frame, when [ViewCompat.getRootWindowInsets] is
-     *    guaranteed non-null and the status-bar height is stable.
-     *  - Runs in a quiet period (between frames) — not during any IME animation.
      */
-    private fun applyCloseButtonStatusBarInsetOnce() {
+    private fun applyCloseButtonStatusBarInset() {
         val root = binding.root
         val close = binding.close
-        close.post {
-            if (!isAdded) return@post
-            if (!close.isAttachedToWindow) return@post
+        // doOnPreDraw is a one-shot listener — it removes itself after the first callback.
+        // This guarantees that keyboard open/close events never re-trigger this code.
+        root.doOnPreDraw {
+            if (!close.isAttachedToWindow) return@doOnPreDraw
+            val location = IntArray(2)
+            root.getLocationInWindow(location)
+            val rootTopInWindow = location[1]
             val statusBarTop = ViewCompat.getRootWindowInsets(root)
                 ?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
-            // translationY shifts the button visually without calling requestLayout().
-            // The XML already provides the base top margin (gps_small); we only add the
-            // status-bar height on top of that visual position.
-            close.translationY = statusBarTop.toFloat()
+            // Effective inset = how much MORE the button needs to be shifted beyond what
+            // the host has already provided via container offset/padding.
+            val effectiveInset = (statusBarTop - rootTopInWindow).coerceAtLeast(0)
+            close.translationY = effectiveInset.toFloat()
         }
     }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -232,39 +232,6 @@ class ReviewFragment private constructor(
         }
     }
 
-    /**
-     * Applies the status-bar inset to the close button via [View.translationY], once.
-     *
-     * Uses [View.doOnPreDraw] so the computation runs **after the first layout pass** —
-     * at that point [View.getLocationInWindow] accurately reflects any padding already
-     * applied by the host to the fragment container.
-     *
-     * Why [View.doOnPreDraw] instead of [ViewCompat.setOnApplyWindowInsetsListener]:
-     *  - [ViewCompat.setOnApplyWindowInsetsListener] fires **before** measure/layout in
-     *    every traversal.  On Android 15+ (API 35) the system dispatches insets to all views
-     *    (bypassing the older [androidx.coordinatorlayout.widget.CoordinatorLayout] filter),
-     *    so the callback fires again when the IME opens/closes.  At that moment
-     *    [View.getLocationInWindow] still returns the **pre-layout** root position, so the
-     *    effective-inset calculation would be wrong and cause a double-shift downward.
-     *  - [View.doOnPreDraw] fires after layout, giving an accurate [View.getLocationInWindow]
-     *    value, and the one-shot nature of [View.doOnPreDraw] means the IME never re-triggers
-     *    this code.
-     *
-     * Why [View.getLocationInWindow] (effective-inset approach):
-     *  - If the host has already offset the fragment container below the status bar
-     *    (e.g. by applying `paddingTop = statusBarHeight` to the content view),
-     *    `rootTopInWindow` will equal `statusBarTop` and the effective inset will be **zero**
-     *    — no extra [View.translationY] is needed and no double-shift occurs.
-     *  - If the host has not applied any inset, `rootTopInWindow` will be 0 and
-     *    [View.translationY] will equal the full status-bar height.
-     *
-     * Why [View.translationY] instead of [View.updateLayoutParams]:
-     *  - [View.translationY] is a rendering transform; it calls [View.invalidate] only —
-     *    **no [View.requestLayout], no layout-traversal disruption**.
-     *  - [androidx.constraintlayout.widget.ConstraintSet.applyTo] only updates layout params;
-     *    it does **not** reset [View.translationY], so the offset survives every
-     *    [applyPagerConstraintFromCurrentSize] / [setupLandscapeBehavior] call.
-     */
     private fun applyCloseButtonStatusBarInset() {
         val root = binding.root
         val close = binding.close

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -402,7 +402,7 @@ class ReviewFragment private constructor(
             if (context.getFontScale() < 1.5) {
                 anchorView = paymentDetailsScrollview
             }
-            setTextMaxLines(3)
+            setTextMaxLines(if (resources.isLandscapeOrientation()) 1 else 3)
             setAction(getLocaleStringResource(net.gini.android.internal.payment.R.string.gps_snackbar_retry)) {
                 onRetry()
             }
@@ -633,6 +633,9 @@ class ReviewFragment private constructor(
     override fun onDestroyView() {
         mediator?.detach()
         mediator = null
+
+        errorSnackbar?.dismiss()
+        errorSnackbar = null
 
         preRKeyboardTracker?.let {
             view?.viewTreeObserver?.removeOnGlobalLayoutListener(it)

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -34,7 +34,6 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
-import dev.chrisbanes.insetter.applyInsetter
 import dev.chrisbanes.insetter.windowInsetTypesOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -159,7 +158,6 @@ class ReviewFragment private constructor(
         binding = GhsFragmentReviewBinding.inflate(inflater).apply {
             configureViews()
             configureOrientation()
-            applyInsets()
         }
         return binding.root
     }
@@ -228,53 +226,7 @@ class ReviewFragment private constructor(
             clone(binding.constraintRoot)
             constrainHeight(binding.pager.id, h)
             clear(binding.pager.id, ConstraintSet.BOTTOM)
-            
-            // HEAL-139: Apply Android 15+ close button position fix
-            applyAndroid15CloseButtonFix(this, binding.close.id)
-            
             applyTo(binding.constraintRoot)
-        }
-    }
-
-    /**
-     * Applies Android 15+ specific constraint fixes to lock the close button position.
-     * 
-     * On API 35+ (Android 15/16), ConstraintSet.applyTo() recalculates all constraints,
-     * causing the close button to shift during device rotation. This method adds a
-     * BOTTOM constraint and vertical bias (not present in the original XML layout) to
-     * create a "locked" position that keeps the button anchored to the top-right corner
-     * even during constraint recalculation.
-     * 
-     * This workaround should be removed if/when Android fixes the underlying constraint
-     * calculation issue in future API levels.
-     * 
-     * @param constraintSet The ConstraintSet to apply the close button fixes to
-     * @param closeButtonId The view ID of the close button
-     */
-    private fun applyAndroid15CloseButtonFix(constraintSet: ConstraintSet, closeButtonId: Int) {
-        if (Build.VERSION.SDK_INT >= 35) {
-            constraintSet.apply {
-                // Clear any potentially stale constraints
-                clear(closeButtonId, ConstraintSet.START)
-                clear(closeButtonId, ConstraintSet.BOTTOM)
-                
-                // Re-establish constraints: END+TOP from XML, plus BOTTOM+bias for position locking
-                connect(closeButtonId, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
-                connect(closeButtonId, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
-                connect(closeButtonId, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)  // Added: locks vertical position
-                setVerticalBias(closeButtonId, 0.0f)  // Added: 0.0 = top, 1.0 = bottom
-                
-                // Calculate margins: base margin + status bar inset
-                // This ensures proper spacing without relying on potentially incorrect current state
-                val baseMarginTop = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_small)
-                val baseMarginEnd = resources.getDimensionPixelSize(InternalPaymentR.dimen.gps_large)
-                
-                val windowInsets = ViewCompat.getRootWindowInsets(binding.root)
-                val statusBarInset = windowInsets?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
-                
-                setMargin(closeButtonId, ConstraintSet.TOP, baseMarginTop + statusBarInset)
-                setMargin(closeButtonId, ConstraintSet.END, baseMarginEnd)
-            }
         }
     }
 
@@ -431,24 +383,6 @@ class ReviewFragment private constructor(
         }
     }
 
-    private fun GhsFragmentReviewBinding.applyInsets() {
-        close.applyInsetter {
-            type(statusBars = true) {
-                margin(top = true)
-            }
-        }
-        
-        // For Android 15+, force the close button to stay at a fixed position
-        // by resetting any translation that might have been applied
-        if (Build.VERSION.SDK_INT >= 35) {
-            close.post {
-                close.translationX = 0f
-                close.translationY = 0f
-            }
-        }
-    }
-
-
     private fun GhsFragmentReviewBinding.setKeyboardAnimation() {
         ViewCompat.setWindowInsetsAnimationCallback(
             ghsPaymentDetails,
@@ -603,10 +537,6 @@ class ReviewFragment private constructor(
                             ?: 0) + bottomLayout.height)
                     )
                 )
-                
-                // Apply Android 15+ close button position fix in landscape
-                applyAndroid15CloseButtonFix(this, binding.close.id)
-                
                 applyTo(binding.constraintRoot)
             }
         }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -256,14 +256,17 @@ class ReviewFragment private constructor(
      *  - Runs in a quiet period (between frames) — not during any IME animation.
      */
     private fun applyCloseButtonStatusBarInsetOnce() {
-        binding.close.post {
+        val root = binding.root
+        val close = binding.close
+        close.post {
             if (!isAdded) return@post
-            val statusBarTop = ViewCompat.getRootWindowInsets(binding.root)
+            if (!close.isAttachedToWindow) return@post
+            val statusBarTop = ViewCompat.getRootWindowInsets(root)
                 ?.getInsets(WindowInsetsCompat.Type.statusBars())?.top ?: 0
             // translationY shifts the button visually without calling requestLayout().
             // The XML already provides the base top margin (gps_small); we only add the
             // status-bar height on top of that visual position.
-            binding.close.translationY = statusBarTop.toFloat()
+            close.translationY = statusBarTop.toFloat()
         }
     }
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/pager/DocumentPageAdapter.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/pager/DocumentPageAdapter.kt
@@ -14,7 +14,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.github.chrisbanes.photoview.PhotoView
-import dev.chrisbanes.insetter.applyInsetter
 import net.gini.android.core.api.Resource
 import android.view.View
 import net.gini.android.health.sdk.databinding.GhsItemPageHorizontalBinding
@@ -101,14 +100,6 @@ class HorizontalViewHolder(
     private val photoViewMatrix = Matrix()
 
     init {
-        imageView.applyInsetter {
-            type(statusBars = true) {
-                padding(top = true)
-            }
-            type(ime = true) {
-                padding(bottom = true)
-            }
-        }
 
         imageView.setOnViewTapListener { view, _, _ ->
             view.hideKeyboard()

--- a/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
+++ b/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
@@ -63,14 +63,14 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Reserves ≥18 % of screen height above the payment panel so the anchored
-             Snackbar (~48dp single-line) always has room to appear fully visible in landscape. -->
+        <!-- Reserves ≥28 % of screen height above the payment panel so the anchored
+             Snackbar (~68–80dp two-line) always has room to appear fully visible in landscape. -->
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/snackbar_guard_guideline"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.20" />
+            app:layout_constraintGuide_percent="0.25" />
 
         <ScrollView
             android:layout_width="match_parent"

--- a/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
+++ b/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
@@ -63,13 +63,25 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <!-- Reserves ≥18 % of screen height above the payment panel so the anchored
+             Snackbar (~48dp single-line) always has room to appear fully visible in landscape. -->
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/snackbar_guard_guideline"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.20" />
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/payment_details_scrollview"
             android:importantForAccessibility="yes"
             android:focusable="true"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintTop_toBottomOf="@id/snackbar_guard_guideline"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintVertical_bias="1.0"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 


### PR DESCRIPTION
This pull request removes workarounds and inset handling related to Android 15+ (API 35+) for the close button and image view in the `ReviewFragment` and `DocumentPageAdapter`. The changes simplify layout and inset management, removing custom fixes for constraint recalculation and window insets.

Layout and constraint handling simplification:

* Removed the `applyAndroid15CloseButtonFix` method and all its usages, eliminating the workaround for close button position on Android 15+ in `ReviewFragment.kt`. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L231-L280) [[2]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L606-L609)
* Removed the call to `applyInsets()` and its implementation in `GhsFragmentReviewBinding`, which previously handled insets for the close button and reset its translation for Android 15+. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L162) [[2]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L434-L451)

Inset handling cleanup:

* Removed usage of `applyInsetter` for the close button and image view, including import statements and initialization code in both `ReviewFragment.kt` and `DocumentPageAdapter.kt`. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L37) [[2]](diffhunk://#diff-03120904ab737beb0af5aebdc900ee7bfa2438ea2950265feef1cdcf801eeabcL17) [[3]](diffhunk://#diff-03120904ab737beb0af5aebdc900ee7bfa2438ea2950265feef1cdcf801eeabcL104-L111)

These changes streamline the code by removing device-specific layout fixes and inset handling, relying instead on the default behavior.