### PR TITLE
fix(bank-sdk): improve document import handling with background proce…

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -1280,20 +1280,21 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
             // when the URI comes from a cross-process content provider (e.g. cloud storage).
             // The image-vs-PDF check itself uses ContentResolver.getType() under the hood,
             // so the mime-type lookup must also run off the main thread.
+            final Context appContext = activity.getApplicationContext();
             final int fileSizeLimit = GiniCapture.hasInstance()
                     ? GiniCapture.getInstance().getImportedFileSizeBytesLimit()
                     : FILE_SIZE_LIMIT;
             final FileImportValidator fileImportValidator =
-                    new FileImportValidator(activity, fileSizeLimit);
+                    new FileImportValidator(appContext, fileSizeLimit);
             mImportExecutor.execute(() -> {
                 boolean streamAvailable = false;
                 boolean isImage = false;
                 boolean matches = false;
                 FileImportValidator.Error validationError = null;
                 try {
-                    streamAvailable = UriHelper.isUriInputStreamAvailable(uri, activity);
+                    streamAvailable = UriHelper.isUriInputStreamAvailable(uri, appContext);
                     if (streamAvailable) {
-                        isImage = isImage(data, activity);
+                        isImage = isImage(data, appContext);
                         if (!isImage) {
                             matches = fileImportValidator.matchesCriteria(data, uri);
                             validationError = fileImportValidator.getError();
@@ -1315,16 +1316,23 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     if (!isFragmentSafe()) {
                         return;
                     }
+                    // Re-fetch the current Activity: a configuration change may have
+                    // happened during the background work, making the originally captured
+                    // Activity stale.
+                    final Activity currentActivity = mFragment.getActivity();
+                    if (currentActivity == null) {
+                        return;
+                    }
                     if (!finalStreamAvailable) {
                         LOG.error("Document import failed: InputStream not available for the Uri");
                         showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                         return;
                     }
                     if (finalIsImage) {
-                        handleMultiPageDocumentAndCallListener(activity, data,
+                        handleMultiPageDocumentAndCallListener(currentActivity, data,
                                 Collections.singletonList(uri));
                     } else if (finalMatches) {
-                        createSinglePageDocumentAndCallListener(data, activity);
+                        createSinglePageDocumentAndCallListener(data, currentActivity);
                     } else if (finalValidationError != null) {
                         Error errorClass = new Error(finalValidationError);
                         ErrorType errorType = ErrorType.typeFromError(errorClass,
@@ -1353,8 +1361,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
         handleMultiPageDocumentAndCallListener(mFragment.getActivity(), new Intent(Intent.ACTION_PICK), uriList);
     }
 
-    private boolean isImage(@NonNull final Intent data, @NonNull final Activity activity) {
-        return IntentHelper.hasMimeTypeWithPrefix(data, activity, MimeType.IMAGE_PREFIX.asString());
+    private boolean isImage(@NonNull final Intent data, @NonNull final Context context) {
+        return IntentHelper.hasMimeTypeWithPrefix(data, context, MimeType.IMAGE_PREFIX.asString());
     }
 
     private void createSinglePageDocumentAndCallListener(final Intent data,
@@ -1610,8 +1618,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
         if (activity == null) {
             return;
         }
-        String errorMessage = activity.getResources()
-                .getString(errorType.getTitleTextResource());
+        final String errorMessage = activity.getString(errorType.getTitleTextResource());
         if (mUserAnalyticsEventTracker != null) {
             mUserAnalyticsEventTracker.trackEvent(
                     UserAnalyticsEvent.ERROR_DIALOG_SHOWN,
@@ -1623,9 +1630,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     }
             );
         }
-        String message = activity.getString(errorType.getTitleTextResource());
-        LOG.error("Invalid document {}", message);
-        showInvalidFileAlert(message);
+        LOG.error("Invalid document {}", errorMessage);
+        showInvalidFileAlert(errorMessage);
     }
 
     private void showInvalidFileAlert(final String message) {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -34,7 +34,6 @@ import androidx.core.os.BundleCompat;
 import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.FragmentActivity;
 import androidx.navigation.NavDestination;
-
 import net.gini.android.capture.AsyncCallback;
 import net.gini.android.capture.Document;
 import net.gini.android.capture.DocumentImportEnabledFileTypes;

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -13,6 +13,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import java.util.concurrent.Executors;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -1268,33 +1269,46 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                 showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                 return;
             }
-            if (!UriHelper.isUriInputStreamAvailable(uri, activity)) {
-                LOG.error("Document import failed: InputStream not available for the Uri");
-                showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
-                return;
-            }
-
             if (isImage(data, activity)) {
+                // For images: quick stream check then hand off to the existing AsyncTask
+                if (!UriHelper.isUriInputStreamAvailable(uri, activity)) {
+                    LOG.error("Document import failed: InputStream not available for the Uri");
+                    showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
+                    return;
+                }
                 handleMultiPageDocumentAndCallListener(activity, data,
                         Collections.singletonList(uri));
             } else {
-                final int fileSizeLimit;
-                if (GiniCapture.hasInstance()) {
-                    fileSizeLimit = GiniCapture.getInstance().getImportedFileSizeBytesLimit();
-                } else {
-                    fileSizeLimit = FILE_SIZE_LIMIT;
-                }
+                // For PDFs: run ALL I/O (stream check + page count via ContentResolver)
+                // on a background thread to prevent NetworkOnMainThreadException when the
+                // URI comes from a cross-process content provider (e.g. Google Drive).
+                final int fileSizeLimit = GiniCapture.hasInstance()
+                        ? GiniCapture.getInstance().getImportedFileSizeBytesLimit()
+                        : FILE_SIZE_LIMIT;
                 final FileImportValidator fileImportValidator = new FileImportValidator(activity, fileSizeLimit);
-                if (fileImportValidator.matchesCriteria(data, uri)) {
-                    createSinglePageDocumentAndCallListener(data, activity);
-                } else {
-                    final FileImportValidator.Error error = fileImportValidator.getError();
-                    if (error != null) {
-                        Error errorClass = new Error(error);
-                        ErrorType errorType = ErrorType.typeFromError(errorClass, getGetEInvoiceFeatureEnabledUseCase().invoke());
-                        showGenericInvalidFileError(errorType);
+                final Handler mainHandler = new Handler(Looper.getMainLooper());
+                Executors.newSingleThreadExecutor().execute(() -> {
+                    if (!UriHelper.isUriInputStreamAvailable(uri, activity)) {
+                        mainHandler.post(() -> {
+                            LOG.error("Document import failed: InputStream not available for the Uri");
+                            showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
+                        });
+                        return;
                     }
-                }
+                    final boolean matches = fileImportValidator.matchesCriteria(data, uri);
+                    final FileImportValidator.Error validationError = fileImportValidator.getError();
+                    mainHandler.post(() -> {
+                        if (matches) {
+                            createSinglePageDocumentAndCallListener(data, activity);
+                        } else {
+                            if (validationError != null) {
+                                Error errorClass = new Error(validationError);
+                                ErrorType errorType = ErrorType.typeFromError(errorClass, getGetEInvoiceFeatureEnabledUseCase().invoke());
+                                showGenericInvalidFileError(errorType);
+                            }
+                        }
+                    });
+                });
             }
         }
     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -1291,6 +1291,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                 boolean isImage = false;
                 boolean matches = false;
                 FileImportValidator.Error validationError = null;
+                GiniCaptureDocument preparedDocument = null;
                 try {
                     streamAvailable = UriHelper.isUriInputStreamAvailable(uri, appContext);
                     if (streamAvailable) {
@@ -1298,6 +1299,20 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                         if (!isImage) {
                             matches = fileImportValidator.matchesCriteria(data, uri);
                             validationError = fileImportValidator.getError();
+                            if (matches) {
+                                // Build the document on the background thread because
+                                // DocumentFactory.newDocumentFromIntent performs additional
+                                // ContentResolver I/O (getType + query for filename), which
+                                // can also trigger NetworkOnMainThreadException for cloud
+                                // URIs. Only the listener callback is dispatched to the UI.
+                                preparedDocument = DocumentFactory.newDocumentFromIntent(
+                                        data,
+                                        appContext,
+                                        DeviceHelper.getDeviceOrientation(appContext),
+                                        DeviceHelper.getDeviceType(appContext),
+                                        ImportMethod.PICKER);
+                                LOG.info("Document imported: {}", preparedDocument);
+                            }
                         }
                     }
                 } catch (final Exception e) {
@@ -1307,11 +1322,13 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     // invalid file rather than letting the executor thread crash.
                     LOG.error("Document import failed: unexpected error while validating Uri", e);
                     streamAvailable = false;
+                    preparedDocument = null;
                 }
                 final boolean finalStreamAvailable = streamAvailable;
                 final boolean finalIsImage = isImage;
                 final boolean finalMatches = matches;
                 final FileImportValidator.Error finalValidationError = validationError;
+                final GiniCaptureDocument finalDocument = preparedDocument;
                 mMainHandler.post(() -> {
                     if (!isFragmentSafe()) {
                         return;
@@ -1331,8 +1348,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     if (finalIsImage) {
                         handleMultiPageDocumentAndCallListener(currentActivity, data,
                                 Collections.singletonList(uri));
-                    } else if (finalMatches) {
-                        createSinglePageDocumentAndCallListener(data, currentActivity);
+                    } else if (finalMatches && finalDocument != null) {
+                        requestClientDocumentCheck(finalDocument);
                     } else if (finalValidationError != null) {
                         Error errorClass = new Error(finalValidationError);
                         ErrorType errorType = ErrorType.typeFromError(errorClass,
@@ -1351,7 +1368,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
             return false;
         }
         final Activity activity = mFragment.getActivity();
-        return activity != null && !activity.isFinishing();
+        return activity != null && !activity.isFinishing() && !activity.isDestroyed();
     }
 
     private void importDocumentFromUriList(List<Uri> uriList) {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -1287,46 +1287,47 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
             final FileImportValidator fileImportValidator =
                     new FileImportValidator(appContext, fileSizeLimit);
             mImportExecutor.execute(() -> {
-                boolean streamAvailable = false;
                 boolean isImage = false;
                 boolean matches = false;
+                boolean validationFailed = false;
                 FileImportValidator.Error validationError = null;
                 GiniCaptureDocument preparedDocument = null;
                 try {
-                    streamAvailable = UriHelper.isUriInputStreamAvailable(uri, appContext);
-                    if (streamAvailable) {
-                        isImage = isImage(data, appContext);
-                        if (!isImage) {
-                            matches = fileImportValidator.matchesCriteria(data, uri);
-                            validationError = fileImportValidator.getError();
-                            if (matches) {
-                                // Build the document on the background thread because
-                                // DocumentFactory.newDocumentFromIntent performs additional
-                                // ContentResolver I/O (getType + query for filename), which
-                                // can also trigger NetworkOnMainThreadException for cloud
-                                // URIs. Only the listener callback is dispatched to the UI.
-                                preparedDocument = DocumentFactory.newDocumentFromIntent(
-                                        data,
-                                        appContext,
-                                        DeviceHelper.getDeviceOrientation(appContext),
-                                        DeviceHelper.getDeviceType(appContext),
-                                        ImportMethod.PICKER);
-                                LOG.info("Document imported: {}", preparedDocument);
-                            }
+                    // Determine if the URI is an image. This performs ContentResolver I/O
+                    // (getType) but is necessary to route images vs PDFs correctly.
+                    isImage = isImage(data, appContext);
+                    if (!isImage) {
+                        // For non-images (PDFs), validate file criteria. This internally
+                        // checks stream availability, so no separate pre-check is needed.
+                        matches = fileImportValidator.matchesCriteria(data, uri);
+                        validationError = fileImportValidator.getError();
+                        if (matches) {
+                            // Build the document on the background thread because
+                            // DocumentFactory.newDocumentFromIntent performs additional
+                            // ContentResolver I/O (getType + query for filename), which
+                            // can also trigger NetworkOnMainThreadException for cloud
+                            // URIs. Only the listener callback is dispatched to the UI.
+                            preparedDocument = DocumentFactory.newDocumentFromIntent(
+                                    data,
+                                    appContext,
+                                    DeviceHelper.getDeviceOrientation(appContext),
+                                    DeviceHelper.getDeviceType(appContext),
+                                    ImportMethod.PICKER);
+                            LOG.info("Document imported: {}", preparedDocument);
                         }
                     }
                 } catch (final Exception e) {
-                    // openInputStream / ContentResolver calls can throw SecurityException
-                    // (revoked URI permission), IllegalArgumentException, or other runtime
-                    // exceptions from cross-process providers. Treat any failure as an
-                    // invalid file rather than letting the executor thread crash.
+                    // ContentResolver calls can throw SecurityException (revoked URI
+                    // permission), IllegalArgumentException, or other runtime exceptions
+                    // from cross-process providers. Treat any failure as a generic
+                    // import error rather than letting the executor thread crash.
                     LOG.error("Document import failed: unexpected error while validating Uri", e);
-                    streamAvailable = false;
+                    validationFailed = true;
                     preparedDocument = null;
                 }
-                final boolean finalStreamAvailable = streamAvailable;
                 final boolean finalIsImage = isImage;
                 final boolean finalMatches = matches;
+                final boolean finalValidationFailed = validationFailed;
                 final FileImportValidator.Error finalValidationError = validationError;
                 final GiniCaptureDocument finalDocument = preparedDocument;
                 mMainHandler.post(() -> {
@@ -1340,8 +1341,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     if (currentActivity == null) {
                         return;
                     }
-                    if (!finalStreamAvailable) {
-                        LOG.error("Document import failed: InputStream not available for the Uri");
+                    if (finalValidationFailed) {
+                        LOG.error("Document import failed: validation error");
                         showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                         return;
                     }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -13,7 +13,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import java.util.concurrent.Executors;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -119,6 +118,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import jersey.repackaged.jsr166e.CompletableFuture;
@@ -199,6 +200,10 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
     private boolean mIsFlashEnabled = true;
 
     private final UIExecutor mUIExecutor = new UIExecutor();
+    // Shared single-thread executor for off-main-thread document import I/O.
+    // Reused across imports to avoid per-call thread leaks; shut down in onDestroy().
+    private final ExecutorService mImportExecutor = Executors.newSingleThreadExecutor();
+    private final Handler mMainHandler = new Handler(Looper.getMainLooper());
     private CameraInterface mCameraController;
     private ImageMultiPageDocument mMultiPageDocument;
     private PaymentQRCodeReader mPaymentQRCodeReader;
@@ -743,6 +748,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
         if (mImportUrisAsyncTask != null) {
             mImportUrisAsyncTask.cancel(true);
         }
+        mMainHandler.removeCallbacksAndMessages(null);
+        mImportExecutor.shutdownNow();
     }
 
     private void closeCamera() {
@@ -1269,48 +1276,53 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                 showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                 return;
             }
-            if (isImage(data, activity)) {
-                // For images: quick stream check then hand off to the existing AsyncTask
-                if (!UriHelper.isUriInputStreamAvailable(uri, activity)) {
-                    LOG.error("Document import failed: InputStream not available for the Uri");
-                    showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
-                    return;
-                }
-                handleMultiPageDocumentAndCallListener(activity, data,
-                        Collections.singletonList(uri));
-            } else {
-                // For PDFs: run ALL I/O (stream check + page count via ContentResolver)
-                // on a background thread to prevent NetworkOnMainThreadException when the
-                // URI comes from a cross-process content provider (e.g. Google Drive).
-                final int fileSizeLimit = GiniCapture.hasInstance()
-                        ? GiniCapture.getInstance().getImportedFileSizeBytesLimit()
-                        : FILE_SIZE_LIMIT;
-                final FileImportValidator fileImportValidator = new FileImportValidator(activity, fileSizeLimit);
-                final Handler mainHandler = new Handler(Looper.getMainLooper());
-                Executors.newSingleThreadExecutor().execute(() -> {
-                    if (!UriHelper.isUriInputStreamAvailable(uri, activity)) {
-                        mainHandler.post(() -> {
-                            LOG.error("Document import failed: InputStream not available for the Uri");
-                            showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
-                        });
+            // Run import I/O (stream check + PDF page count via ContentResolver) on a
+            // background thread to prevent NetworkOnMainThreadException when the URI
+            // comes from a cross-process content provider (e.g. Google Drive).
+            // Fix for: PP-2362 (crash reported by customer Mario, bank-sdk 4.1.0).
+            final boolean isImage = isImage(data, activity);
+            final int fileSizeLimit = GiniCapture.hasInstance()
+                    ? GiniCapture.getInstance().getImportedFileSizeBytesLimit()
+                    : FILE_SIZE_LIMIT;
+            final FileImportValidator fileImportValidator =
+                    isImage ? null : new FileImportValidator(activity, fileSizeLimit);
+            mImportExecutor.execute(() -> {
+                final boolean streamAvailable = UriHelper.isUriInputStreamAvailable(uri, activity);
+                final boolean matches = !isImage && streamAvailable
+                        && fileImportValidator.matchesCriteria(data, uri);
+                final FileImportValidator.Error validationError =
+                        fileImportValidator != null ? fileImportValidator.getError() : null;
+                mMainHandler.post(() -> {
+                    if (!isFragmentSafe()) {
                         return;
                     }
-                    final boolean matches = fileImportValidator.matchesCriteria(data, uri);
-                    final FileImportValidator.Error validationError = fileImportValidator.getError();
-                    mainHandler.post(() -> {
-                        if (matches) {
-                            createSinglePageDocumentAndCallListener(data, activity);
-                        } else {
-                            if (validationError != null) {
-                                Error errorClass = new Error(validationError);
-                                ErrorType errorType = ErrorType.typeFromError(errorClass, getGetEInvoiceFeatureEnabledUseCase().invoke());
-                                showGenericInvalidFileError(errorType);
-                            }
-                        }
-                    });
+                    if (!streamAvailable) {
+                        LOG.error("Document import failed: InputStream not available for the Uri");
+                        showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
+                        return;
+                    }
+                    if (isImage) {
+                        handleMultiPageDocumentAndCallListener(activity, data,
+                                Collections.singletonList(uri));
+                    } else if (matches) {
+                        createSinglePageDocumentAndCallListener(data, activity);
+                    } else if (validationError != null) {
+                        Error errorClass = new Error(validationError);
+                        ErrorType errorType = ErrorType.typeFromError(errorClass,
+                                getGetEInvoiceFeatureEnabledUseCase().invoke());
+                        showGenericInvalidFileError(errorType);
+                    }
                 });
-            }
+            });
         }
+    }
+
+    private boolean isFragmentSafe() {
+        if (mFragment == null) {
+            return false;
+        }
+        final Activity activity = mFragment.getActivity();
+        return activity != null && !activity.isFinishing();
     }
 
     private void importDocumentFromUriList(List<Uri> uriList) {
@@ -1573,7 +1585,11 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
     }
 
     private void showGenericInvalidFileError(ErrorType errorType) {
-        String errorMessage = mFragment.getActivity().getResources()
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return;
+        }
+        String errorMessage = activity.getResources()
                 .getString(errorType.getTitleTextResource());
         if (mUserAnalyticsEventTracker != null) {
             mUserAnalyticsEventTracker.trackEvent(
@@ -1585,10 +1601,6 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                         }
                     }
             );
-        }
-        final Activity activity = mFragment.getActivity();
-        if (activity == null) {
-            return;
         }
         String message = activity.getString(errorType.getTitleTextResource());
         LOG.error("Invalid document {}", message);

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -1276,41 +1276,62 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                 showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                 return;
             }
-            // Run import I/O (stream check + PDF page count via ContentResolver) on a
-            // background thread to prevent NetworkOnMainThreadException when the URI
-            // comes from a cross-process content provider (e.g. Google Drive).
-            // Fix for: PP-2362 (crash reported by customer Mario, bank-sdk 4.1.0).
-            final boolean isImage = isImage(data, activity);
+            // Run import I/O on a background thread to prevent NetworkOnMainThreadException
+            // when the URI comes from a cross-process content provider (e.g. cloud storage).
+            // The image-vs-PDF check itself uses ContentResolver.getType() under the hood,
+            // so the mime-type lookup must also run off the main thread.
             final int fileSizeLimit = GiniCapture.hasInstance()
                     ? GiniCapture.getInstance().getImportedFileSizeBytesLimit()
                     : FILE_SIZE_LIMIT;
             final FileImportValidator fileImportValidator =
-                    isImage ? null : new FileImportValidator(activity, fileSizeLimit);
+                    new FileImportValidator(activity, fileSizeLimit);
             mImportExecutor.execute(() -> {
-                final boolean streamAvailable = UriHelper.isUriInputStreamAvailable(uri, activity);
-                final boolean matches = !isImage && streamAvailable
-                        && fileImportValidator.matchesCriteria(data, uri);
-                final FileImportValidator.Error validationError =
-                        fileImportValidator != null ? fileImportValidator.getError() : null;
+                boolean streamAvailable = false;
+                boolean isImage = false;
+                boolean matches = false;
+                FileImportValidator.Error validationError = null;
+                try {
+                    streamAvailable = UriHelper.isUriInputStreamAvailable(uri, activity);
+                    if (streamAvailable) {
+                        isImage = isImage(data, activity);
+                        if (!isImage) {
+                            matches = fileImportValidator.matchesCriteria(data, uri);
+                            validationError = fileImportValidator.getError();
+                        }
+                    }
+                } catch (final Exception e) {
+                    // openInputStream / ContentResolver calls can throw SecurityException
+                    // (revoked URI permission), IllegalArgumentException, or other runtime
+                    // exceptions from cross-process providers. Treat any failure as an
+                    // invalid file rather than letting the executor thread crash.
+                    LOG.error("Document import failed: unexpected error while validating Uri", e);
+                    streamAvailable = false;
+                }
+                final boolean finalStreamAvailable = streamAvailable;
+                final boolean finalIsImage = isImage;
+                final boolean finalMatches = matches;
+                final FileImportValidator.Error finalValidationError = validationError;
                 mMainHandler.post(() -> {
                     if (!isFragmentSafe()) {
                         return;
                     }
-                    if (!streamAvailable) {
+                    if (!finalStreamAvailable) {
                         LOG.error("Document import failed: InputStream not available for the Uri");
                         showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                         return;
                     }
-                    if (isImage) {
+                    if (finalIsImage) {
                         handleMultiPageDocumentAndCallListener(activity, data,
                                 Collections.singletonList(uri));
-                    } else if (matches) {
+                    } else if (finalMatches) {
                         createSinglePageDocumentAndCallListener(data, activity);
-                    } else if (validationError != null) {
-                        Error errorClass = new Error(validationError);
+                    } else if (finalValidationError != null) {
+                        Error errorClass = new Error(finalValidationError);
                         ErrorType errorType = ErrorType.typeFromError(errorClass,
                                 getGetEInvoiceFeatureEnabledUseCase().invoke());
                         showGenericInvalidFileError(errorType);
+                    } else {
+                        showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                     }
                 });
             });

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -103,7 +103,6 @@ import net.gini.android.capture.tracking.useranalytics.UserAnalyticsEventTracker
 import net.gini.android.capture.tracking.useranalytics.UserAnalyticsScreen;
 import net.gini.android.capture.tracking.useranalytics.properties.UserAnalyticsEventProperty;
 import net.gini.android.capture.util.IntentHelper;
-import net.gini.android.capture.util.UriHelper;
 import net.gini.android.capture.view.CustomLoadingIndicatorAdapter;
 import net.gini.android.capture.view.InjectedViewAdapterHolder;
 import net.gini.android.capture.view.InjectedViewContainer;
@@ -1287,44 +1286,50 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
             final FileImportValidator fileImportValidator =
                     new FileImportValidator(appContext, fileSizeLimit);
             mImportExecutor.execute(() -> {
-                boolean streamAvailable = false;
+                boolean validationFailed = false;
                 boolean isImage = false;
                 boolean matches = false;
                 FileImportValidator.Error validationError = null;
                 GiniCaptureDocument preparedDocument = null;
                 try {
-                    streamAvailable = UriHelper.isUriInputStreamAvailable(uri, appContext);
-                    if (streamAvailable) {
-                        isImage = isImage(data, appContext);
-                        if (!isImage) {
-                            matches = fileImportValidator.matchesCriteria(data, uri);
-                            validationError = fileImportValidator.getError();
-                            if (matches) {
-                                // Build the document on the background thread because
-                                // DocumentFactory.newDocumentFromIntent performs additional
-                                // ContentResolver I/O (getType + query for filename), which
-                                // can also trigger NetworkOnMainThreadException for cloud
-                                // URIs. Only the listener callback is dispatched to the UI.
-                                preparedDocument = DocumentFactory.newDocumentFromIntent(
-                                        data,
-                                        appContext,
-                                        DeviceHelper.getDeviceOrientation(appContext),
-                                        DeviceHelper.getDeviceType(appContext),
-                                        ImportMethod.PICKER);
-                                LOG.info("Document imported: {}", preparedDocument);
-                            }
+                    // Skip the explicit isUriInputStreamAvailable() pre-check:
+                    //   - For images, AbstractImportImageUrisAsyncTask runs the same check
+                    //     internally on its background thread.
+                    //   - For PDFs, FileImportValidator.matchesCriteria() opens the file
+                    //     (via Pdf.getPageCount -> ContentResolver.openFileDescriptor)
+                    //     as part of validation.
+                    // Removing the pre-check avoids duplicate cross-process I/O.
+                    isImage = isImage(data, appContext);
+                    if (!isImage) {
+                        matches = fileImportValidator.matchesCriteria(data, uri);
+                        validationError = fileImportValidator.getError();
+                        if (matches) {
+                            // Build the document on the background thread because
+                            // DocumentFactory.newDocumentFromIntent performs additional
+                            // ContentResolver I/O (getType + query for filename), which
+                            // can also trigger NetworkOnMainThreadException for cloud
+                            // URIs. Only the listener callback is dispatched to the UI.
+                            preparedDocument = DocumentFactory.newDocumentFromIntent(
+                                    data,
+                                    appContext,
+                                    DeviceHelper.getDeviceOrientation(appContext),
+                                    DeviceHelper.getDeviceType(appContext),
+                                    ImportMethod.PICKER);
+                            LOG.info("Document imported: {}", preparedDocument);
                         }
                     }
                 } catch (final Exception e) {
-                    // openInputStream / ContentResolver calls can throw SecurityException
-                    // (revoked URI permission), IllegalArgumentException, or other runtime
-                    // exceptions from cross-process providers. Treat any failure as an
-                    // invalid file rather than letting the executor thread crash.
-                    LOG.error("Document import failed: unexpected error while validating Uri", e);
-                    streamAvailable = false;
+                    // ContentResolver calls (getType / query / openFileDescriptor) can throw
+                    // SecurityException (revoked URI permission), IllegalArgumentException,
+                    // or other runtime exceptions from cross-process providers. Mark the
+                    // whole validation as failed so the UI can show a generic import error
+                    // instead of crashing the executor thread or showing a misleading
+                    // "InputStream not available" message.
+                    LOG.error("Document import failed: unexpected error during validation", e);
+                    validationFailed = true;
                     preparedDocument = null;
                 }
-                final boolean finalStreamAvailable = streamAvailable;
+                final boolean finalValidationFailed = validationFailed;
                 final boolean finalIsImage = isImage;
                 final boolean finalMatches = matches;
                 final FileImportValidator.Error finalValidationError = validationError;
@@ -1340,8 +1345,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                     if (currentActivity == null) {
                         return;
                     }
-                    if (!finalStreamAvailable) {
-                        LOG.error("Document import failed: InputStream not available for the Uri");
+                    if (finalValidationFailed) {
                         showGenericInvalidFileError(ErrorType.FILE_IMPORT_GENERIC);
                         return;
                     }


### PR DESCRIPTION
This pull request improves the document import process in `CameraFragmentImpl.java` by ensuring that all I/O operations for PDF imports are performed off the main thread, preventing potential `NetworkOnMainThreadException` errors. The logic for importing images and PDFs has been separated for clarity and robustness.

**Improvements to document import process:**

* Refactored the PDF import logic in `importDocumentFromIntent` to run all I/O operations (input stream check and page count) on a background thread using `Executors.newSingleThreadExecutor()`. This avoids `NetworkOnMainThreadException` when importing files from cross-process content providers like Google Drive.
* Added an import statement for `java.util.concurrent.Executors` to support background threading.…ssing

PP-2552