### PR TITLE
Heal 142 oops error message pop up not appearing in landscape mode

### DIFF
--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -402,7 +402,7 @@ class ReviewFragment private constructor(
             if (context.getFontScale() < 1.5) {
                 anchorView = paymentDetailsScrollview
             }
-            setTextMaxLines(if (resources.isLandscapeOrientation()) 1 else 3)
+            setTextMaxLines(if (resources.isLandscapeOrientation()) 2 else 3)
             setAction(getLocaleStringResource(net.gini.android.internal.payment.R.string.gps_snackbar_retry)) {
                 onRetry()
             }

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/ReviewFragment.kt
@@ -402,7 +402,7 @@ class ReviewFragment private constructor(
             if (context.getFontScale() < 1.5) {
                 anchorView = paymentDetailsScrollview
             }
-            setTextMaxLines(3)
+            setTextMaxLines(if (resources.isLandscapeOrientation()) 1 else 3)
             setAction(getLocaleStringResource(net.gini.android.internal.payment.R.string.gps_snackbar_retry)) {
                 onRetry()
             }
@@ -633,6 +633,9 @@ class ReviewFragment private constructor(
     override fun onDestroyView() {
         mediator?.detach()
         mediator = null
+
+        errorSnackbar?.dismiss()
+        errorSnackbar = null
 
         preRKeyboardTracker?.let {
             view?.viewTreeObserver?.removeOnGlobalLayoutListener(it)

--- a/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
+++ b/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
@@ -63,14 +63,14 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <!-- Reserves ≥18 % of screen height above the payment panel so the anchored
-             Snackbar (~48dp single-line) always has room to appear fully visible in landscape. -->
+        <!-- Reserves ≥28 % of screen height above the payment panel so the anchored
+             Snackbar (~68–80dp two-line) always has room to appear fully visible in landscape. -->
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/snackbar_guard_guideline"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.20" />
+            app:layout_constraintGuide_percent="0.25" />
 
         <ScrollView
             android:layout_width="match_parent"

--- a/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
+++ b/health-sdk/sdk/src/main/res/layout-land/ghs_fragment_review.xml
@@ -63,13 +63,25 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <!-- Reserves ≥18 % of screen height above the payment panel so the anchored
+             Snackbar (~48dp single-line) always has room to appear fully visible in landscape. -->
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/snackbar_guard_guideline"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.20" />
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/payment_details_scrollview"
             android:importantForAccessibility="yes"
             android:focusable="true"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintTop_toBottomOf="@id/snackbar_guard_guideline"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintVertical_bias="1.0"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 


### PR DESCRIPTION
This pull request refactors how system window insets (such as status bar and IME) are handled in the `ReviewFragment` and related views. The previous approach using the `applyInsetter` library has been removed in favor of a more robust, manual solution for positioning the close button and handling landscape layout edge cases, especially for Android 15+ (API 35+). Additionally, landscape layouts now ensure snackbars are always visible, and some minor UI and resource management improvements are included.

**Inset and Layout Handling Improvements:**

* Removed all usages of the `applyInsetter` library from `ReviewFragment.kt` and `DocumentPageAdapter.kt`, eliminating automatic inset handling in favor of manual control. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L37) [[2]](diffhunk://#diff-03120904ab737beb0af5aebdc900ee7bfa2438ea2950265feef1cdcf801eeabcL17) [[3]](diffhunk://#diff-03120904ab737beb0af5aebdc900ee7bfa2438ea2950265feef1cdcf801eeabcL104-L111) [[4]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L434-L451)
* Introduced a new method, `applyCloseButtonStatusBarInsetOnce`, which shifts the close button down by the status bar height using `translationY` after the first frame, ensuring the button remains correctly positioned on Android 15+ and preventing layout jumps during IME or orientation changes. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6R209-R210) [[2]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L231-R269)
* Removed the previous workaround that modified constraints for the close button during every layout update, simplifying the logic and improving reliability. [[1]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L231-R269) [[2]](diffhunk://#diff-f5398c03c1142e1821042cb439cfdb849302d639617db0ce75b6d37115b318a6L606-L609)

**Landscape and Snackbar UI Improvements:**

* Added a horizontal guideline (`snackbar_guard_guideline`) to the landscape layout XML to reserve vertical space above the payment panel, ensuring that anchored snackbars are always fully visible. The payment details scrollview is now constrained below this guideline.
* Adjusted the maximum number of lines for snackbar text to 1 in landscape orientation, improving visual consistency and preventing overlap.

**Resource Management:**

* Ensured that any error snackbar is dismissed and reference cleared when the fragment is destroyed, preventing memory leaks.