### PR TITLE
Pp 2379 extend extraction result model for cx labels

### DIFF
--- a/bank-api-library/library/src/test/java/net/gini/android/bank/api/BankApiDocumentRemoteSourceTest.kt
+++ b/bank-api-library/library/src/test/java/net/gini/android/bank/api/BankApiDocumentRemoteSourceTest.kt
@@ -170,14 +170,6 @@ class BankApiDocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getLayoutForDocument(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<ResponseBody> {
-            // Is tested in core api library
-            return Response.success(null)
-        }
-
         override suspend fun getPaymentRequest(
             bearer: Map<String, String>,
             id: String

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
@@ -156,7 +156,7 @@ data class ExampleAppBankConfiguration(
     val isCustomHttpClientEnabled: Boolean = false,
 
     // product tag
-    val productTag: ProductTag = ProductTag.CxExtractions,
+    val productTag: ProductTag = ProductTag.SepaExtractions,
 
 ) : Parcelable {
 

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/data/ExampleAppBankConfiguration.kt
@@ -156,7 +156,7 @@ data class ExampleAppBankConfiguration(
     val isCustomHttpClientEnabled: Boolean = false,
 
     // product tag
-    val productTag: ProductTag = ProductTag.SepaExtractions,
+    val productTag: ProductTag = ProductTag.CxExtractions,
 
 ) : Parcelable {
 

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowFragment.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/CaptureFlowFragment.kt
@@ -37,9 +37,11 @@ import net.gini.android.bank.sdk.transactiondocs.internal.usecase.TransactionDoc
 import net.gini.android.bank.sdk.transactiondocs.internal.usecase.TransactionDocDialogConfirmAttachUseCase
 import net.gini.android.bank.sdk.transactiondocs.ui.dialog.attachdoc.AttachDocumentToTransactionDialog
 import net.gini.android.bank.sdk.util.disallowScreenshots
+import net.gini.android.bank.sdk.capture.extractions.CxExtractionsFilter
 import net.gini.android.capture.CaptureSDKResult
 import net.gini.android.capture.Document
 import net.gini.android.capture.GiniCapture
+import net.gini.android.capture.ProductTag
 import net.gini.android.capture.GiniCaptureFragment
 import net.gini.android.capture.GiniCaptureFragmentDirections
 import net.gini.android.capture.GiniCaptureFragmentListener
@@ -219,15 +221,22 @@ class CaptureFlowFragment(private val openWithDocument: Document? = null) :
     }
 
     private fun processOnFinishedResultSuccessState(result: CaptureSDKResult.Success) {
+        val filteredResult = if (GiniCapture.hasInstance() &&
+            GiniCapture.getInstance().productTag is ProductTag.CxExtractions
+        ) {
+            CxExtractionsFilter.filterForCxExtractions(result)
+        } else {
+            result
+        }
         when {
             GiniBank.getCaptureConfiguration()?.returnAssistantEnabled == true -> {
                 try {
-                    tryShowingReturnAssistant(result)
+                    tryShowingReturnAssistant(filteredResult)
                     return
                 } catch (notUsed: DigitalInvoiceException) {
-                    tryShowingSkontoScreen(result) {
+                    tryShowingSkontoScreen(filteredResult) {
                         tryShowAttachDocToTransactionDialog {
-                            finishWithResult(interceptSuccessResult(result).toCaptureResult())
+                            finishWithResult(interceptSuccessResult(filteredResult).toCaptureResult())
                         }
                     }
                     return
@@ -235,9 +244,9 @@ class CaptureFlowFragment(private val openWithDocument: Document? = null) :
             }
 
             GiniBank.getCaptureConfiguration()?.skontoEnabled == true -> {
-                tryShowingSkontoScreen(result) {
+                tryShowingSkontoScreen(filteredResult) {
                     tryShowAttachDocToTransactionDialog {
-                        finishWithResult(interceptSuccessResult(result).toCaptureResult())
+                        finishWithResult(interceptSuccessResult(filteredResult).toCaptureResult())
                     }
                 }
                 return
@@ -245,7 +254,7 @@ class CaptureFlowFragment(private val openWithDocument: Document? = null) :
 
             else -> {
                 tryShowAttachDocToTransactionDialog {
-                    finishWithResult(interceptSuccessResult(result).toCaptureResult())
+                    finishWithResult(interceptSuccessResult(filteredResult).toCaptureResult())
                 }
 
             }
@@ -396,6 +405,15 @@ class CaptureFlowFragment(private val openWithDocument: Document? = null) :
     }
 
     private fun interceptSuccessResult(result: CaptureSDKResult.Success): CaptureSDKResult {
+        if (GiniCapture.hasInstance() &&
+            GiniCapture.getInstance().productTag is ProductTag.CxExtractions
+        ) {
+            return if (result.compoundExtractions.containsKey(CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY)) {
+                result
+            } else {
+                CaptureSDKResult.Empty
+            }
+        }
         return if (result.specificExtractions.isEmpty() ||
             !pay5ExtractionsAvailable(result.specificExtractions) &&
             !epsPaymentAvailable(result.specificExtractions)

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilter.kt
@@ -1,0 +1,60 @@
+package net.gini.android.bank.sdk.capture.extractions
+
+import net.gini.android.capture.CaptureSDKResult
+import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
+import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
+
+/**
+ * Filters extraction results when [net.gini.android.capture.ProductTag.CxExtractions] is active.
+ *
+ * For cross-border payments, the Gini API returns payment data in the [CROSS_BORDER_PAYMENT_KEY]
+ * compound extraction. SEPA-specific flat extractions, payment hint extractions, and compound
+ * extractions tied to Skonto and Return Assistant are not applicable and are removed.
+ */
+internal object CxExtractionsFilter {
+
+    internal const val CROSS_BORDER_PAYMENT_KEY = "crossBorderPayment"
+
+    private val SEPA_SPECIFIC_EXTRACTION_KEYS = setOf(
+        "iban",
+        "bic",
+        "amountToPay",
+        "paymentRecipient",
+        "paymentReference",
+        "paymentPurpose",
+        "instantPayment",
+    )
+
+    private val PAYMENT_HINTS_EXTRACTION_KEYS = setOf(
+        "paymentDueDate",
+        "creditNote",
+    )
+
+    private val SEPA_COMPOUND_EXTRACTION_KEYS = setOf(
+        "skontoDiscounts",
+        "lineItems",
+    )
+
+    /**
+     * Returns a new [CaptureSDKResult.Success] with all SEPA-specific, payment-hints, and
+     * Skonto/Return-Assistant extractions removed, leaving [CROSS_BORDER_PAYMENT_KEY] and any
+     * other non-SEPA compound extractions intact.
+     */
+    fun filterForCxExtractions(result: CaptureSDKResult.Success): CaptureSDKResult.Success {
+        val filteredSpecific: Map<String, GiniCaptureSpecificExtraction> =
+            result.specificExtractions.filterKeys { key ->
+                key !in SEPA_SPECIFIC_EXTRACTION_KEYS && key !in PAYMENT_HINTS_EXTRACTION_KEYS
+            }
+
+        val filteredCompound: Map<String, GiniCaptureCompoundExtraction> =
+            result.compoundExtractions.filterKeys { key ->
+                key !in SEPA_COMPOUND_EXTRACTION_KEYS
+            }
+
+        return CaptureSDKResult.Success(
+            specificExtractions = filteredSpecific,
+            compoundExtractions = filteredCompound,
+            returnReasons = emptyList(),
+        )
+    }
+}

--- a/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilter.kt
+++ b/bank-sdk/sdk/src/main/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilter.kt
@@ -15,7 +15,7 @@ internal object CxExtractionsFilter {
 
     internal const val CROSS_BORDER_PAYMENT_KEY = "crossBorderPayment"
 
-    private val SEPA_SPECIFIC_EXTRACTION_KEYS = setOf(
+    private val sepaSpecificExtractionKeys = setOf(
         "iban",
         "bic",
         "amountToPay",
@@ -25,12 +25,12 @@ internal object CxExtractionsFilter {
         "instantPayment",
     )
 
-    private val PAYMENT_HINTS_EXTRACTION_KEYS = setOf(
+    private val paymentHintsExtractionKeys = setOf(
         "paymentDueDate",
         "creditNote",
     )
 
-    private val SEPA_COMPOUND_EXTRACTION_KEYS = setOf(
+    private val sepaCompoundExtractionKeys = setOf(
         "skontoDiscounts",
         "lineItems",
     )
@@ -43,12 +43,12 @@ internal object CxExtractionsFilter {
     fun filterForCxExtractions(result: CaptureSDKResult.Success): CaptureSDKResult.Success {
         val filteredSpecific: Map<String, GiniCaptureSpecificExtraction> =
             result.specificExtractions.filterKeys { key ->
-                key !in SEPA_SPECIFIC_EXTRACTION_KEYS && key !in PAYMENT_HINTS_EXTRACTION_KEYS
+                key !in sepaSpecificExtractionKeys && key !in paymentHintsExtractionKeys
             }
 
         val filteredCompound: Map<String, GiniCaptureCompoundExtraction> =
             result.compoundExtractions.filterKeys { key ->
-                key !in SEPA_COMPOUND_EXTRACTION_KEYS
+                key !in sepaCompoundExtractionKeys
             }
 
         return CaptureSDKResult.Success(

--- a/bank-sdk/sdk/src/test/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilterTest.kt
+++ b/bank-sdk/sdk/src/test/java/net/gini/android/bank/sdk/capture/extractions/CxExtractionsFilterTest.kt
@@ -1,0 +1,175 @@
+package net.gini.android.bank.sdk.capture.extractions
+
+import net.gini.android.capture.CaptureSDKResult
+import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction
+import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CxExtractionsFilterTest {
+
+    // region filterForCxExtractions — specific extractions
+
+    @Test
+    fun `SEPA specific extractions are removed`() {
+        val sepaKeys = listOf("iban", "bic", "amountToPay", "paymentRecipient", "paymentReference",
+            "paymentPurpose", "instantPayment")
+        val input = successResult(
+            specific = sepaKeys.associateWith { makeSpecific(it) }
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertTrue(
+            "Expected all SEPA specific extractions to be removed",
+            filtered.specificExtractions.isEmpty()
+        )
+    }
+
+    @Test
+    fun `payment hints specific extractions are removed`() {
+        val input = successResult(
+            specific = mapOf(
+                "paymentDueDate" to makeSpecific("paymentDueDate"),
+                "creditNote" to makeSpecific("creditNote"),
+            )
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertTrue(
+            "Expected paymentDueDate and creditNote to be removed",
+            filtered.specificExtractions.isEmpty()
+        )
+    }
+
+    @Test
+    fun `non-SEPA specific extractions are kept`() {
+        val input = successResult(
+            specific = mapOf(
+                "epsPaymentQRCodeUrl" to makeSpecific("epsPaymentQRCodeUrl"),
+                "someOtherExtraction" to makeSpecific("someOtherExtraction"),
+            )
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertEquals(2, filtered.specificExtractions.size)
+        assertTrue(filtered.specificExtractions.containsKey("epsPaymentQRCodeUrl"))
+        assertTrue(filtered.specificExtractions.containsKey("someOtherExtraction"))
+    }
+
+    @Test
+    fun `SEPA and non-SEPA specific extractions are mixed - only SEPA removed`() {
+        val input = successResult(
+            specific = mapOf(
+                "iban" to makeSpecific("iban"),
+                "amountToPay" to makeSpecific("amountToPay"),
+                "epsPaymentQRCodeUrl" to makeSpecific("epsPaymentQRCodeUrl"),
+                "paymentDueDate" to makeSpecific("paymentDueDate"),
+            )
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertEquals(1, filtered.specificExtractions.size)
+        assertTrue(filtered.specificExtractions.containsKey("epsPaymentQRCodeUrl"))
+    }
+
+    // endregion
+
+    // region filterForCxExtractions — compound extractions
+
+    @Test
+    fun `skontoDiscounts compound extraction is removed`() {
+        val input = successResult(
+            compound = mapOf("skontoDiscounts" to makeCompound("skontoDiscounts"))
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertFalse(filtered.compoundExtractions.containsKey("skontoDiscounts"))
+    }
+
+    @Test
+    fun `lineItems compound extraction is removed`() {
+        val input = successResult(
+            compound = mapOf("lineItems" to makeCompound("lineItems"))
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertFalse(filtered.compoundExtractions.containsKey("lineItems"))
+    }
+
+    @Test
+    fun `crossBorderPayment compound extraction is kept`() {
+        val input = successResult(
+            compound = mapOf(
+                CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY to makeCompound(
+                    CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY
+                )
+            )
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertTrue(filtered.compoundExtractions.containsKey(CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY))
+    }
+
+    @Test
+    fun `crossBorderPayment kept while skonto and lineItems are removed`() {
+        val input = successResult(
+            compound = mapOf(
+                "skontoDiscounts" to makeCompound("skontoDiscounts"),
+                "lineItems" to makeCompound("lineItems"),
+                CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY to makeCompound(
+                    CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY
+                ),
+            )
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertEquals(1, filtered.compoundExtractions.size)
+        assertTrue(filtered.compoundExtractions.containsKey(CxExtractionsFilter.CROSS_BORDER_PAYMENT_KEY))
+    }
+
+    // endregion
+
+    // region filterForCxExtractions — returnReasons preserved
+
+    @Test
+    fun `returnReasons are cleared after filtering`() {
+        val input = successResult(
+            specific = mapOf("iban" to makeSpecific("iban")),
+        )
+
+        val filtered = CxExtractionsFilter.filterForCxExtractions(input)
+
+        assertTrue("Expected returnReasons to be empty", filtered.returnReasons.isEmpty())
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun makeSpecific(name: String) =
+        GiniCaptureSpecificExtraction(name, "value", "text", null, emptyList())
+
+    private fun makeCompound(name: String) =
+        GiniCaptureCompoundExtraction(name, emptyList())
+
+    private fun successResult(
+        specific: Map<String, GiniCaptureSpecificExtraction> = emptyMap(),
+        compound: Map<String, GiniCaptureCompoundExtraction> = emptyMap(),
+    ) = CaptureSDKResult.Success(
+        specificExtractions = specific,
+        compoundExtractions = compound,
+        returnReasons = emptyList(),
+    )
+
+    // endregion
+}

--- a/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.kt
+++ b/capture-sdk/default-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.kt
@@ -237,6 +237,7 @@ internal constructor(
         }
 
         val uploadMetadata = document.generateUploadMetadata(context)
+        val productTagValue = runCatching { GiniCapture.getInstance().productTag.value }.getOrNull()
 
         val partialDocumentResource = giniBankApi.documentManager.createPartialDocument(
             document = documentData,
@@ -245,8 +246,10 @@ internal constructor(
             documentType = null,
             documentMetadata?.copy()?.apply {
                 setUploadMetadata(uploadMetadata)
+                productTagValue?.let { setProductTag(it) }
             } ?: DocumentMetadata().apply {
                 setUploadMetadata(uploadMetadata)
+                productTagValue?.let { setProductTag(it) }
             }
         )
 
@@ -343,8 +346,16 @@ internal constructor(
 
         analyzedGiniApiDocument = null
 
+        val productTagValue = runCatching { GiniCapture.getInstance().productTag.value }.getOrNull()
+        val compositeDocumentMetadata = DocumentMetadata().apply {
+            productTagValue?.let { setProductTag(it) }
+        }
+
         val compositeDocumentAndExtractionsResource =
-            giniBankApi.documentManager.createCompositeDocument(giniApiDocumentRotationMap)
+            giniBankApi.documentManager.createCompositeDocument(
+                giniApiDocumentRotationMap,
+                documentMetadata = compositeDocumentMetadata
+            )
                 .mapSuccess { compositeDocumentResource ->
                     val compositeDocument = compositeDocumentResource.data
                     giniApiDocuments[compositeDocument.id] = compositeDocument

--- a/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
+++ b/capture-sdk/default-network/src/test/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkServiceTest.kt
@@ -74,6 +74,7 @@ class GiniCaptureDefaultNetworkServiceTest {
         coEvery {
             documentManager.createCompositeDocument(
                 any<LinkedHashMap<net.gini.android.core.api.models.Document, Int>>(),
+                any(),
                 any()
             )
         } returns Resource.Success(compositeDocument)

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/ProductTag.kt
@@ -17,13 +17,13 @@ sealed class ProductTag(val value: String) : Parcelable {
      * This is the default behavior.
      */
     @Parcelize
-    object SepaExtractions : ProductTag("sepa-extractions")
+    object SepaExtractions : ProductTag("sepaExtractions")
 
     /**
      * Cross-border extractions - shows compound extractions.
      */
     @Parcelize
-    object CxExtractions : ProductTag("cx-extractions")
+    object CxExtractions : ProductTag("cxExtractions")
 
     /**
      * Auto-detect extractions.
@@ -31,7 +31,7 @@ sealed class ProductTag(val value: String) : Parcelable {
      * Note: This option is reserved for future use and is not yet available for customer use.
      */
     @Parcelize
-    object AutoDetectExtractions : ProductTag("auto-detect-extractions")
+    object AutoDetectExtractions : ProductTag("autoDetectExtractions")
 
     /**
      * Custom product tag for extensibility.

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/ProductTagTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/ProductTagTest.kt
@@ -1,0 +1,14 @@
+package net.gini.android.capture
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ProductTagTest {
+
+    @Test
+    fun `built in product tags use backend values`() {
+        assertThat(ProductTag.SepaExtractions.value).isEqualTo("sepaExtractions")
+        assertThat(ProductTag.CxExtractions.value).isEqualTo("cxExtractions")
+        assertThat(ProductTag.AutoDetectExtractions.value).isEqualTo("autoDetectExtractions")
+    }
+}

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentManager.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentManager.kt
@@ -72,7 +72,23 @@ abstract class DocumentManager<out DR: DocumentRepository<E>, E: ExtractionsCont
         documents: List<Document>,
         documentType: DocumentType? = null
     ): Resource<Document> =
-        documentRepository.createCompositeDocument(documents, documentType)
+        createCompositeDocument(documents, documentType, null)
+
+    /**
+     * Creates a new Gini composite document.
+     *
+     * @param documents         A list of partial documents which should be part of a multi-page document
+     * @param documentType      Optional a document type hint. See the documentation for the document type hints for
+     *                          possible values
+     * @param documentMetadata  Optional metadata to be sent as request headers with the submission
+     * @return [Resource] with the [Document] instance or information about the error
+     */
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentType? = null,
+        documentMetadata: DocumentMetadata? = null
+    ): Resource<Document> =
+        documentRepository.createCompositeDocument(documents, documentType, documentMetadata)
 
     /**
      * Creates a new Gini composite document. The input Map must contain the partial documents as keys. These will be
@@ -88,7 +104,25 @@ abstract class DocumentManager<out DR: DocumentRepository<E>, E: ExtractionsCont
         documentRotationMap: LinkedHashMap<Document, Int>,
         documentType: DocumentType? = null
     ): Resource<Document> =
-        documentRepository.createCompositeDocument(documentRotationMap, documentType)
+        createCompositeDocument(documentRotationMap, documentType, null)
+
+    /**
+     * Creates a new Gini composite document. The input Map must contain the partial documents as keys. These will be
+     * part of the multi-page document. The value for each partial document key is the amount in degrees the document
+     * has been rotated by the user.
+     *
+     * @param documentRotationMap A map of partial documents and their rotation in degrees
+     * @param documentType        Optional a document type hint. See the documentation for the document type hints for
+     *                            possible values
+     * @param documentMetadata    Optional metadata to be sent as request headers with the submission
+     * @return [Resource] with the [Document] instance or information about the error
+     */
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentType? = null,
+        documentMetadata: DocumentMetadata? = null
+    ): Resource<Document> =
+        documentRepository.createCompositeDocument(documentRotationMap, documentType, documentMetadata)
 
     /**
      * Get the document with the given unique identifier.

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
@@ -28,6 +28,8 @@ public class DocumentMetadata {
     public static final String BRANCH_ID_HEADER_FIELD_NAME = HEADER_FIELD_NAME_PREFIX + "BranchId";
     @VisibleForTesting
     public static final String UPLOAD_METADATA_HEADER_FIELD_NAME = HEADER_FIELD_NAME_PREFIX + "Upload";
+    @VisibleForTesting
+    public static final String PRODUCT_TAG_HEADER_FIELD_NAME = "x-document-metadata-product-tag";
 
 
     private final Map<String, String> mMetadataMap = new HashMap<>();
@@ -59,7 +61,7 @@ public class DocumentMetadata {
      */
     public void setBranchId(@NonNull final String branchId) throws IllegalArgumentException {
         if (isASCIIEncodable(branchId)) {
-            mMetadataMap.put(BRANCH_ID_HEADER_FIELD_NAME, branchId);
+            putMetadata(BRANCH_ID_HEADER_FIELD_NAME, branchId);
         } else {
             throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + branchId);
         }
@@ -72,9 +74,23 @@ public class DocumentMetadata {
      */
     public void setUploadMetadata(@NonNull final String uploadMetadata) {
         if (isASCIIEncodable(uploadMetadata)) {
-            mMetadataMap.put(UPLOAD_METADATA_HEADER_FIELD_NAME, uploadMetadata);
+            putMetadata(UPLOAD_METADATA_HEADER_FIELD_NAME, uploadMetadata);
         } else {
             throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + uploadMetadata);
+        }
+    }
+
+    /**
+     * Set the product tag to be sent to backend for document submissions.
+     *
+     * @param productTag identifies which extraction type should be used
+     * @throws IllegalArgumentException if the productTag string cannot be encoded as ASCII
+     */
+    public void setProductTag(@NonNull final String productTag) {
+        if (isASCIIEncodable(productTag)) {
+            putMetadata(PRODUCT_TAG_HEADER_FIELD_NAME, productTag);
+        } else {
+            throw new IllegalArgumentException("Metadata is not encodable as ASCII: " + productTag);
         }
     }
 
@@ -110,7 +126,7 @@ public class DocumentMetadata {
         } else {
             completeName = HEADER_FIELD_NAME_PREFIX + name;
         }
-        mMetadataMap.put(completeName, value);
+        putMetadata(completeName, value);
     }
 
     /**
@@ -120,8 +136,12 @@ public class DocumentMetadata {
      */
     public DocumentMetadata copy() {
         DocumentMetadata copy = new DocumentMetadata();
-        mMetadataMap.forEach((key, value) -> copy.add(key, value));
+        mMetadataMap.forEach(copy::putMetadata);
         return copy;
+    }
+
+    private void putMetadata(@NonNull final String name, @NonNull final String value) {
+        mMetadataMap.put(name, value);
     }
 
     @NonNull

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
@@ -82,7 +82,17 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
             }
         }
 
-    suspend fun createCompositeDocument(documents: List<Document>, documentType: DocumentManager.DocumentType?): Resource<Document> =
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentManager.DocumentType?
+    ): Resource<Document> =
+        createCompositeDocument(documents, documentType, null)
+
+    suspend fun createCompositeDocument(
+        documents: List<Document>,
+        documentType: DocumentManager.DocumentType?,
+        documentMetadata: DocumentMetadata?
+    ): Resource<Document> =
         withAccessToken { accessToken ->
             wrapInResource {
                 val uri = documentRemoteSource.uploadDocument(
@@ -91,13 +101,23 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
                     giniApiType.giniCompositeJsonMediaType,
                     null,
                     documentType?.apiDoctypeHint,
-                    null
+                    documentMetadata?.metadata
                 )
                 getDocumentInternal(accessToken, uri)
             }
         }
 
-    suspend fun createCompositeDocument(documentRotationMap: LinkedHashMap<Document, Int>, documentType: DocumentManager.DocumentType?): Resource<Document> =
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentManager.DocumentType?
+    ): Resource<Document> =
+        createCompositeDocument(documentRotationMap, documentType, null)
+
+    suspend fun createCompositeDocument(
+        documentRotationMap: LinkedHashMap<Document, Int>,
+        documentType: DocumentManager.DocumentType?,
+        documentMetadata: DocumentMetadata?
+    ): Resource<Document> =
         withAccessToken { accessToken ->
             wrapInResource {
                 val uri = documentRemoteSource.uploadDocument(
@@ -106,7 +126,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
                     giniApiType.giniCompositeJsonMediaType,
                     null,
                     documentType?.apiDoctypeHint,
-                    null
+                    documentMetadata?.metadata
                 )
                 getDocumentInternal(accessToken, uri)
             }

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentMetadataUnitTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentMetadataUnitTest.kt
@@ -1,0 +1,33 @@
+package net.gini.android.core.api
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class DocumentMetadataUnitTest {
+
+    @Test
+    fun `setProductTag uses backend header name`() {
+        val documentMetadata = DocumentMetadata()
+
+        documentMetadata.setProductTag("sepaExtractions")
+
+        assertThat(documentMetadata.metadata).containsEntry(
+            DocumentMetadata.PRODUCT_TAG_HEADER_FIELD_NAME,
+            "sepaExtractions"
+        )
+    }
+
+    @Test
+    fun `copy preserves product tag header name`() {
+        val documentMetadata = DocumentMetadata().apply {
+            setProductTag("cxExtractions")
+        }
+
+        val copy = documentMetadata.copy()
+
+        assertThat(copy.metadata).containsEntry(
+            DocumentMetadata.PRODUCT_TAG_HEADER_FIELD_NAME,
+            "cxExtractions"
+        )
+    }
+}

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
@@ -86,7 +86,7 @@ class DocumentRemoteSourceTest {
         val accessToken = UUID.randomUUID().toString()
         val expectedAuthorizationHeader = "Bearer $accessToken"
         verifyAuthorizationHeader(expectedAuthorizationHeader, this) {
-            getLayout(accessToken, "")
+            getDocumentLayout(accessToken, "")
         }
     }
 
@@ -194,12 +194,20 @@ class DocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getLayoutForDocument(
+        override suspend fun getDocumentLayout(
             bearer: Map<String, String>,
             documentId: String
-        ): Response<ResponseBody> {
+        ): Response<DocumentLayoutResponse> {
             bearerAuthHeader = bearer["Authorization"]
-            return Response.success("response".toResponseBody())
+            return Response.success(DocumentLayoutResponse(emptyList()))
+        }
+
+        override suspend fun getDocumentPages(
+            bearer: Map<String, String>,
+            documentId: String
+        ): Response<List<DocumentPageResponse>> {
+            bearerAuthHeader = bearer["Authorization"]
+            return Response.success(emptyList())
         }
 
         override suspend fun getPaymentRequest(
@@ -237,20 +245,5 @@ class DocumentRemoteSourceTest {
             return Response.success(null)
         }
 
-        override suspend fun getDocumentLayout(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<DocumentLayoutResponse> {
-            bearerAuthHeader = bearer["Authorization"]
-            return Response.success(null)
-        }
-
-        override suspend fun getDocumentPages(
-            bearer: Map<String, String>,
-            documentId: String
-        ): Response<List<DocumentPageResponse>> {
-            bearerAuthHeader = bearer["Authorization"]
-            return Response.success(null)
-        }
     }
 }

--- a/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
+++ b/core-api-library/library/src/test/java/net/gini/android/core/api/DocumentRemoteSourceTest.kt
@@ -82,7 +82,7 @@ class DocumentRemoteSourceTest {
     }
 
     @Test
-    fun `sets bearer authorization header with capital case 'Bearer' in getLayout`() = runTest {
+    fun `sets bearer authorization header with capital case 'Bearer' in getDocumentLayout`() = runTest {
         val accessToken = UUID.randomUUID().toString()
         val expectedAuthorizationHeader = "Bearer $accessToken"
         verifyAuthorizationHeader(expectedAuthorizationHeader, this) {


### PR DESCRIPTION
 ## Add CxExtractions support to bank-sdk capture flow
 
 ### Why
 The Gini API supports two payment extraction modes controlled by `productTag`. For
 `sepaExtractions` (the default), payment data is returned as flat SEPA-specific extractions.
 For `cxExtractions` (cross-border payments), payment data is returned inside a
 `crossBorderPayment` compound extraction. The bank-sdk had no awareness of this distinction —
 it always expected SEPA flat fields, always routed through Skonto/Return Assistant, and always
 forwarded all extractions to the bank integrator regardless of the active product tag.
 
 ---
 
 ### What
 
 **`CxExtractionsFilter` (new)**
 An internal utility that filters a `CaptureSDKResult.Success` when `productTag=cxExtractions`.
 It removes SEPA flat extractions (`iban`, `bic`, `amountToPay`, `paymentRecipient`,
 `paymentReference`, `paymentPurpose`, `instantPayment`), payment-hint extractions
 (`paymentDueDate`, `creditNote`), Skonto/Return-Assistant compound extractions
 (`skontoDiscounts`, `lineItems`), and clears `returnReasons`. The `crossBorderPayment`
 compound extraction is passed through as-is with all its fields dynamically, so no fixed
 field definitions are needed in the SDK.
 
 **`CaptureFlowFragment`**
 The filter is applied at the top of `processOnFinishedResultSuccessState()` before any
 routing. Because `skontoDiscounts` and `lineItems` are stripped early, Skonto and Return
 Assistant screens are naturally skipped for CX flows without any additional bypass logic.
 `interceptSuccessResult()` also gains a CX-specific validation path: it returns
 `CaptureResult.Empty` if `crossBorderPayment` is absent, or forwards the result if present.
 The existing SEPA/EPS validation path is completely unchanged.
 
 **`CxExtractionsFilterTest` (new)**
 9 unit tests covering SEPA removal, payment-hint removal, Skonto/lineItems removal,
 `crossBorderPayment` passthrough, non-SEPA extraction preservation, mixed cases, and cleared
 `returnReasons`.
 
 ---
 
 ### Notes
 - No public API changes — the bank integrator uses the same
   `CaptureFlowFragmentListener.onFinishedWithResult(CaptureResult)` for both SEPA and CX flows.
 - Scope: **bank-sdk only.** Health-sdk is unaffected.