### PR TITLE
Pp 2378 add cx extractions flag as header

### DIFF
--- a/bank-api-library/library/src/test/java/net/gini/android/bank/api/BankApiDocumentRemoteSourceTest.kt
+++ b/bank-api-library/library/src/test/java/net/gini/android/bank/api/BankApiDocumentRemoteSourceTest.kt
@@ -170,14 +170,6 @@ class BankApiDocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getLayoutForDocument(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<ResponseBody> {
-            // Is tested in core api library
-            return Response.success(null)
-        }
-
         override suspend fun getPaymentRequest(
             bearer: Map<String, String>,
             id: String

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.kt
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.kt
@@ -237,6 +237,7 @@ internal constructor(
         }
 
         val uploadMetadata = document.generateUploadMetadata(context)
+        val productTagValue = runCatching { GiniCapture.getInstance().productTag.value }.getOrNull()
 
         val partialDocumentResource = giniBankApi.documentManager.createPartialDocument(
             document = documentData,
@@ -245,8 +246,10 @@ internal constructor(
             documentType = null,
             documentMetadata?.copy()?.apply {
                 setUploadMetadata(uploadMetadata)
+                productTagValue?.let { setProductTag(it) }
             } ?: DocumentMetadata().apply {
                 setUploadMetadata(uploadMetadata)
+                productTagValue?.let { setProductTag(it) }
             }
         )
 
@@ -343,8 +346,16 @@ internal constructor(
 
         analyzedGiniApiDocument = null
 
+        val productTagValue = runCatching { GiniCapture.getInstance().productTag.value }.getOrNull()
+        val compositeDocumentMetadata = DocumentMetadata().apply {
+            productTagValue?.let { setProductTag(it) }
+        }
+
         val compositeDocumentAndExtractionsResource =
-            giniBankApi.documentManager.createCompositeDocument(giniApiDocumentRotationMap)
+            giniBankApi.documentManager.createCompositeDocument(
+                giniApiDocumentRotationMap,
+                documentMetadata = compositeDocumentMetadata
+            )
                 .mapSuccess { compositeDocumentResource ->
                     val compositeDocument = compositeDocumentResource.data
                     giniApiDocuments[compositeDocument.id] = compositeDocument

--- a/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
+++ b/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
@@ -74,6 +74,7 @@ class GiniCaptureDefaultNetworkServiceTest {
         coEvery {
             documentManager.createCompositeDocument(
                 any<LinkedHashMap<net.gini.android.core.api.models.Document, Int>>(),
+                any(),
                 any()
             )
         } returns Resource.Success(compositeDocument)

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
@@ -17,13 +17,13 @@ sealed class ProductTag(val value: String) : Parcelable {
      * This is the default behavior.
      */
     @Parcelize
-    object SepaExtractions : ProductTag("sepa-extractions")
+    object SepaExtractions : ProductTag("sepaExtractions")
 
     /**
      * Cross-border extractions - shows compound extractions.
      */
     @Parcelize
-    object CxExtractions : ProductTag("cx-extractions")
+    object CxExtractions : ProductTag("cxExtractions")
 
     /**
      * Auto-detect extractions.
@@ -31,7 +31,7 @@ sealed class ProductTag(val value: String) : Parcelable {
      * Note: This option is reserved for future use and is not yet available for customer use.
      */
     @Parcelize
-    object AutoDetectExtractions : ProductTag("auto-detect-extractions")
+    object AutoDetectExtractions : ProductTag("autoDetectExtractions")
 
     /**
      * Custom product tag for extensibility.

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/ProductTagTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/ProductTagTest.kt
@@ -1,0 +1,14 @@
+package net.gini.android.capture
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ProductTagTest {
+
+    @Test
+    fun `built in product tags use backend values`() {
+        assertThat(ProductTag.SepaExtractions.value).isEqualTo("sepaExtractions")
+        assertThat(ProductTag.CxExtractions.value).isEqualTo("cxExtractions")
+        assertThat(ProductTag.AutoDetectExtractions.value).isEqualTo("autoDetectExtractions")
+    }
+}

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentManager.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentManager.kt
@@ -72,7 +72,23 @@ abstract class DocumentManager<out DR: DocumentRepository<E>, E: ExtractionsCont
         documents: List<Document>,
         documentType: DocumentType? = null
     ): Resource<Document> =
-        documentRepository.createCompositeDocument(documents, documentType)
+        createCompositeDocument(documents, documentType, null)
+
+    /**
+     * Creates a new Gini composite document.
+     *
+     * @param documents         A list of partial documents which should be part of a multi-page document
+     * @param documentType      Optional a document type hint. See the documentation for the document type hints for
+     *                          possible values
+     * @param documentMetadata  Optional metadata to be sent as request headers with the submission
+     * @return [Resource] with the [Document] instance or information about the error
+     */
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentType? = null,
+        documentMetadata: DocumentMetadata? = null
+    ): Resource<Document> =
+        documentRepository.createCompositeDocument(documents, documentType, documentMetadata)
 
     /**
      * Creates a new Gini composite document. The input Map must contain the partial documents as keys. These will be
@@ -88,7 +104,25 @@ abstract class DocumentManager<out DR: DocumentRepository<E>, E: ExtractionsCont
         documentRotationMap: LinkedHashMap<Document, Int>,
         documentType: DocumentType? = null
     ): Resource<Document> =
-        documentRepository.createCompositeDocument(documentRotationMap, documentType)
+        createCompositeDocument(documentRotationMap, documentType, null)
+
+    /**
+     * Creates a new Gini composite document. The input Map must contain the partial documents as keys. These will be
+     * part of the multi-page document. The value for each partial document key is the amount in degrees the document
+     * has been rotated by the user.
+     *
+     * @param documentRotationMap A map of partial documents and their rotation in degrees
+     * @param documentType        Optional a document type hint. See the documentation for the document type hints for
+     *                            possible values
+     * @param documentMetadata    Optional metadata to be sent as request headers with the submission
+     * @return [Resource] with the [Document] instance or information about the error
+     */
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentType? = null,
+        documentMetadata: DocumentMetadata? = null
+    ): Resource<Document> =
+        documentRepository.createCompositeDocument(documentRotationMap, documentType, documentMetadata)
 
     /**
      * Get the document with the given unique identifier.

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
@@ -28,6 +28,8 @@ public class DocumentMetadata {
     public static final String BRANCH_ID_HEADER_FIELD_NAME = HEADER_FIELD_NAME_PREFIX + "BranchId";
     @VisibleForTesting
     public static final String UPLOAD_METADATA_HEADER_FIELD_NAME = HEADER_FIELD_NAME_PREFIX + "Upload";
+    @VisibleForTesting
+    public static final String PRODUCT_TAG_HEADER_FIELD_NAME = "x-document-metadata-product-tag";
 
 
     private final Map<String, String> mMetadataMap = new HashMap<>();
@@ -59,7 +61,7 @@ public class DocumentMetadata {
      */
     public void setBranchId(@NonNull final String branchId) throws IllegalArgumentException {
         if (isASCIIEncodable(branchId)) {
-            mMetadataMap.put(BRANCH_ID_HEADER_FIELD_NAME, branchId);
+            putMetadata(BRANCH_ID_HEADER_FIELD_NAME, branchId);
         } else {
             throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + branchId);
         }
@@ -72,9 +74,23 @@ public class DocumentMetadata {
      */
     public void setUploadMetadata(@NonNull final String uploadMetadata) {
         if (isASCIIEncodable(uploadMetadata)) {
-            mMetadataMap.put(UPLOAD_METADATA_HEADER_FIELD_NAME, uploadMetadata);
+            putMetadata(UPLOAD_METADATA_HEADER_FIELD_NAME, uploadMetadata);
         } else {
             throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + uploadMetadata);
+        }
+    }
+
+    /**
+     * Set the product tag to be sent to backend for document submissions.
+     *
+     * @param productTag identifies which extraction type should be used
+     * @throws IllegalArgumentException if the productTag string cannot be encoded as ASCII
+     */
+    public void setProductTag(@NonNull final String productTag) {
+        if (isASCIIEncodable(productTag)) {
+            putMetadata(PRODUCT_TAG_HEADER_FIELD_NAME, productTag);
+        } else {
+            throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + productTag);
         }
     }
 
@@ -110,7 +126,7 @@ public class DocumentMetadata {
         } else {
             completeName = HEADER_FIELD_NAME_PREFIX + name;
         }
-        mMetadataMap.put(completeName, value);
+        putMetadata(completeName, value);
     }
 
     /**
@@ -120,8 +136,12 @@ public class DocumentMetadata {
      */
     public DocumentMetadata copy() {
         DocumentMetadata copy = new DocumentMetadata();
-        mMetadataMap.forEach((key, value) -> copy.add(key, value));
+        mMetadataMap.forEach(copy::putMetadata);
         return copy;
+    }
+
+    private void putMetadata(@NonNull final String name, @NonNull final String value) {
+        mMetadataMap.put(name, value);
     }
 
     @NonNull

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
@@ -82,7 +82,17 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
             }
         }
 
-    suspend fun createCompositeDocument(documents: List<Document>, documentType: DocumentManager.DocumentType?): Resource<Document> =
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentManager.DocumentType?
+    ): Resource<Document> =
+        createCompositeDocument(documents, documentType, null)
+
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentManager.DocumentType?,
+        documentMetadata: DocumentMetadata?
+    ): Resource<Document> =
         withAccessToken { accessToken ->
             wrapInResource {
                 val uri = documentRemoteSource.uploadDocument(
@@ -91,13 +101,23 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
                     giniApiType.giniCompositeJsonMediaType,
                     null,
                     documentType?.apiDoctypeHint,
-                    null
+                    documentMetadata?.metadata
                 )
                 getDocumentInternal(accessToken, uri)
             }
         }
 
-    suspend fun createCompositeDocument(documentRotationMap: LinkedHashMap<Document, Int>, documentType: DocumentManager.DocumentType?): Resource<Document> =
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentManager.DocumentType?
+    ): Resource<Document> =
+        createCompositeDocument(documentRotationMap, documentType, null)
+
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentManager.DocumentType?,
+        documentMetadata: DocumentMetadata?
+    ): Resource<Document> =
         withAccessToken { accessToken ->
             wrapInResource {
                 val uri = documentRemoteSource.uploadDocument(
@@ -106,7 +126,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
                     giniApiType.giniCompositeJsonMediaType,
                     null,
                     documentType?.apiDoctypeHint,
-                    null
+                    documentMetadata?.metadata
                 )
                 getDocumentInternal(accessToken, uri)
             }

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentMetadataUnitTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentMetadataUnitTest.kt
@@ -1,0 +1,33 @@
+package net.gini.android.core.api
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DocumentMetadataUnitTest {
+
+    @Test
+    fun `setProductTag uses backend header name`() {
+        val documentMetadata = DocumentMetadata()
+
+        documentMetadata.setProductTag("sepaExtractions")
+
+        assertThat(documentMetadata.metadata).containsEntry(
+            DocumentMetadata.PRODUCT_TAG_HEADER_FIELD_NAME,
+            "sepaExtractions"
+        )
+    }
+
+    @Test
+    fun `copy preserves product tag header name`() {
+        val documentMetadata = DocumentMetadata().apply {
+            setProductTag("cxExtractions")
+        }
+
+        val copy = documentMetadata.copy()
+
+        assertThat(copy.metadata).containsEntry(
+            DocumentMetadata.PRODUCT_TAG_HEADER_FIELD_NAME,
+            "cxExtractions"
+        )
+    }
+}

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
@@ -86,7 +86,7 @@ class DocumentRemoteSourceTest {
         val accessToken = UUID.randomUUID().toString()
         val expectedAuthorizationHeader = "Bearer $accessToken"
         verifyAuthorizationHeader(expectedAuthorizationHeader, this) {
-            getLayout(accessToken, "")
+            getDocumentLayout(accessToken, "")
         }
     }
 
@@ -194,12 +194,20 @@ class DocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getLayoutForDocument(
+        override suspend fun getDocumentLayout(
             bearer: Map<String, String>,
             documentId: String
-        ): Response<ResponseBody> {
+        ): Response<DocumentLayoutResponse> {
             bearerAuthHeader = bearer["Authorization"]
-            return Response.success("response".toResponseBody())
+            return Response.success(DocumentLayoutResponse(emptyList()))
+        }
+
+        override suspend fun getDocumentPages(
+            bearer: Map<String, String>,
+            documentId: String
+        ): Response<List<DocumentPageResponse>> {
+            bearerAuthHeader = bearer["Authorization"]
+            return Response.success(emptyList())
         }
 
         override suspend fun getPaymentRequest(
@@ -237,20 +245,5 @@ class DocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getDocumentLayout(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<DocumentLayoutResponse> {
-            bearerAuthHeader = bearer["Authorization"]
-            return Response.success(null)
-        }
-
-        override suspend fun getDocumentPages(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<List<DocumentPageResponse>> {
-            bearerAuthHeader = bearer["Authorization"]
-            return Response.success(null)
-        }
     }
 }

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
@@ -82,7 +82,7 @@ class DocumentRemoteSourceTest {
     }
 
     @Test
-    fun `sets bearer authorization header with capital case 'Bearer' in getLayout`() = runTest {
+    fun `sets bearer authorization header with capital case 'Bearer' in getDocumentLayout`() = runTest {
         val accessToken = UUID.randomUUID().toString()
         val expectedAuthorizationHeader = "Bearer $accessToken"
         verifyAuthorizationHeader(expectedAuthorizationHeader, this) {


### PR DESCRIPTION
Add x-document-metadata-product-tag header to every document submission

Background

The backend now supports a x-document-metadata-product-tag request header to identify which extraction type is being used. The default value is sepaExtractions.

Changes

capture-sdk/sdk — ProductTag.kt
Updated built-in values to match the backend contract:

 - sepa-extractions → sepaExtractions
 - cx-extractions → cxExtractions
 - auto-detect-extractions → autoDetectExtractions

core-api-library/library — DocumentMetadata.java
Added PRODUCT_TAG_HEADER_FIELD_NAME constant (x-document-metadata-product-tag) and a setProductTag(String) method so callers can attach the header without touching raw
maps.

core-api-library/library — DocumentRepository.kt / DocumentManager.kt
Extended createCompositeDocument() with an optional documentMetadata parameter (new overloads; old signatures delegate to them with null for full backward
compatibility). Previously composite submissions always sent null metadata, making it impossible to attach any header.

capture-sdk/default-network — GiniCaptureDefaultNetworkService.kt 

 - upload() — reads GiniCapture.getInstance().productTag (via runCatching for safety) and calls setProductTag() on the DocumentMetadata before every partial document 
upload (single-page capture, file import, QR code flow).
 - analyze() — builds a DocumentMetadata with the product tag and passes it to createCompositeDocument(), covering multi-page submissions.

Tests 

 - Added ProductTagTest — asserts new built-in ProductTag values match the backend contract.
 - Added DocumentMetadataUnitTest — asserts setProductTag() uses the exact header key and survives copy().
 - Fixed pre-existing broken test shims in DocumentRemoteSourceTest and BankApiDocumentRemoteSourceTest (stale getLayoutForDocument override that no longer existed in 
the interface).
 - Updated GiniCaptureDefaultNetworkServiceTest mock to match the new 3-parameter createCompositeDocument overload.