### PR TITLE
fix(health-sdk): refactor feedback submission to use specific extractions

### DIFF
--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -177,6 +177,36 @@ If the request fails or is canceled, an exception will be thrown with an error m
         }
     }
 
+Sending Feedback for Extractions
+---------------------------------
+
+The SDK sends feedback automatically when using the integrated flow (``PaymentFragment``). If you need to send it
+manually in a custom flow, use the ``sendFeedbackForExtractions`` method on the document manager.
+
+.. note::
+
+    As of version 5.x, the SDK sends feedback using **specific extractions only** (``payment_recipient``, ``iban``,
+    ``amount_to_pay``, ``payment_purpose``).
+
+.. code-block:: kotlin
+
+    coroutineScope.launch {
+        try {
+            val updatedExtractions = extractionsContainer.specificExtractions
+                .toMutableMap()
+                .withFeedback(updatedPaymentDetails)
+
+            giniHealth.giniHealthApi.documentManager
+                .sendFeedbackForExtractions(document, updatedExtractions)
+        } catch (e: Exception) {
+            // Handle exception
+        }
+    }
+
+.. important::
+
+    **Feedback is optional and non-blocking**: Feedback failures do not interrupt the payment flow.
+
 Delete payment request
 ---------------------------------
 

--- a/health-sdk/sdk/src/doc/source/flow.rst
+++ b/health-sdk/sdk/src/doc/source/flow.rst
@@ -185,8 +185,10 @@ manually in a custom flow, use the ``sendFeedbackForExtractions`` method on the 
 
 .. note::
 
-    As of version 5.x, the SDK sends feedback using **specific extractions only** (``payment_recipient``, ``iban``,
-    ``amount_to_pay``, ``payment_purpose``).
+    As of version 5.x, the SDK sends feedback using the **specific extractions** map. The four payment fields
+    (``payment_recipient``, ``iban``, ``amount_to_pay``, ``payment_purpose``) are updated with the user's input,
+    while any other specific extractions present in the map (e.g. ``medical_service_provider``) are preserved and
+    sent as-is.
 
 .. code-block:: kotlin
 

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
@@ -211,12 +211,7 @@ class PaymentFlowViewModel(
                         )
                     }
 
-                    is ResultWrapper.Error -> {
-                        // no implemention is needed
-                    }
-                    is ResultWrapper.Loading -> {
-                        // no implemention is needed
-                    }
+                    is ResultWrapper.Error, is ResultWrapper.Loading -> Unit
                 }
             } catch (ignored: Throwable) {
                 // Ignored since we don't want to interrupt the flow because of feedback failure

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/integratedFlow/PaymentFlowViewModel.kt
@@ -207,13 +207,16 @@ class PaymentFlowViewModel(
                     is ResultWrapper.Success -> paymentDetails?.extractions?.let { extractionsContainer ->
                         giniHealth.documentManager.sendFeedbackForExtractions(
                             documentResult.value,
-                            extractionsContainer.specificExtractions,
-                            extractionsContainer.compoundExtractions.withFeedback(paymentDetails!!)
+                            extractionsContainer.specificExtractions.toMutableMap().withFeedback(paymentDetails!!)
                         )
                     }
 
-                    is ResultWrapper.Error -> {}
-                    is ResultWrapper.Loading -> {}
+                    is ResultWrapper.Error -> {
+                        // no implemention is needed
+                    }
+                    is ResultWrapper.Loading -> {
+                        // no implemention is needed
+                    }
                 }
             } catch (ignored: Throwable) {
                 // Ignored since we don't want to interrupt the flow because of feedback failure

--- a/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
+++ b/health-sdk/sdk/src/main/java/net/gini/android/health/sdk/review/model/PaymentDetails.kt
@@ -46,56 +46,62 @@ internal fun String.toAmount(): String {
     }
 }
 
-internal fun MutableMap<String, CompoundExtraction>.withFeedback(paymentDetails: PaymentDetails): Map<String, CompoundExtraction> {
-    this["payment"] = this["payment"].let { payment ->
-        CompoundExtraction(
-            payment?.name ?: "payment",
-            payment?.specificExtractionMaps?.mapIndexed { index, specificExtractions ->
-                if (index > 0) return@mapIndexed specificExtractions
-
-                mutableMapOf<String, SpecificExtraction>().also { extractions ->
-                    extractions.putAll(specificExtractions)
-                    extractions["payment_recipient"] = extractions["payment_recipient"].let { extraction ->
-                        SpecificExtraction(
-                            extraction?.name ?: "payment_recipient",
-                            paymentDetails.recipient,
-                            extraction?.entity ?: "",
-                            extraction?.box,
-                            extraction?.candidate ?: emptyList()
-                        )
-                    }
-                    extractions["iban"] = extractions["iban"].let { extraction ->
-                        SpecificExtraction(
-                            extraction?.name ?: "iban",
-                            paymentDetails.iban,
-                            extraction?.entity ?: "",
-                            extraction?.box,
-                            extraction?.candidate ?: emptyList()
-                        )
-                    }
-                    extractions["amount_to_pay"] = extractions["amount_to_pay"].let { extraction ->
-                        SpecificExtraction(
-                            extraction?.name ?: "amount_to_pay",
-                            "${paymentDetails.amount.sanitizeAmount().toBackendFormat()}:EUR",
-                            extraction?.entity ?: "",
-                            extraction?.box,
-                            extraction?.candidate ?: emptyList()
-                        )
-                    }
-                    extractions["payment_purpose"] = extractions["payment_purpose"].let { extraction ->
-                        SpecificExtraction(
-                            extraction?.name ?: "payment_purpose",
-                            paymentDetails.purpose,
-                            extraction?.entity ?: "",
-                            extraction?.box,
-                            extraction?.candidate ?: emptyList()
-                        )
-                    }
-                }
-            } ?: listOf()
-        )
+/**
+ * Updates specific extractions with feedback from payment details.
+ *
+ * This function creates a new map of specific extractions with updated values from the provided
+ * [PaymentDetails]. The backend (as of BAC-1771) automatically maps feedback sent via specific
+ * extractions to both specific and compound extractions, eliminating the need for duplicate data.
+ *
+ * The function preserves existing extraction metadata (box, entity, candidates) while updating
+ * the values with user-modified payment information.
+ *
+ * @param paymentDetails The payment details containing updated values to send as feedback
+ * @return A map of specific extractions with updated values for the four main payment fields:
+ *         payment_recipient, iban, amount_to_pay, and payment_purpose
+ *
+ * @see PaymentDetails
+ * @see SpecificExtraction
+ */
+internal fun MutableMap<String, SpecificExtraction>.withFeedback(paymentDetails: PaymentDetails): Map<String, SpecificExtraction> {
+    return this.toMutableMap().apply {
+        this["payment_recipient"] = this["payment_recipient"].let { extraction ->
+            SpecificExtraction(
+                extraction?.name ?: "payment_recipient",
+                paymentDetails.recipient,
+                extraction?.entity ?: "companyname",
+                extraction?.box,
+                extraction?.candidate ?: emptyList()
+            )
+        }
+        this["iban"] = this["iban"].let { extraction ->
+            SpecificExtraction(
+                extraction?.name ?: "iban",
+                paymentDetails.iban,
+                extraction?.entity ?: "iban",
+                extraction?.box,
+                extraction?.candidate ?: emptyList()
+            )
+        }
+        this["amount_to_pay"] = this["amount_to_pay"].let { extraction ->
+            SpecificExtraction(
+                extraction?.name ?: "amount_to_pay",
+                "${paymentDetails.amount.sanitizeAmount().toBackendFormat()}:EUR",
+                extraction?.entity ?: "amount",
+                extraction?.box,
+                extraction?.candidate ?: emptyList()
+            )
+        }
+        this["payment_purpose"] = this["payment_purpose"].let { extraction ->
+            SpecificExtraction(
+                extraction?.name ?: "payment_purpose",
+                paymentDetails.purpose,
+                extraction?.entity ?: "text",
+                extraction?.box,
+                extraction?.candidate ?: emptyList()
+            )
+        }
     }
-    return this
 }
 
 internal fun MutableMap<String, CompoundExtraction>.getPaymentExtraction(name: String) = this["payment"]?.specificExtractionMaps?.get(0)?.get(name)

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
@@ -211,8 +211,38 @@ class PaymentDetailsTest {
     }
 
     @Test
-    fun `Does not modify original specific extractions map`() {
-        // Given
+    fun `Preserves blank entity types for existing payment extractions`() {
+        // Given - extractions with blank entity (as returned by some backends)
+        // This is expected behaviour: blank entities are preserved as-is, not overwritten with defaults
+        val specificExtractions = mutableMapOf(
+            "payment_recipient" to SpecificExtraction("payment_recipient", "Old Recipient", "", null, emptyList()),
+            "iban" to SpecificExtraction("iban", "DE123456789", "", null, emptyList()),
+            "amount_to_pay" to SpecificExtraction("amount_to_pay", "1.23:EUR", "", null, emptyList()),
+            "payment_purpose" to SpecificExtraction("payment_purpose", "Old purpose", "", null, emptyList())
+        )
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99",
+            purpose = "Still testing"
+        )
+
+        // When
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
+
+        // Then - blank entities are preserved, values are updated
+        assertEquals("", updatedExtractions["payment_recipient"]?.entity)
+        assertEquals("", updatedExtractions["iban"]?.entity)
+        assertEquals("", updatedExtractions["amount_to_pay"]?.entity)
+        assertEquals("", updatedExtractions["payment_purpose"]?.entity)
+        assertEquals(paymentDetails.recipient, updatedExtractions["payment_recipient"]?.value)
+        assertEquals(paymentDetails.iban, updatedExtractions["iban"]?.value)
+        assertEquals(paymentDetails.purpose, updatedExtractions["payment_purpose"]?.value)
+    }
+
+    @Test
+    fun `Does not modify original specific extractions map`() {        // Given
         val specificExtractions = mutableMapOf(
             "iban" to SpecificExtraction(
                 "iban",

--- a/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
+++ b/health-sdk/sdk/src/test/java/net/gini/android/health/sdk/review/model/PaymentDetailsTest.kt
@@ -21,38 +21,35 @@ class PaymentDetailsTest {
     }
 
     @Test
-    fun `Updates payment extractions with payment detail values for feedback`() {
+    fun `Updates specific extractions with payment detail values for feedback`() {
         // Given
-        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
-            "payment",
-            listOf(mapOf(
-                "payment_recipient" to SpecificExtraction(
-                    "payment_recipient",
-                    "John Doe",
-                    "", null, emptyList()
-                ),
-                "iban" to SpecificExtraction(
-                    "iban",
-                    "DE123456789",
-                    "", null, emptyList()
-                ),
-                "amount_to_pay" to SpecificExtraction(
-                    "amount_to_pay",
-                    "1.11:EUR",
-                    "", null, emptyList()
-                ),
-                "payment_purpose" to SpecificExtraction(
-                    "payment_purpose",
-                    "Testing",
-                    "", null, emptyList()
-                ),
-                "payment_state" to SpecificExtraction(
-                    "payment_state",
-                    "Payable",
-                    "", null, emptyList()
-                )
-            ))
-        ))
+        val specificExtractions = mutableMapOf(
+            "payment_recipient" to SpecificExtraction(
+                "payment_recipient",
+                "John Doe",
+                "companyname", null, emptyList()
+            ),
+            "iban" to SpecificExtraction(
+                "iban",
+                "DE123456789",
+                "iban", null, emptyList()
+            ),
+            "amount_to_pay" to SpecificExtraction(
+                "amount_to_pay",
+                "1.11:EUR",
+                "amount", null, emptyList()
+            ),
+            "payment_purpose" to SpecificExtraction(
+                "payment_purpose",
+                "Testing",
+                "text", null, emptyList()
+            ),
+            "payment_state" to SpecificExtraction(
+                "payment_state",
+                "Payable",
+                "text", null, emptyList()
+            )
+        )
 
         val paymentDetails = PaymentDetails(
             recipient = "Jack Vance",
@@ -62,38 +59,37 @@ class PaymentDetailsTest {
         )
 
         // When
-        compoundExtractions.withFeedback(paymentDetails)
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
 
         // Then
-        assertEquals(paymentDetails.recipient, compoundExtractions.getPaymentExtraction("payment_recipient")?.value)
-        assertEquals(paymentDetails.iban, compoundExtractions.getPaymentExtraction("iban")?.value)
-        assertEquals(paymentDetails.amount, compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
-        assertEquals(paymentDetails.purpose, compoundExtractions.getPaymentExtraction("payment_purpose")?.value)
+        assertEquals(paymentDetails.recipient, updatedExtractions["payment_recipient"]?.value)
+        assertEquals(paymentDetails.iban, updatedExtractions["iban"]?.value)
+        assertEquals(paymentDetails.amount, updatedExtractions["amount_to_pay"]?.value)
+        assertEquals(paymentDetails.purpose, updatedExtractions["payment_purpose"]?.value)
+        // Verify other extractions are preserved
+        assertEquals("Payable", updatedExtractions["payment_state"]?.value)
     }
 
     @Test
     fun `Adds missing payment extraction when updating payment detail values for feedback`() {
         // Given
-        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
-            "payment",
-            listOf(mapOf(
-                "iban" to SpecificExtraction(
-                    "iban",
-                    "DE123456789",
-                    "", null, emptyList()
-                ),
-                "amount_to_pay" to SpecificExtraction(
-                    "amount_to_pay",
-                    "1.11:EUR",
-                    "", null, emptyList()
-                ),
-                "payment_purpose" to SpecificExtraction(
-                    "payment_purpose",
-                    "Testing",
-                    "", null, emptyList()
-                )
-            ))
-        ))
+        val specificExtractions = mutableMapOf(
+            "iban" to SpecificExtraction(
+                "iban",
+                "DE123456789",
+                "iban", null, emptyList()
+            ),
+            "amount_to_pay" to SpecificExtraction(
+                "amount_to_pay",
+                "1.11:EUR",
+                "amount", null, emptyList()
+            ),
+            "payment_purpose" to SpecificExtraction(
+                "payment_purpose",
+                "Testing",
+                "text", null, emptyList()
+            )
+        )
 
         val paymentDetails = PaymentDetails(
             recipient = "Jack Vance",
@@ -103,28 +99,26 @@ class PaymentDetailsTest {
         )
 
         // When
-        compoundExtractions.withFeedback(paymentDetails)
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
 
         // Then
-        assertEquals(paymentDetails.recipient, compoundExtractions.getPaymentExtraction("payment_recipient")?.value)
-        assertEquals(paymentDetails.iban, compoundExtractions.getPaymentExtraction("iban")?.value)
-        assertEquals(paymentDetails.amount, compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
-        assertEquals(paymentDetails.purpose, compoundExtractions.getPaymentExtraction("payment_purpose")?.value)
+        assertEquals(paymentDetails.recipient, updatedExtractions["payment_recipient"]?.value)
+        assertEquals("companyname", updatedExtractions["payment_recipient"]?.entity)
+        assertEquals(paymentDetails.iban, updatedExtractions["iban"]?.value)
+        assertEquals(paymentDetails.amount, updatedExtractions["amount_to_pay"]?.value)
+        assertEquals(paymentDetails.purpose, updatedExtractions["payment_purpose"]?.value)
     }
 
     @Test
     fun `Converts amount_to_pay to backend format when updating payment detail values for feedback`() {
         // Given
-        val compoundExtractions = mutableMapOf("payment" to CompoundExtraction(
-            "payment",
-            listOf(mapOf(
-                "amount_to_pay" to SpecificExtraction(
-                    "amount_to_pay",
-                    "1.11:EUR",
-                    "", null, emptyList()
-                )
-            ))
-        ))
+        val specificExtractions = mutableMapOf(
+            "amount_to_pay" to SpecificExtraction(
+                "amount_to_pay",
+                "1.11:EUR",
+                "amount", null, emptyList()
+            )
+        )
 
         val paymentDetails = PaymentDetails(
             recipient = "Jack Vance",
@@ -134,10 +128,10 @@ class PaymentDetailsTest {
         )
 
         // When
-        compoundExtractions.withFeedback(paymentDetails)
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
 
         // Then
-        assertEquals("9.99:EUR", compoundExtractions.getPaymentExtraction("amount_to_pay")?.value)
+        assertEquals("9.99:EUR", updatedExtractions["amount_to_pay"]?.value)
     }
 
     @Test
@@ -163,4 +157,85 @@ class PaymentDetailsTest {
         // Then
         assertEquals("1.11", paymentDetails.amount)
     }
+
+    @Test
+    fun `Preserves extraction metadata when updating with feedback`() {
+        // Given
+        val box = net.gini.android.core.api.models.Box(1, 100.0, 200.0, 300.0, 400.0)
+        val specificExtractions = mutableMapOf(
+            "iban" to SpecificExtraction(
+                "iban",
+                "DE123456789",
+                "iban",
+                box,
+                emptyList()
+            )
+        )
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99",
+            purpose = "Still testing"
+        )
+
+        // When
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals("DE987654321", updatedExtractions["iban"]?.value)
+        assertEquals(box, updatedExtractions["iban"]?.box)
+        assertEquals("iban", updatedExtractions["iban"]?.entity)
+    }
+
+    @Test
+    fun `Sets correct entity types for payment extractions`() {
+        // Given
+        val specificExtractions = mutableMapOf<String, SpecificExtraction>()
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99",
+            purpose = "Still testing"
+        )
+
+        // When
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals("companyname", updatedExtractions["payment_recipient"]?.entity)
+        assertEquals("iban", updatedExtractions["iban"]?.entity)
+        assertEquals("amount", updatedExtractions["amount_to_pay"]?.entity)
+        assertEquals("text", updatedExtractions["payment_purpose"]?.entity)
+    }
+
+    @Test
+    fun `Does not modify original specific extractions map`() {
+        // Given
+        val specificExtractions = mutableMapOf(
+            "iban" to SpecificExtraction(
+                "iban",
+                "DE123456789",
+                "iban", null, emptyList()
+            )
+        )
+        val originalIban = specificExtractions["iban"]?.value
+
+        val paymentDetails = PaymentDetails(
+            recipient = "Jack Vance",
+            iban = "DE987654321",
+            amount = "9.99",
+            purpose = "Still testing"
+        )
+
+        // When
+        val updatedExtractions = specificExtractions.withFeedback(paymentDetails)
+
+        // Then
+        assertEquals(originalIban, specificExtractions["iban"]?.value)
+        assertEquals("DE987654321", updatedExtractions["iban"]?.value)
+    }
 }
+
+


### PR DESCRIPTION
Feedback was being sent via compound extractions; the backend (BAC-1771) now handles mapping automatically from specific extractions, making the compound approach redundant.

## Changes

- **`PaymentDetails.kt`** – Refactored `withFeedback()` to operate on and return a `Map<String, SpecificExtraction>`. Preserves existing extraction metadata (box, candidates, entity) while updating values for the four payment fields. Does not mutate the original map.

- **`PaymentFlowViewModel.kt`** – Updated `sendFeedback()` to pass the result of `withFeedback()` directly to `sendFeedbackForExtractions`. Consolidated no-op `Error`/`Loading` branches.

- **`PaymentDetailsTest.kt`** – Expanded test coverage: value updates, metadata preservation, correct default entity types when extractions are absent, blank entity preservation (intentional, matches prior behavior), and non-mutation of the original map.

- **`flow.rst`** – Documents the shift to specific extractions and clarifies that other existing specific extractions (e.g. `medical_service_provider`) are preserved alongside the four updated payment fields.

```kotlin
// Before: compound extraction map was updated
val feedbackMap = compoundExtractions.withFeedback(paymentDetails)

// After: specific extractions map is updated directly
val feedbackMap = specificExtractions.toMutableMap().withFeedback(paymentDetails)
sendFeedbackForExtractions(document, feedbackMap)
```