### PR TITLE
fix(capture-sdk): cancel coroutines on stop to prevent NPE crash

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
@@ -209,6 +209,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     @Override
     public void stop() {
         mStopped = true;
+        extension.cancel();
         stopScanAnimation();
         if (!mAnalysisCompleted) {
             deleteUploadedDocuments();

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenterExtension.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenterExtension.kt
@@ -3,6 +3,7 @@ package net.gini.android.capture.analysis
 import android.app.Activity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -58,9 +59,16 @@ internal class AnalysisScreenPresenterExtension(
     private val incrementInvoiceRecognizedCounterUseCase: IncrementInvoiceRecognizedCounterUseCase
             by getGiniCaptureKoin().inject()
 
+    private val job = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+
     private val educationMutex = Mutex()
 
     private var invoiceEducationType: InvoiceEducationType? = null
+
+    fun cancel() {
+        job.cancel()
+    }
 
     fun getAnalysisFragmentListenerOrNoOp(): AnalysisFragmentListener {
         return listener ?: noOpListener
@@ -254,7 +262,7 @@ internal class AnalysisScreenPresenterExtension(
     }
 
     private fun doWhenEducationFinished(action: () -> Unit) {
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch {
             educationMutex.withLock {
                 withContext(Dispatchers.Main) {
                     action()

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragment.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/noresults/NoResultsFragment.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
+import androidx.navigation.NavDestination;
 import androidx.navigation.NavDirections;
 import androidx.navigation.fragment.NavHostFragment;
 
@@ -104,7 +105,8 @@ public class NoResultsFragment extends Fragment implements FragmentImplCallback 
             NavController navController,
             NavDirections direction
     ) {
-        if (navController.getCurrentDestination().getId() == R.id.gc_destination_noresults_fragment) {
+        NavDestination currentDest = navController.getCurrentDestination();
+        if (currentDest == null || currentDest.getId() == R.id.gc_destination_noresults_fragment) {
             return;
         }
         navController.navigate(direction);

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/analysis/AnalysisScreenPresenterExtensionCancellationTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/analysis/AnalysisScreenPresenterExtensionCancellationTest.kt
@@ -1,0 +1,71 @@
+package net.gini.android.capture.analysis
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.Job
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for [AnalysisScreenPresenterExtension] cancellation.
+ *
+ * Root cause: [AnalysisScreenPresenterExtension.doWhenEducationFinished] used to create a fresh
+ * CoroutineScope(Dispatchers.IO) for every invocation. These anonymous scopes were never
+ * cancelled when the user pressed Back (fragment destroyed), so the pending navigation callback
+ * could still execute on a dead NavController, causing an NPE crash.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnalysisScreenPresenterExtensionCancellationTest {
+
+    /**
+     * The extension must own a named [Job] so that [AnalysisScreenPresenterExtension.cancel]
+     * can reliably cancel ALL coroutines launched by [AnalysisScreenPresenterExtension].
+     *
+     * **Fails when reverted**: Reverting to `CoroutineScope(Dispatchers.IO).launch` inside
+     * `doWhenEducationFinished` removes the `job` field entirely, causing this test to throw
+     * [NoSuchFieldException].
+     */
+    @Test
+    fun extension_owns_active_coroutine_job_on_construction() {
+        val view = mock<AnalysisScreenContract.View>()
+        val extension = AnalysisScreenPresenterExtension(view)
+
+        val job = getJobViaReflection(extension)
+
+        assertThat(job.isActive).isTrue()
+    }
+
+    /**
+     * After [AnalysisScreenPresenterExtension.cancel] is called the owned [Job] must be
+     * cancelled. A cancelled job means any subsequent `scope.launch { ... }` inside
+     * `doWhenEducationFinished` is a no-op and will never invoke the navigation callback.
+     *
+     * **Fails when reverted**: Removing [AnalysisScreenPresenterExtension.cancel] (or reverting
+     * the named scope) means the job is never cancelled and [Job.isCancelled] stays false.
+     */
+    @Test
+    fun cancel_cancels_the_owned_coroutine_job() {
+        val view = mock<AnalysisScreenContract.View>()
+        val extension = AnalysisScreenPresenterExtension(view)
+
+        extension.cancel()
+
+        val job = getJobViaReflection(extension)
+        assertThat(job.isCancelled).isTrue()
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    /**
+     * Reads the private `job` field from [AnalysisScreenPresenterExtension] via reflection.
+     * Throws [NoSuchFieldException] if the field does not exist, which is itself evidence
+     * that Fix 2 was reverted.
+     */
+    private fun getJobViaReflection(extension: AnalysisScreenPresenterExtension): Job {
+        val field = AnalysisScreenPresenterExtension::class.java.getDeclaredField("job")
+        field.isAccessible = true
+        return field.get(extension) as Job
+    }
+}
+

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/analysis/AnalysisScreenPresenterTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/analysis/AnalysisScreenPresenterTest.kt
@@ -64,6 +64,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import java.util.Collections
 import java.util.concurrent.CancellationException
+import kotlinx.coroutines.Job
 
 /**
  * Created by Alpar Szotyori on 10.05.2019.
@@ -631,6 +632,36 @@ class AnalysisScreenPresenterTest {
 
         // Then
         verify(listener).onDefaultPDFAppAlertDialogCancelled()
+    }
+
+    // ── PP-2278 regression test (Fix 3) ───────────────────────────────────────
+
+    /**
+     * [AnalysisScreenPresenter.stop] must call [AnalysisScreenPresenterExtension.cancel] so that
+     * all coroutines managing post-analysis navigation are cancelled when the fragment is destroyed.
+     *
+     * Without this call, the coroutine scope inside the extension is never cancelled and a
+     * pending navigation can still fire on a dead NavController, causing an NPE crash.
+     *
+     * **Fails when reverted**: Removing `extension.cancel()` from [AnalysisScreenPresenter.stop]
+     * leaves the extension job active after stop() and this assertion fails.
+     */
+    @Test
+    @Throws(Exception::class)
+    fun should_cancel_extensionScope_whenStopped() {
+        // Given
+        val imageDocument: ImageDocument = ImageDocumentFake()
+        val presenter = createPresenter(imageDocument, null)
+        val jobField = AnalysisScreenPresenterExtension::class.java.getDeclaredField("job")
+        jobField.isAccessible = true
+        val job = jobField.get(presenter.extension) as Job
+        Truth.assertThat(job.isActive).isTrue()
+
+        // When: user presses Back (fragment destroyed -> stop() is called)
+        presenter.stop()
+
+        // Then: extension scope must be cancelled so no pending navigation fires on dead NavController
+        Truth.assertThat(job.isCancelled).isTrue()
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses a regression where coroutines related to post-analysis navigation could continue running after the analysis screen was stopped, potentially causing crashes due to navigation callbacks firing on a destroyed fragment. The main fix is to ensure all coroutines in `AnalysisScreenPresenterExtension` are properly cancelled when the presenter is stopped. The changes also improve test coverage for this behavior and make navigation handling more robust.

**Coroutine scope management and cancellation:**

* Added a `SupervisorJob` and a dedicated `CoroutineScope` to `AnalysisScreenPresenterExtension`, and provided a `cancel()` method to cancel all coroutines launched by the extension. This ensures that background tasks are properly cancelled when the fragment or presenter is stopped.
* Updated `doWhenEducationFinished` to launch coroutines using the extension's managed scope instead of creating anonymous, uncancellable scopes.
* Modified `AnalysisScreenPresenter.stop()` to call `extension.cancel()`, ensuring that all coroutines are cancelled when the presenter is stopped.

**Regression tests:**

* Added `AnalysisScreenPresenterExtensionCancellationTest` to verify that the extension owns a cancellable coroutine job and that `cancel()` properly cancels all coroutines.
* Added a regression test in `AnalysisScreenPresenterTest` to ensure that calling `stop()` on the presenter cancels the extension's coroutine scope.

**Navigation robustness:**

* Improved `navigateToNoResultsFragment` to safely handle cases where the current navigation destination is `null`, preventing potential crashes.

These changes collectively prevent navigation callbacks from firing after the analysis fragment has been destroyed, addressing the root cause of a previously observed crash.PP-2278