### PR TITLE
feat(health-sdk): document new error handling model and usage in SDK

### DIFF
--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/configuration/ConfigurationFragment.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/configuration/ConfigurationFragment.kt
@@ -59,6 +59,13 @@ class ConfigurationFragment: Fragment() {
                 copy(shouldShowReviewBottomDialog = isChecked)
             }
         }
+
+        ghsHandleErrorsInternally.isChecked = viewModel.getPaymentFlowConfiguration()?.shouldHandleErrorsInternally ?: true
+        ghsHandleErrorsInternally.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.updatePaymentFlowConfiguration {
+                copy(shouldHandleErrorsInternally = isChecked)
+            }
+        }
     }
 
     private fun FragmentConfigurationBinding.setupSliderListener() {

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
@@ -101,10 +101,10 @@ class InvoicesViewModel(
                 val paymentReviewFragment = invoicesRepository.giniHealth.getPaymentFragmentWithDocument(
                     documentWithExtractions.documentId,
                     PaymentFlowConfiguration(
-                        shouldHandleErrorsInternally = true,
+                        shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true,
                         shouldShowReviewBottomDialog = false,
                         showCloseButtonOnReviewFragment = true,
-                        popupDurationPaymentReview = paymentFlowConfiguration?.popupDurationPaymentReview?: PaymentFlowConfiguration.DEFAULT_POPUP_DURATION
+                        popupDurationPaymentReview = paymentFlowConfiguration?.popupDurationPaymentReview ?: PaymentFlowConfiguration.DEFAULT_POPUP_DURATION
                     )
                 )
                 Result.success(paymentReviewFragment)
@@ -124,7 +124,7 @@ class InvoicesViewModel(
 
     fun getPaymentFragmentForPaymentDetails(paymentDetails: PaymentDetails, paymentFlowConfiguration: PaymentFlowConfiguration?): Result<PaymentFragment> {
         try {
-            val paymentFragment = invoicesRepository.giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false, shouldHandleErrorsInternally = true))
+            val paymentFragment = invoicesRepository.giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false, shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true))
             return Result.success(paymentFragment)
         } catch (e: Exception) {
             LOG.error("Error getting payment fragment without document", e)

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/orders/OrdersViewModel.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/orders/OrdersViewModel.kt
@@ -76,7 +76,7 @@ class OrdersViewModel(
 
     fun getPaymentFragmentForPaymentDetails(paymentDetails: PaymentDetails, paymentFlowConfiguration: PaymentFlowConfiguration?): Result<PaymentFragment> {
         try {
-            val paymentFragment = giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = (paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false), shouldHandleErrorsInternally = true))
+            val paymentFragment = giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = (paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false), shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true))
             return Result.success(paymentFragment)
         } catch (e: Exception) {
             return Result.failure(e)

--- a/health-sdk/example-app/src/main/res/layout/fragment_configuration.xml
+++ b/health-sdk/example-app/src/main/res/layout/fragment_configuration.xml
@@ -37,6 +37,14 @@
         android:checked="false"
         android:text="@string/show_review_bottom_dialog"/>
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/ghs_handle_errors_internally"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/handle_errors_internally"
+        android:layout_marginTop="@dimen/gps_medium" />
+
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/divider3"
         android:layout_width="match_parent"

--- a/health-sdk/example-app/src/main/res/values-en/strings.xml
+++ b/health-sdk/example-app/src/main/res/values-en/strings.xml
@@ -24,6 +24,7 @@
     <string name="close_screen_for_configurations_to_take_place">The configuration changes will take effect after closing this screen.</string>
     <string name="hide_powered_by_gini">Hide powered by Gini on payment component</string>
     <string name="show_review_bottom_dialog">Show the review bottom dialog</string>
+    <string name="handle_errors_internally">Handle errors internally</string>
     <string name="gini_health_version">Gini Health SDK v: </string>
     <string name="sdk_language">SDK language: </string>
     <string name="recipient">Recipient</string>

--- a/health-sdk/example-app/src/main/res/values/strings.xml
+++ b/health-sdk/example-app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="close_screen_for_configurations_to_take_place">The configuration changes will take effect after closing this screen.</string>
     <string name="hide_powered_by_gini">Hide powered by Gini on payment component</string>
     <string name="show_review_bottom_dialog">Show the review bottom dialog</string>
+    <string name="handle_errors_internally">Handle errors internally</string>
     <string name="gini_health_version">Gini Health SDK v: </string>
     <string name="sdk_language">SDK language: </string>
     <string name="recipient">Recipient</string>

--- a/health-sdk/sdk/src/doc/source/error-handling.rst
+++ b/health-sdk/sdk/src/doc/source/error-handling.rst
@@ -150,8 +150,11 @@ All ``GiniHealth`` suspend functions throw ``GiniHealthException`` when an API c
         }
     }
 
-The same pattern applies to ``deletePaymentRequest()``, ``deletePaymentRequests()``, ``deleteDocuments()``,
-``checkIfDocumentIsPayable()``, and ``checkIfDocumentContainsMultipleDocuments()``.
+The same pattern applies to ``deletePaymentRequest()``, ``deletePaymentRequests()``, and ``deleteDocuments()``.
+
+For ``checkIfDocumentIsPayable()`` and ``checkIfDocumentContainsMultipleDocuments()``, the same
+``GiniHealthException`` is thrown on API failure — however, **cancellation does not throw**: both
+functions return ``false`` when the underlying request is cancelled.
 
 ``documentManager`` functions (``Resource`` return type)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/health-sdk/sdk/src/doc/source/error-handling.rst
+++ b/health-sdk/sdk/src/doc/source/error-handling.rst
@@ -85,7 +85,7 @@ Mapped to Kotlin as:
     data class ErrorItem(
         val code: String,                        // Short error code (e.g., "2002")
         val message: String? = null,             // Per-item description
-        val documentIdList: List<String>? = null // Affected entity IDs (documents or payment requests)
+        val affectedIds: List<String>? = null // Affected entity IDs (documents or payment requests)
     )
 
 .. note::
@@ -142,7 +142,7 @@ All ``GiniHealth`` suspend functions throw ``GiniHealthException`` when an API c
             Log.e("GiniHealth", "HTTP ${e.statusCode}: ${e.parsedMessage}")
             Log.e("GiniHealth", "Request ID: ${e.requestId}")
             e.errorItems?.forEach { item ->
-                Log.e("GiniHealth", "  Code=${item.code} | Affected: ${item.documentIdList}")
+                Log.e("GiniHealth", "  Code=${item.code} | Affected: ${item.affectedIds}")
             }
         } catch (e: Exception) {
             // SDK request cancellation, validation error, or CancellationException from coroutine scope
@@ -223,7 +223,7 @@ New API — ``try/catch`` block:
         showError(e.parsedMessage)
         // Inspect which IDs caused the failure
         e.errorItems?.forEach { item ->
-            Log.e("GiniHealth", "Code=${item.code} | Affected: ${item.documentIdList}")
+            Log.e("GiniHealth", "Code=${item.code} | Affected: ${item.affectedIds}")
         }
     } catch (e: Exception) {
         // SDK request cancellation, validation error, or CancellationException from coroutine scope

--- a/health-sdk/sdk/src/doc/source/error-handling.rst
+++ b/health-sdk/sdk/src/doc/source/error-handling.rst
@@ -1,0 +1,229 @@
+Error Handling
+==============
+
+The Gini Health SDK provides structured, detailed error information for API failures. Errors carry the HTTP
+status code, a human-readable message, a support request ID, and — for bulk operations — the list of affected
+document IDs.
+
+The SDK error model is built around ``GiniHealthException``, ``ErrorResponse``, and ``ErrorItem``, each
+described in detail below.
+
+The ``GiniHealthException`` class
+----------------------------------
+
+``GiniHealthException`` extends ``Exception`` and is thrown whenever an API call fails — whether the failure
+is an HTTP error response (``statusCode`` and ``errorResponse`` are populated) or a network-level failure such
+as a timeout (``cause`` holds the underlying exception, ``statusCode`` and ``errorResponse`` are ``null``).
+
+.. important::
+
+    ``GiniHealthException`` does **not** cover all exceptions that the SDK may throw. The following categories of
+    exception are thrown directly as their native types and are **not** wrapped in ``GiniHealthException``:
+
+    * **Request cancellation** — cancelled coroutines surface as a plain ``Exception``.
+    * **Validation / precondition errors** — e.g. ``IllegalStateException`` when input validation fails
+      (for example, calling ``getPaymentFragmentWithoutDocument()`` with incomplete payment details or
+      an invalid IBAN).
+    * **Programming errors** — e.g. ``NullPointerException`` or ``IllegalArgumentException`` caused by
+      internal SDK misconfiguration.
+
+    Always include a general ``catch (e: Exception)`` block **after** your ``catch (e: GiniHealthException)`` block
+    to handle these remaining cases.
+
+.. code-block:: kotlin
+
+    open class GiniHealthException(
+        message: String,             // Raw message (may be a JSON string — kept for backward compatibility)
+        cause: Throwable? = null,    // Underlying exception — e.g. SocketTimeoutException for network failures, ApiException for HTTP errors
+        val statusCode: Int? = null, // HTTP status code (e.g., 404, 422, 500)
+        val errorResponse: ErrorResponse? = null  // Fully parsed API error body
+    ) : Exception(message, cause) {
+
+        // Human-readable message for display — resolves in priority order:
+        // 1. errorResponse.message  2. raw message  3. "Unknown error"
+        val parsedMessage: String
+
+        // Unique request ID from errorResponse — provide to Gini support when reporting issues
+        val requestId: String?
+
+        // Individual error entries from errorResponse.items (code, message, affected document IDs)
+        val errorItems: List<ErrorItem>?
+    }
+
+
+The ``ErrorResponse`` class
+----------------------------
+
+``ErrorResponse`` is the data model for the Gini Health API v5.0 error body:
+
+.. code-block:: json
+
+    {
+      "message": "Validation of the request entity failed",
+      "requestId": "8896f9dc-260d-4133-9848-c54e5715270f",
+      "items": [
+        {
+          "code": "2002",
+          "message": "Value too long",
+          "object": ["doc-id-1", "doc-id-2"]
+        }
+      ]
+    }
+
+Mapped to Kotlin as:
+
+.. code-block:: kotlin
+
+    data class ErrorResponse(
+        val message: String? = null,         // Human-consumable description — not intended for direct end-user display
+        val requestId: String? = null,       // Unique request ID — provide to support
+        val items: List<ErrorItem>? = null   // Individual error entries
+    )
+
+    data class ErrorItem(
+        val code: String,                        // Short error code (e.g., "2002")
+        val message: String? = null,             // Per-item description
+        val documentIdList: List<String>? = null // Affected document IDs (bulk operations)
+    )
+
+.. note::
+
+    ``ErrorResponse`` is parsed automatically from the raw HTTP response body. You do not need to parse it yourself.
+    It is available via ``GiniHealthException.errorResponse``.
+
+How errors are propagated
+--------------------------
+
+Flows
+~~~~~
+
+Errors from ``GiniHealth.documentFlow`` and ``GiniHealth.paymentFlow`` arrive as ``ResultWrapper.Error``.
+The ``error`` property is a ``GiniHealthException`` when an API call fails, or a plain ``Throwable`` otherwise:
+
+.. code-block:: kotlin
+
+    lifecycleScope.launch {
+        giniHealth.documentFlow.collect { result ->
+            when (result) {
+                is ResultWrapper.Loading -> showProgressIndicator()
+                is ResultWrapper.Success -> showDocument(result.value)
+                is ResultWrapper.Error -> {
+                    val exception = result.error
+                    if (exception is GiniHealthException) {
+                        Log.e("GiniHealth", "HTTP ${exception.statusCode}: ${exception.parsedMessage}")
+                        showError(exception.parsedMessage)
+                    } else {
+                        showError(exception.message ?: "Unknown error")
+                    }
+                }
+            }
+        }
+    }
+
+The ``paymentFlow`` and ``trustMarkersFlow`` flows follow the same pattern. For ``openBankState``, errors
+are surfaced as ``GiniHealth.PaymentState.Error`` — check its ``throwable`` property with the same
+``is GiniHealthException`` cast.
+
+``GiniHealth`` suspend functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All ``GiniHealth`` suspend functions throw ``GiniHealthException`` when an API call fails. Always add a second
+``catch`` for cancellation and other non-API failures:
+
+.. code-block:: kotlin
+
+    coroutineScope.launch {
+        try {
+            val payment = giniHealth.getPayment(paymentRequestId)
+        } catch (e: GiniHealthException) {
+            // API error — structured details available
+            Log.e("GiniHealth", "HTTP ${e.statusCode}: ${e.parsedMessage}")
+            Log.e("GiniHealth", "Request ID: ${e.requestId}")
+            e.errorItems?.forEach { item ->
+                Log.e("GiniHealth", "  Code=${item.code} | Affected: ${item.documentIdList}")
+            }
+        } catch (e: Exception) {
+            // Request cancelled or other non-API error
+            Log.e("GiniHealth", "Unexpected: ${e.message}")
+        }
+    }
+
+The same pattern applies to ``deletePaymentRequest()``, ``deletePaymentRequests()``, ``deleteDocuments()``,
+``checkIfDocumentIsPayable()``, and ``checkIfDocumentContainsMultipleDocuments()``.
+
+``documentManager`` functions (``Resource`` return type)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Functions on ``giniHealth.documentManager`` return ``Resource<T>`` directly instead of throwing.
+``Resource.Error`` carries the full ``errorResponse``:
+
+.. code-block:: kotlin
+
+    coroutineScope.launch {
+        val result = giniHealth.documentManager.createPartialDocument(
+            document = imageBytes,
+            contentType = "image/jpeg",
+            filename = "invoice_page_1.jpg"
+        )
+        when (result) {
+            is Resource.Success -> { /* use result.data */ }
+            is Resource.Error -> {
+                val errorMsg = result.errorResponse?.message ?: result.message
+                Log.e("GiniHealth", "HTTP ${result.responseStatusCode}: $errorMsg")
+                Log.e("GiniHealth", "Request ID: ${result.errorResponse?.requestId}")
+            }
+            is Resource.Cancelled -> { /* handle cancellation */ }
+        }
+    }
+
+The same pattern applies to ``createCompositeDocument()``, ``getDocument()``,
+``getAllExtractionsWithPolling()``, and all other ``documentManager`` calls.
+
+Breaking changes
+----------------
+
+Return type changes
+~~~~~~~~~~~~~~~~~~~~
+
+The three delete functions **do not return error information** — they return ``Unit`` and throw
+``GiniHealthException`` on failure. Any existing code that checked for a non-null return value must be
+replaced with a ``try/catch`` block.
+
++-------------------------------+------------------------------------------+------------------------------------------------------------+
+| Method                        | Old return type                          | New behaviour                                              |
++===============================+==========================================+============================================================+
+| ``deletePaymentRequest``      | ``String?`` (error message or null)      | ``Unit`` — throws ``GiniHealthException`` (API error) or  |
+|                               |                                          | ``Exception`` (cancelled)                                  |
++-------------------------------+------------------------------------------+------------------------------------------------------------+
+| ``deletePaymentRequests``     | ``DeletePaymentRequestErrorResponse?``   | ``Unit`` — throws ``GiniHealthException`` (API error) or  |
+|                               |                                          | ``Exception`` (cancelled)                                  |
++-------------------------------+------------------------------------------+------------------------------------------------------------+
+| ``deleteDocuments``           | ``DeleteDocumentErrorResponse?``         | ``Unit`` — throws ``GiniHealthException`` (API error) or  |
+|                               |                                          | ``Exception`` (cancelled)                                  |
++-------------------------------+------------------------------------------+------------------------------------------------------------+
+
+Old API — return value check:
+
+.. code-block:: kotlin
+
+    val error = giniHealth.deletePaymentRequests(ids)
+    if (error != null) {
+        showError(error.message ?: "Unknown error")
+    }
+
+New API — ``try/catch`` block:
+
+.. code-block:: kotlin
+
+    try {
+        giniHealth.deletePaymentRequests(ids)
+    } catch (e: GiniHealthException) {
+        showError(e.parsedMessage)
+        // Inspect which IDs caused the failure
+        e.errorItems?.forEach { item ->
+            Log.e("GiniHealth", "Code=${item.code} | Affected: ${item.documentIdList}")
+        }
+    } catch (e: Exception) {
+        // Request cancelled
+    }
+

--- a/health-sdk/sdk/src/doc/source/error-handling.rst
+++ b/health-sdk/sdk/src/doc/source/error-handling.rst
@@ -3,7 +3,7 @@ Error Handling
 
 The Gini Health SDK provides structured, detailed error information for API failures. Errors carry the HTTP
 status code, a human-readable message, a support request ID, and — for bulk operations — the list of affected
-document IDs.
+entity IDs (documents or payment requests).
 
 The SDK error model is built around ``GiniHealthException``, ``ErrorResponse``, and ``ErrorItem``, each
 described in detail below.
@@ -20,14 +20,16 @@ as a timeout (``cause`` holds the underlying exception, ``statusCode`` and ``err
     ``GiniHealthException`` does **not** cover all exceptions that the SDK may throw. The following categories of
     exception are thrown directly as their native types and are **not** wrapped in ``GiniHealthException``:
 
-    * **Request cancellation** — cancelled coroutines surface as a plain ``Exception``.
+    * **Coroutine cancellation** — Kotlin's coroutine framework signals cancellation via ``CancellationException``
+      (a subclass of ``Exception``). It will be caught by a generic ``catch (e: Exception)`` block — if your
+      coroutine scope requires cooperative cancellation, rethrow it manually.
     * **Validation / precondition errors** — e.g. ``IllegalStateException`` when input validation fails
       (for example, calling ``getPaymentFragmentWithoutDocument()`` with incomplete payment details or
       an invalid IBAN).
     * **Programming errors** — e.g. ``NullPointerException`` or ``IllegalArgumentException`` caused by
       internal SDK misconfiguration.
 
-    Always include a general ``catch (e: Exception)`` block **after** your ``catch (e: GiniHealthException)`` block
+    Always place a general ``catch (e: Exception)`` block **after** your ``catch (e: GiniHealthException)`` block
     to handle these remaining cases.
 
 .. code-block:: kotlin
@@ -46,7 +48,7 @@ as a timeout (``cause`` holds the underlying exception, ``statusCode`` and ``err
         // Unique request ID from errorResponse — provide to Gini support when reporting issues
         val requestId: String?
 
-        // Individual error entries from errorResponse.items (code, message, affected document IDs)
+        // Individual error entries from errorResponse.items (code, message, affected entity IDs)
         val errorItems: List<ErrorItem>?
     }
 
@@ -83,7 +85,7 @@ Mapped to Kotlin as:
     data class ErrorItem(
         val code: String,                        // Short error code (e.g., "2002")
         val message: String? = null,             // Per-item description
-        val documentIdList: List<String>? = null // Affected document IDs (bulk operations)
+        val documentIdList: List<String>? = null // Affected entity IDs (documents or payment requests)
     )
 
 .. note::
@@ -143,7 +145,7 @@ All ``GiniHealth`` suspend functions throw ``GiniHealthException`` when an API c
                 Log.e("GiniHealth", "  Code=${item.code} | Affected: ${item.documentIdList}")
             }
         } catch (e: Exception) {
-            // Request cancelled or other non-API error
+            // SDK request cancellation, validation error, or CancellationException from coroutine scope
             Log.e("GiniHealth", "Unexpected: ${e.message}")
         }
     }
@@ -224,6 +226,5 @@ New API — ``try/catch`` block:
             Log.e("GiniHealth", "Code=${item.code} | Affected: ${item.documentIdList}")
         }
     } catch (e: Exception) {
-        // Request cancelled
+        // SDK request cancellation, validation error, or CancellationException from coroutine scope
     }
-

--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -8,7 +8,8 @@ manages interaction with the Gini Health API and ``PaymentFragment`` controls th
 
     API call failures are surfaced as ``GiniHealthException``, which gives you the HTTP status code, a
     human-readable ``parsedMessage``, a ``requestId`` for support, and per-item error codes for bulk
-    operations. Cancellation and validation errors surface as different exception types.
+    operations. Cancellation and validation issues may surface either as specific exception types or as
+    non-exception results — for example, some methods return ``false`` on cancellation instead of throwing.
     See the `Error Handling <error-handling.html>`_ guide for the full reference.
 
 .. contents:: The recommended flow is:
@@ -110,7 +111,7 @@ Health API. You can then store the ``isPayable`` state in your own data model.
         } catch (e: GiniHealthException) {
             // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle unexpected error (cancellation returns false, not an exception)
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
@@ -132,7 +133,7 @@ multiple invoices, ``false`` if otherwise.
         } catch (e: GiniHealthException) {
             // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle unexpected error (cancellation returns false, not an exception)
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
@@ -187,7 +188,7 @@ If the request is cancelled, a plain ``Exception`` is thrown.
         } catch (e: GiniHealthException) {
             // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle cancellation
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
@@ -208,14 +209,14 @@ parsed error message, request ID, and the original cause. See `Error Handling <e
         } catch (e: GiniHealthException) {
             // Handle error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle cancellation
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
 Delete multiple payment requests
 ---------------------------------
 
-``GiniHealthSDK`` provides a  method to delete multiple payment request at once. You can do this by calling ``giniHealth.deletePaymentRequests(...)`` with a list of payment request IDs. The call will only succeed if all payment request were successfully deleted. If any payment request is invalid, unauthorized, or not found, the entire deletion request will fail, and no payment requests will be deleted.
+``GiniHealthSDK`` provides a method to delete multiple payment requests at once. You can do this by calling ``giniHealth.deletePaymentRequests(...)`` with a list of payment request IDs. The call will only succeed if all payment requests were successfully deleted. If any payment request is invalid, unauthorized, or not found, the entire deletion request will fail, and no payment requests will be deleted.
 
 On failure a ``GiniHealthException`` is thrown. Inspect ``e.errorItems`` to see which payment request IDs caused
 the failure and their error codes. See `Error Handling <error-handling.html>`_ for details.
@@ -234,7 +235,7 @@ the failure and their error codes. See `Error Handling <error-handling.html>`_ f
             // e.errorItems   — per-ID error codes and affected IDs
             // e.requestId    — provide to Gini support
         } catch (e: Exception) {
-            // Handle cancellation
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
@@ -262,7 +263,7 @@ failure and their error codes. See `Error Handling <error-handling.html>`_ for d
             // e.errorItems   — per-ID error codes and affected IDs
             // e.requestId    — provide to Gini support
         } catch (e: Exception) {
-            // Handle cancellation
+            // SDK cancellation, validation error, or CancellationException from coroutine scope
         }
     }
 
@@ -346,5 +347,4 @@ Initialize Koin once at app startup so the ``GiniHealth`` instance is created an
 
 .. note::
    You can also initialize without a DI framework by creating the ``GiniHealth`` instance in your ``Application`` and calling the ``setInstance()`` method once at startup. The sample app includes Koin-based usage for reference.
-
 

--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -4,6 +4,13 @@ Flow
 ``GiniHealth`` and ``PaymentFragment`` are the main classes for interacting with the Gini Health SDK. ``GiniHealth``
 manages interaction with the Gini Health API and ``PaymentFragment`` controls the payment flow and the displayed screens.
 
+.. note::
+
+    API call failures are surfaced as ``GiniHealthException``, which gives you the HTTP status code, a
+    human-readable ``parsedMessage``, a ``requestId`` for support, and per-item error codes for bulk
+    operations. Cancellation and validation errors surface as different exception types.
+    See the `Error Handling <error-handling.html>`_ guide for the full reference.
+
 .. contents:: The recommended flow is:
    :local:
 
@@ -100,8 +107,10 @@ Health API. You can then store the ``isPayable`` state in your own data model.
         try {
             // Check whether the composite document is payable
             val isPayable = giniHealth.checkIfDocumentIsPayable(compositeDocument.id)
+        } catch (e: GiniHealthException) {
+            // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle error
+            // Handle unexpected error (cancellation returns false, not an exception)
         }
     }
 
@@ -120,8 +129,10 @@ multiple invoices, ``false`` if otherwise.
         try {
             // Check whether the composite document contains multiple invoices
             val containsMultipleInvoices = giniHealth.checkIfDocumentContainsMultipleDocuments(compositeDocument.id)
+        } catch (e: GiniHealthException) {
+            // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle error
+            // Handle unexpected error (cancellation returns false, not an exception)
         }
     }
 
@@ -162,7 +173,8 @@ Get Payment Details
 Call ``giniHealth.getPayment()`` with the payment request ID to retrieve the details of a specific payment.
 The method returns a ``Payment`` object containing the relevant payment information.
 
-If the request fails or is canceled, an exception will be thrown with an error message.
+If the request fails it throws a ``GiniHealthException`` (with ``statusCode``, ``parsedMessage``, and ``requestId``).
+If the request is cancelled, a plain ``Exception`` is thrown.
 
 .. code-block:: kotlin
 
@@ -172,8 +184,10 @@ If the request fails or is canceled, an exception will be thrown with an error m
         try {
             // Retrieve payment details
             val paymentDetails = giniHealth.getPayment(paymentId)
+        } catch (e: GiniHealthException) {
+            // Handle structured error — e.parsedMessage, e.statusCode, e.requestId
         } catch (e: Exception) {
-            // Handle error
+            // Handle cancellation
         }
     }
 
@@ -182,25 +196,29 @@ Delete payment request
 
 ``GiniHealthSDK`` provides a method to delete a payment request. You can do this by calling ``giniHealth.deletePaymentRequest(...)`` with a payment request ID.
 
+On success the function completes normally. On failure it throws a ``GiniHealthException`` with the HTTP status code,
+parsed error message, request ID, and the original cause. See `Error Handling <error-handling.html>`_ for details.
+
 .. code-block:: kotlin
 
     coroutineScope.launch {
-        // Delete  payment requests
-        val deletePaymentRequest = giniHealth.deletePaymentRequest(paymentRequestId)
-
-        when (deletePaymentRequest) {
-            is Resource.Success -> {
-                // `null` will be returned here
-            }
-            is Resource.Error -> // Handle Error
-            is Resource.Cancelled -> //  Handle cancellation
+        try {
+            giniHealth.deletePaymentRequest(paymentRequestId)
+            // Success
+        } catch (e: GiniHealthException) {
+            // Handle error — e.parsedMessage, e.statusCode, e.requestId
+        } catch (e: Exception) {
+            // Handle cancellation
         }
     }
 
 Delete multiple payment requests
 ---------------------------------
 
-``GiniHealthSDK`` provides a  method to delete multiple payment request at once. You can do this by calling ``giniHealth.deletePaymentRequests(...)`` with a list of payment request IDs. The call will only succeed if all payment request were successfully deleted. If any payment request is invalid, unauthorized, or not found, the entire deletion request will fail, and no payment requests will be deleted. In the case of failures, an error or type ``DeletePaymentRequestErrorResponse`` will be provided, with more insight into why the deletion failed.
+``GiniHealthSDK`` provides a  method to delete multiple payment request at once. You can do this by calling ``giniHealth.deletePaymentRequests(...)`` with a list of payment request IDs. The call will only succeed if all payment request were successfully deleted. If any payment request is invalid, unauthorized, or not found, the entire deletion request will fail, and no payment requests will be deleted.
+
+On failure a ``GiniHealthException`` is thrown. Inspect ``e.errorItems`` to see which payment request IDs caused
+the failure and their error codes. See `Error Handling <error-handling.html>`_ for details.
 
 .. code-block:: kotlin
 
@@ -208,15 +226,15 @@ Delete multiple payment requests
     // representing the IDs of the payment requests to be deleted
 
     coroutineScope.launch {
-        // Delete multiple payment requests at once
-        val deletePaymentRequests = giniHealth.deletePaymentRequests(paymentRequestIds)
-
-        when (deletePaymentRequests) {
-            is Resource.Success -> {
-                // `null` will be returned here
-            }
-            is Resource.Error -> // Handle `DeletePaymentRequestErrorResponse`
-            is Resource.Cancelled -> // Handle `DeletePaymentRequestErrorResponse`
+        try {
+            giniHealth.deletePaymentRequests(paymentRequestIds)
+            // All payment requests deleted successfully
+        } catch (e: GiniHealthException) {
+            // e.parsedMessage — human-readable reason
+            // e.errorItems   — per-ID error codes and affected IDs
+            // e.requestId    — provide to Gini support
+        } catch (e: Exception) {
+            // Handle cancellation
         }
     }
 
@@ -225,7 +243,10 @@ Delete multiple documents at once
 
 ``GiniHealthSDK`` provides an easy method to delete multiple documents at once. You can call ``giniHealth.deleteDocuments(...)`` with the list of document
 ids you want to delete. The call will only succeed if all documents were successfully deleted. If not all documents can be deleted, the whole call will fail
-and no documents will be deleted. In the case of failures, an error or type ``DeleteDocumentErrorResponse`` will be provided, with more insight into why the deletion failed.
+and no documents will be deleted.
+
+On failure a ``GiniHealthException`` is thrown. Inspect ``e.errorItems`` to see which document IDs caused the
+failure and their error codes. See `Error Handling <error-handling.html>`_ for details.
 
 .. code-block:: kotlin
 
@@ -233,15 +254,15 @@ and no documents will be deleted. In the case of failures, an error or type ``De
     // represent the ids of the documents to be deleted
 
     coroutineScope.launch {
-        // Delete multiple documents at once
-        val deleteDocuments = giniHealth.deleteDocuments(documentIds)
-
-        when (deleteDocuments) {
-            is Resource.Success -> {
-                // `null` will be returned here
-            }
-            is Resource.Error -> // Handle `DeleteDocumentErrorResponse`
-            is Resource.Cancelled -> // Handle `DeleteDocumentErrorResponse`
+        try {
+            giniHealth.deleteDocuments(documentIds)
+            // All documents deleted successfully
+        } catch (e: GiniHealthException) {
+            // e.parsedMessage — human-readable reason
+            // e.errorItems   — per-ID error codes and affected IDs
+            // e.requestId    — provide to Gini support
+        } catch (e: Exception) {
+            // Handle cancellation
         }
     }
 

--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -122,6 +122,12 @@ Call ``giniHealth.checkIfDocumentContainsMultipleDocuments()`` with the composit
 We recommend performing this check after checking if the document is payable. The method will return ``true`` if the document contains
 multiple invoices, ``false`` if otherwise.
 
+.. note::
+
+    A ``false`` result may also indicate that the underlying request was cancelled. If you need to distinguish
+    between "single invoice" and "cancelled", check whether the coroutine was cancelled before relying on the
+    ``false`` return value.
+
 .. code-block:: kotlin
 
     // Assuming `compositeDocument` is `Document` returned by `createCompositeDocument(...)`

--- a/health-sdk/sdk/src/doc/source/index.rst
+++ b/health-sdk/sdk/src/doc/source/index.rst
@@ -22,6 +22,7 @@ Table of contents
     setup
     authentication
     flow
+    error-handling
     event-tracking
     testing
     customization


### PR DESCRIPTION
This pull request significantly improves the Gini Health SDK documentation by introducing a comprehensive error handling guide and updating usage examples throughout the flow documentation to reflect the new error model. The main focus is on clarifying how API errors, cancellations, and validation errors are surfaced, and on documenting the new structured error types and breaking changes in error handling for delete operations.

**New error handling documentation and improved examples:**

* Added a detailed `error-handling.rst` guide that explains the `GiniHealthException`, `ErrorResponse`, and `ErrorItem` classes, how errors are propagated in different SDK flows, and breaking changes to error handling in delete functions.
* Updated the table of contents in `index.rst` to include the new error handling documentation.

**Flow documentation updates for error handling:**

* Added a prominent note to the top of `flow.rst` referencing the new error handling guide and summarizing the new error model.
* Updated all code examples for API calls (such as `getPayment`, `deletePaymentRequest`, `deletePaymentRequests`, `deleteDocuments`, `checkIfDocumentIsPayable`, and `checkIfDocumentContainsMultipleDocuments`) to use `try/catch` blocks that distinguish between `GiniHealthException` (structured API errors) and generic exceptions (cancellation or unexpected errors). [[1]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735R110-R113) [[2]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735R132-R135) [[3]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735L165-R177) [[4]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735R187-R190) [[5]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735R199-R237) [[6]](diffhunk://#diff-7ebef5bf1bfd6e567d7471f25714855bc79df68a96652e178d8cf7b3fa2a9735L228-R265)

**Breaking changes and migration guidance:**

* Documented that delete functions (`deletePaymentRequest`, `deletePaymentRequests`, `deleteDocuments`) now throw exceptions instead of returning error responses, and provided migration examples for updating client code to use `try/catch` instead of checking return values.

These changes ensure that developers have clear, consistent, and actionable guidance for handling errors in the Gini Health SDK, and that all documentation and examples reflect the current SDK behavior.HEAL-116