### PR TITLE
feat(health-sdk): add toggle for handling errors internally in config…

### DIFF
--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/configuration/ConfigurationFragment.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/configuration/ConfigurationFragment.kt
@@ -59,6 +59,13 @@ class ConfigurationFragment: Fragment() {
                 copy(shouldShowReviewBottomDialog = isChecked)
             }
         }
+
+        ghsHandleErrorsInternally.isChecked = viewModel.getPaymentFlowConfiguration()?.shouldHandleErrorsInternally ?: true
+        ghsHandleErrorsInternally.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.updatePaymentFlowConfiguration {
+                copy(shouldHandleErrorsInternally = isChecked)
+            }
+        }
     }
 
     private fun FragmentConfigurationBinding.setupSliderListener() {

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/invoices/ui/InvoicesViewModel.kt
@@ -101,10 +101,10 @@ class InvoicesViewModel(
                 val paymentReviewFragment = invoicesRepository.giniHealth.getPaymentFragmentWithDocument(
                     documentWithExtractions.documentId,
                     PaymentFlowConfiguration(
-                        shouldHandleErrorsInternally = true,
+                        shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true,
                         shouldShowReviewBottomDialog = false,
                         showCloseButtonOnReviewFragment = true,
-                        popupDurationPaymentReview = paymentFlowConfiguration?.popupDurationPaymentReview?: PaymentFlowConfiguration.DEFAULT_POPUP_DURATION
+                        popupDurationPaymentReview = paymentFlowConfiguration?.popupDurationPaymentReview ?: PaymentFlowConfiguration.DEFAULT_POPUP_DURATION
                     )
                 )
                 Result.success(paymentReviewFragment)
@@ -124,7 +124,7 @@ class InvoicesViewModel(
 
     fun getPaymentFragmentForPaymentDetails(paymentDetails: PaymentDetails, paymentFlowConfiguration: PaymentFlowConfiguration?): Result<PaymentFragment> {
         try {
-            val paymentFragment = invoicesRepository.giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false, shouldHandleErrorsInternally = true))
+            val paymentFragment = invoicesRepository.giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false, shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true))
             return Result.success(paymentFragment)
         } catch (e: Exception) {
             LOG.error("Error getting payment fragment without document", e)

--- a/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/orders/OrdersViewModel.kt
+++ b/health-sdk/example-app/src/main/java/net/gini/android/health/sdk/exampleapp/orders/OrdersViewModel.kt
@@ -76,7 +76,7 @@ class OrdersViewModel(
 
     fun getPaymentFragmentForPaymentDetails(paymentDetails: PaymentDetails, paymentFlowConfiguration: PaymentFlowConfiguration?): Result<PaymentFragment> {
         try {
-            val paymentFragment = giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = (paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false), shouldHandleErrorsInternally = true))
+            val paymentFragment = giniHealth.getPaymentFragmentWithoutDocument(paymentDetails, PaymentFlowConfiguration(shouldShowReviewBottomDialog = (paymentFlowConfiguration?.shouldShowReviewBottomDialog ?: false), shouldHandleErrorsInternally = paymentFlowConfiguration?.shouldHandleErrorsInternally ?: true))
             return Result.success(paymentFragment)
         } catch (e: Exception) {
             return Result.failure(e)

--- a/health-sdk/example-app/src/main/res/layout/fragment_configuration.xml
+++ b/health-sdk/example-app/src/main/res/layout/fragment_configuration.xml
@@ -37,6 +37,14 @@
         android:checked="false"
         android:text="@string/show_review_bottom_dialog"/>
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/ghs_handle_errors_internally"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="true"
+        android:text="@string/handle_errors_internally"
+        android:layout_marginTop="@dimen/gps_medium" />
+
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/divider3"
         android:layout_width="match_parent"

--- a/health-sdk/example-app/src/main/res/values-en/strings.xml
+++ b/health-sdk/example-app/src/main/res/values-en/strings.xml
@@ -24,6 +24,7 @@
     <string name="close_screen_for_configurations_to_take_place">The configuration changes will take effect after closing this screen.</string>
     <string name="hide_powered_by_gini">Hide powered by Gini on payment component</string>
     <string name="show_review_bottom_dialog">Show the review bottom dialog</string>
+    <string name="handle_errors_internally">Handle errors internally</string>
     <string name="gini_health_version">Gini Health SDK v: </string>
     <string name="sdk_language">SDK language: </string>
     <string name="recipient">Recipient</string>

--- a/health-sdk/example-app/src/main/res/values/strings.xml
+++ b/health-sdk/example-app/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="close_screen_for_configurations_to_take_place">The configuration changes will take effect after closing this screen.</string>
     <string name="hide_powered_by_gini">Hide powered by Gini on payment component</string>
     <string name="show_review_bottom_dialog">Show the review bottom dialog</string>
+    <string name="handle_errors_internally">Handle errors internally</string>
     <string name="gini_health_version">Gini Health SDK v: </string>
     <string name="sdk_language">SDK language: </string>
     <string name="recipient">Recipient</string>


### PR DESCRIPTION
This pull request adds a new configuration option to control whether errors in the payment flow are handled internally or externally, making error handling behavior configurable through the UI and propagating this setting throughout the payment flow logic. The most important changes are grouped below:

**UI and User Configuration:**

* Added a new switch (`ghs_handle_errors_internally`) to the `fragment_configuration.xml` layout, allowing users to toggle internal error handling for the payment flow.
* Added a corresponding string resource for the new switch label in both English and default string files. [[1]](diffhunk://#diff-7b9ceb6268db179739527453afc0a6b10e98bfdc74cd54fa693dfc93d5efe28dR27) [[2]](diffhunk://#diff-44c846fb4ca5a1631ba43fc665402a2153d2bccc697bd9b5a01be8743a3324fbR29)
* Updated `ConfigurationFragment.kt` to initialize and handle the new switch, updating the `PaymentFlowConfiguration` accordingly via the ViewModel.

**Payment Flow Logic:**

* Updated the construction of `PaymentFlowConfiguration` in `InvoicesViewModel.kt` and `OrdersViewModel.kt` to use the new `shouldHandleErrorsInternally` value from the configuration, instead of always defaulting to `true`. This ensures the user's choice is respected throughout the payment flow. [[1]](diffhunk://#diff-43c6884ea1be64beea643f96eb13145ebed56d4675f68e0c0f43223ea829a29eL104-R104) [[2]](diffhunk://#diff-43c6884ea1be64beea643f96eb13145ebed56d4675f68e0c0f43223ea829a29eL127-R127) [[3]](diffhunk://#diff-8cbca16eabe2b1406f9737eca5c15bbb3bc0ebb08110a4c13788dc7558e67f47L79-R79)