### PR TITLE
XPL 16  SonarQube Core API Library issues

### DIFF
--- a/core-api-library/library/src/androidTest/java/net/gini/android/core/api/DocumentMetadataTest.java
+++ b/core-api-library/library/src/androidTest/java/net/gini/android/core/api/DocumentMetadataTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import net.gini.android.core.api.DocumentMetadata;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class DocumentMetadataTest {
     private DocumentMetadata mDocumentMetadata;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mDocumentMetadata = new DocumentMetadata();
     }
 

--- a/core-api-library/library/src/androidTest/java/net/gini/android/core/api/MediaTypesTest.java
+++ b/core-api-library/library/src/androidTest/java/net/gini/android/core/api/MediaTypesTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import androidx.test.filters.SmallTest;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import net.gini.android.core.api.MediaTypes;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core-api-library/library/src/androidTest/java/net/gini/android/core/api/SessionTest.java
+++ b/core-api-library/library/src/androidTest/java/net/gini/android/core/api/SessionTest.java
@@ -11,8 +11,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import net.gini.android.core.api.authorization.Session;
 import net.gini.android.core.api.authorization.apimodels.SessionToken;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,14 +32,14 @@ public class SessionTest {
     }
 
     @Test
-    public void testFactoryReturnsSession() throws JSONException {
+    public void testFactoryReturnsSession() {
         SessionToken responseData = createTestResponse();
 
         assertNotNull(Session.fromAPIResponse(responseData));
     }
 
     @Test
-    public void testFactorySetsCorrectAccessToken() throws JSONException {
+    public void testFactorySetsCorrectAccessToken() {
         SessionToken responseData = createTestResponse();
 
         Session session = Session.fromAPIResponse(responseData);
@@ -50,7 +48,7 @@ public class SessionTest {
     }
 
     @Test
-    public void testFactorySetsCorrectExpirationDate() throws JSONException {
+    public void testFactorySetsCorrectExpirationDate() {
         SessionToken responseData = createTestResponse();
 
         Session session = Session.fromAPIResponse(responseData);

--- a/core-api-library/library/src/androidTest/java/net/gini/android/core/api/authorization/EncryptedCredentialsStoreTest.java
+++ b/core-api-library/library/src/androidTest/java/net/gini/android/core/api/authorization/EncryptedCredentialsStoreTest.java
@@ -4,8 +4,8 @@ import static android.content.Context.MODE_PRIVATE;
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import android.content.SharedPreferences;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -29,7 +29,7 @@ public class EncryptedCredentialsStoreTest {
     private EncryptedCredentialsStore mCredentialsStore;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mSharedPreferences = getApplicationContext().getSharedPreferences("GiniTests", MODE_PRIVATE);
         mSharedPreferences.edit().clear().commit();
 
@@ -37,7 +37,7 @@ public class EncryptedCredentialsStoreTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         mSharedPreferences.edit().clear().commit();
     }
 
@@ -52,8 +52,8 @@ public class EncryptedCredentialsStoreTest {
         // Then
         final UserCredentials encryptedUserCredentials =
                 mCredentialsStore.getEncryptedUserCredentials();
-        assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
-        assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
+        assertNotEquals(userCredentials.getUsername(), encryptedUserCredentials.getUsername());
+        assertNotEquals(userCredentials.getPassword(), encryptedUserCredentials.getPassword());
     }
 
     @Test
@@ -98,8 +98,8 @@ public class EncryptedCredentialsStoreTest {
         // Then
         final UserCredentials encryptedUserCredentials =
                 mCredentialsStore.getEncryptedUserCredentials();
-        assertTrue(!userCredentials.getUsername().equals(encryptedUserCredentials.getUsername()));
-        assertTrue(!userCredentials.getPassword().equals(encryptedUserCredentials.getPassword()));
+        assertNotEquals(userCredentials.getUsername(), encryptedUserCredentials.getUsername());
+        assertNotEquals(userCredentials.getPassword(), encryptedUserCredentials.getPassword());
     }
 
     @Test
@@ -135,7 +135,7 @@ public class EncryptedCredentialsStoreTest {
         mCredentialsStore.storeUserCredentials(userCredentials);
         // Then
         final int encryptionVersion = mCredentialsStore.getEncryptionVersion();
-        assertEquals(encryptionVersion, EncryptedCredentialsStore.ENCRYPTION_VERSION);
+        assertEquals(EncryptedCredentialsStore.ENCRYPTION_VERSION, encryptionVersion);
     }
 
     @Test
@@ -149,8 +149,8 @@ public class EncryptedCredentialsStoreTest {
         mCredentialsStore.storeUserCredentials(userCredentials);
         final UserCredentials encryptedCredentials2 = mCredentialsStore.getEncryptedUserCredentials();
         // Then
-        assertTrue(!encryptedCredentials1.getUsername().equals(encryptedCredentials2.getUsername()));
-        assertTrue(!encryptedCredentials1.getPassword().equals(encryptedCredentials2.getPassword()));
+        assertNotEquals(encryptedCredentials1.getUsername(), encryptedCredentials2.getUsername());
+        assertNotEquals(encryptedCredentials1.getPassword(), encryptedCredentials2.getPassword());
     }
 
     @Test

--- a/core-api-library/library/src/androidTest/java/net/gini/android/core/api/authorization/SharedPreferencesCredentialsStoreTest.java
+++ b/core-api-library/library/src/androidTest/java/net/gini/android/core/api/authorization/SharedPreferencesCredentialsStoreTest.java
@@ -41,6 +41,7 @@ public class SharedPreferencesCredentialsStoreTest {
             new SharedPreferencesCredentialsStore(null);
             fail("NullPointerException not raised");
         } catch (NullPointerException ignored) {
+            // Expected: NullPointerException should be thrown for null argument
         }
     }
 

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -40,13 +39,7 @@ public class DocumentMetadata {
      * Create a new instance.
      */
     public DocumentMetadata() {
-        try {
-            final Charset asciiCharset = StandardCharsets.US_ASCII;
-            mAsciiCharsetEncoder = asciiCharset.newEncoder();
-        } catch (IllegalArgumentException ignore) {
-            // Shouldn't happen
-            mAsciiCharsetEncoder = null;
-        }
+        mAsciiCharsetEncoder = StandardCharsets.US_ASCII.newEncoder();
     }
 
     @VisibleForTesting

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentMetadata.java
@@ -6,10 +6,11 @@ import androidx.annotation.VisibleForTesting;
 
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
+/*
  * Created by Alpar Szotyori on 25.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.
@@ -40,7 +41,7 @@ public class DocumentMetadata {
      */
     public DocumentMetadata() {
         try {
-            final Charset asciiCharset = Charset.forName("ASCII");
+            final Charset asciiCharset = StandardCharsets.US_ASCII;
             mAsciiCharsetEncoder = asciiCharset.newEncoder();
         } catch (IllegalArgumentException ignore) {
             // Shouldn't happen

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRemoteSource.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRemoteSource.kt
@@ -58,21 +58,21 @@ abstract class DocumentRemoteSource(
         val response = SafeApiRequest.apiRequest {
             documentService.getDocument(bearerHeaderMap(accessToken), documentId)
         }
-        response.body()?.string() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.string() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getDocumentFromUri(accessToken: String, uri: Uri): String = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             documentService.getDocumentFromUri(bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType), uriRelativeToBaseUri(uri).toString())
         }
-        response.body()?.string() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.string() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getExtractions(accessToken: String, documentId: String): String = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             documentService.getExtractions(bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType), documentId)
         }
-        response.body()?.string() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.string() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getDocumentLayout(accessToken: String, documentId: String): DocumentLayout =
@@ -82,7 +82,7 @@ abstract class DocumentRemoteSource(
                     bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType), documentId
                 )
         }
-        response.body()?.toDocumentLayout() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.toDocumentLayout() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getDocumentPages(accessToken: String, documentId: String): List<DocumentPage> = withContext(coroutineContext) {
@@ -91,7 +91,7 @@ abstract class DocumentRemoteSource(
                 bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType), documentId
             )
         }
-        response.body()?.map { it.toDocumentPage() } ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.map { it.toDocumentPage() } ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun sendFeedback(accessToken: String, documentId: String, requestBody: RequestBody): Unit = withContext(coroutineContext) {
@@ -104,28 +104,28 @@ abstract class DocumentRemoteSource(
         val response = SafeApiRequest.apiRequest {
             documentService.getFile(bearerHeaderMap(accessToken, accept = null, contentType = giniApiType.giniJsonMediaType), location)
         }
-        response.body()?.bytes() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.bytes() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getPaymentRequest(accessToken: String, id: String): PaymentRequestResponse = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             documentService.getPaymentRequest(bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType), id)
         }
-        response.body() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getPaymentRequests(accessToken: String): List<PaymentRequestResponse> = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             documentService.getPaymentRequests(bearerHeaderMap(accessToken, contentType = giniApiType.giniJsonMediaType))
         }
-        response.body() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun getPayment(accessToken: String, id: String): Payment = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             documentService.getPayment(bearerHeaderMap(accessToken, giniApiType.giniJsonMediaType), id)
         }
-        response.body()?.toPayment() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body()?.toPayment() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     protected fun bearerHeaderMap(
@@ -142,8 +142,8 @@ abstract class DocumentRemoteSource(
         }
     }
 
-    private fun uriRelativeToBaseUri(uri: Uri): Uri? {
-        return baseUri?.buildUpon()?.path(uri.path)?.query(uri.query)?.build()
+    private fun uriRelativeToBaseUri(uri: Uri): Uri {
+        return baseUri.buildUpon().path(uri.path).query(uri.query).build()
     }
 
     private fun getBaseUri(baseUriString: String?, giniApiType: GiniApiType): Uri {
@@ -156,6 +156,7 @@ abstract class DocumentRemoteSource(
 
     companion object {
         const val HEADER_LOCATION_KEY = "location"
+        private const val EMPTY_RESPONSE_BODY = "Empty response body"
     }
 
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/DocumentRepository.kt
@@ -175,7 +175,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
         do {
             when (val apiDocumentResource = getDocument(document.id)) {
                 is Resource.Success -> {
-                    if (apiDocumentResource.data?.state != Document.ProcessingState.PENDING) {
+                    if (apiDocumentResource.data.state != Document.ProcessingState.PENDING) {
                         return apiDocumentResource
                     }
                 }
@@ -204,7 +204,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
 
         val bodyJSON = JSONObject()
         bodyJSON.put("feedback", feedbackForExtractions)
-        val body: RequestBody = bodyJSON.toString().toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+        val body: RequestBody = bodyJSON.toString().toRequestBody(JSON_CONTENT_TYPE.toMediaTypeOrNull())
         return withAccessToken { accessToken ->
             wrapInResource {
                 documentRemoteSource.sendFeedback(accessToken, document.id, body)
@@ -225,7 +225,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
 
         val bodyJSON = JSONObject()
         bodyJSON.put("extractions", feedbackForExtractions)
-        val body: RequestBody = bodyJSON.toString().toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+        val body: RequestBody = bodyJSON.toString().toRequestBody(JSON_CONTENT_TYPE.toMediaTypeOrNull())
         return withAccessToken { accessToken ->
             wrapInResource {
                 documentRemoteSource.sendFeedback(accessToken, document.id, body)
@@ -265,7 +265,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
         val bodyJSON = JSONObject()
         bodyJSON.put("extractions", feedbackForExtractions)
         bodyJSON.put("compoundExtractions", feedbackForCompoundExtractions)
-        val body: RequestBody = bodyJSON.toString().toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())
+        val body: RequestBody = bodyJSON.toString().toRequestBody(JSON_CONTENT_TYPE.toMediaTypeOrNull())
         return withAccessToken { accessToken ->
             wrapInResource {
                 documentRemoteSource.sendFeedback(accessToken, document.id, body)
@@ -331,7 +331,7 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
             if (extractionData.has("candidates")) {
                 val candidatesName = extractionData.getString("candidates")
                 if (candidates.containsKey(candidatesName)) {
-                    candidatesForExtraction = candidates[candidatesName]!!
+                    candidatesForExtraction = candidates[candidatesName] ?: emptyList()
                 }
             }
             val specificExtraction = SpecificExtraction(
@@ -468,5 +468,6 @@ abstract class DocumentRepository<E: ExtractionsContainer>(
          */
         const val DEFAULT_COMPRESSION = 50
 
+        private const val JSON_CONTENT_TYPE = "application/json; charset=utf-8"
     }
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/Utils.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/Utils.java
@@ -1,9 +1,7 @@
 package net.gini.android.core.api;
 
-import android.net.Uri;
-
 import java.nio.charset.Charset;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Internal use only.
@@ -27,5 +25,5 @@ public class Utils {
         return reference;
     }
 
-    public static Charset CHARSET_UTF8 = Charset.forName("utf-8");
+    public static final Charset CHARSET_UTF8 = StandardCharsets.UTF_8;
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/AnonymousSessionManager.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/AnonymousSessionManager.kt
@@ -2,7 +2,6 @@ package net.gini.android.core.api.authorization
 
 import net.gini.android.core.api.Resource
 import net.gini.android.core.api.Utils
-import net.gini.android.core.api.authorization.apimodels.SessionToken
 import net.gini.android.core.api.authorization.apimodels.UserRequestModel
 import org.json.JSONObject
 import java.util.*
@@ -18,55 +17,44 @@ internal class AnonymousSessionManager(
     private var currentSession: Session? = null
 
     override suspend fun getSession(): Resource<Session> {
-        currentSession?.let { session ->
-            if (!session.hasExpired()) {
-                return Resource.Success(session)
-            }
-        }
-
-        val userCredentials = credentialsStore.userCredentials
-        return if (userCredentials == null) {
-            when (val createResponse = createUser()) {
-                is Resource.Cancelled -> Resource.Cancelled()
-                is Resource.Error -> Resource.Error(createResponse)
-                is Resource.Success -> {
-                    val loginResponse = loginUser()
-                    currentSession = when (loginResponse) {
-                        is Resource.Success -> loginResponse.data
-                        else -> null
-                    }
-                    loginResponse
-                }
-            }
+        currentSession?.takeUnless { it.hasExpired() }?.let { return Resource.Success(it) }
+        return if (credentialsStore.userCredentials == null) {
+            createUserAndLogin()
         } else {
-            return when (val loginResponse = loginUser()) {
-                is Resource.Success -> {
-                    currentSession = loginResponse.data
-                    loginResponse
-                }
-                is Resource.Error -> {
-                    if (isInvalidUserError(loginResponse)) {
-                        currentSession = null
-                        credentialsStore.deleteUserCredentials()
-                        return when (val createResponse = createUser()) {
-                            is Resource.Cancelled -> Resource.Cancelled()
-                            is Resource.Error -> Resource.Error(createResponse)
-                            is Resource.Success -> {
-                                val newUserLoginResponse = loginUser()
-                                currentSession = when (newUserLoginResponse) {
-                                    is Resource.Success -> newUserLoginResponse.data
-                                    else -> null
-                                }
-                                newUserLoginResponse
-                            }
-                        }
-                    } else {
-                        loginResponse
-                    }
-                }
-                is Resource.Cancelled -> loginResponse
-            }
+            loginOrRecreateUser()
         }
+    }
+
+    private suspend fun createUserAndLogin(): Resource<Session> {
+        return when (val createResponse = createUser()) {
+            is Resource.Cancelled -> Resource.Cancelled()
+            is Resource.Error -> Resource.Error(createResponse)
+            is Resource.Success -> loginAndCacheSession()
+        }
+    }
+
+    private suspend fun loginOrRecreateUser(): Resource<Session> {
+        return when (val loginResponse = loginUser()) {
+            is Resource.Success -> {
+                currentSession = loginResponse.data
+                loginResponse
+            }
+            is Resource.Error -> handleLoginError(loginResponse)
+            is Resource.Cancelled -> loginResponse
+        }
+    }
+
+    private suspend fun handleLoginError(error: Resource.Error<Session>): Resource<Session> {
+        if (!isInvalidUserError(error)) return error
+        currentSession = null
+        credentialsStore.deleteUserCredentials()
+        return createUserAndLogin()
+    }
+
+    private suspend fun loginAndCacheSession(): Resource<Session> {
+        val loginResponse = loginUser()
+        currentSession = (loginResponse as? Resource.Success)?.data
+        return loginResponse
     }
 
     private suspend fun createUser(): Resource<Unit> {

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/EncryptedCredentialsStore.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/EncryptedCredentialsStore.java
@@ -8,7 +8,7 @@ import androidx.annotation.VisibleForTesting;
 import net.gini.android.core.api.authorization.crypto.GiniCrypto;
 import net.gini.android.core.api.authorization.crypto.GiniCryptoException;
 
-/**
+/*
  * Created by Alpar Szotyori on 08.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.
@@ -65,6 +65,7 @@ public class EncryptedCredentialsStore implements CredentialsStore {
             }
             return stored;
         } catch (GiniCryptoException ignored) {
+            // Encryption failed — return false to indicate credentials were not stored
         }
         return false;
     }
@@ -84,6 +85,7 @@ public class EncryptedCredentialsStore implements CredentialsStore {
                 return new UserCredentials(mCrypto.decrypt(encryptedUserCredentials.getUsername()),
                         mCrypto.decrypt(encryptedUserCredentials.getPassword()));
             } catch (GiniCryptoException ignored) {
+                // Decryption failed — return null to indicate credentials are unavailable
             }
         }
         return null;

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/PubKeyManager.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/PubKeyManager.java
@@ -52,6 +52,7 @@ public final class PubKeyManager implements X509TrustManager {
             TrustKit.initializeWithNetworkSecurityConfiguration(mContext,
                     mNetworkSecurityConfigResId);
         } catch (IllegalStateException ignore) {
+            // TrustKit is already initialized — safe to continue
         }
         mLocalPublicKeys = getPublicKeys(TrustKit.getInstance());
         mTrustKitTrustManagers.clear();
@@ -124,8 +125,7 @@ public final class PubKeyManager implements X509TrustManager {
         }
     }
 
-    private Boolean isValidCertificate(final X509Certificate remoteCertificate)
-            throws CertificateException {
+    private boolean isValidCertificate(final X509Certificate remoteCertificate) {
         final PublicKeyPin remotePublicKey = new PublicKeyPin(remoteCertificate);
         for (final PublicKeyPin localPublicKey : mLocalPublicKeys) {
             if (localPublicKey.equals(remotePublicKey)) {

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/SessionManager.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/SessionManager.kt
@@ -8,6 +8,6 @@ import net.gini.android.core.api.authorization.apimodels.SessionToken
  *
  * Implement this interface and pass it to the API builder to provide your own session management.
  */
-interface SessionManager {
+fun interface SessionManager {
     suspend fun getSession(): Resource<Session>
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/UserRemoteSource.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/UserRemoteSource.kt
@@ -23,14 +23,14 @@ internal class UserRemoteSource(
         val response = SafeApiRequest.apiRequest {
             userService.signIn(basicHeaderMap(), userRequestModel.email ?: "", userRequestModel.password ?: "")
         }
-        response.body() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun loginClient(): SessionToken = withContext(coroutineContext) {
         val response = SafeApiRequest.apiRequest {
             userService.loginClient(basicHeaderMap())
         }
-        response.body() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun createUser(userRequestModel: UserRequestModel, accessToken: String): Unit = withContext(coroutineContext) {
@@ -43,11 +43,11 @@ internal class UserRemoteSource(
         val response = SafeApiRequest.apiRequest {
             userService.getUserInfo(bearerHeaderMap(accessToken), uri)
         }
-        response.body() ?: throw ApiException.forResponse("Empty response body", response)
+        response.body() ?: throw ApiException.forResponse(EMPTY_RESPONSE_BODY, response)
     }
 
     suspend fun updateEmail(userId: String, userRequestModel: UserRequestModel, accessToken: String): Unit = withContext(coroutineContext) {
-        val response = SafeApiRequest.apiRequest {
+        SafeApiRequest.apiRequest {
             userService.updateEmail(bearerHeaderMap(accessToken), userId, userRequestModel)
         }
     }
@@ -61,5 +61,9 @@ internal class UserRemoteSource(
     private fun bearerHeaderMap(accessToken: String): Map<String, String> {
         return mapOf(JsonAcceptHeader().toPair(),
             BearerAuthorizatonHeader(accessToken).toPair())
+    }
+
+    companion object {
+        private const val EMPTY_RESPONSE_BODY = "Empty response body"
     }
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCrypto.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCrypto.java
@@ -19,7 +19,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 
-/**
+/*
  * Created by Alpar Szotyori on 08.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.
@@ -33,6 +33,8 @@ public abstract class GiniCrypto {
     static final String ANDROID_KEY_STORE = "AndroidKeyStore";
     static final String SECRET_KEY_ALIAS = "GiniCryptoKey";
     static final String AES_MODE = "AES/GCM/NoPadding";
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public static GiniCrypto newInstance(@NonNull final SharedPreferences sharedPreferences,
             @NonNull final Context context) {
@@ -67,9 +69,8 @@ public abstract class GiniCrypto {
     }
 
     private byte[] generateIV() {
-        final SecureRandom secureRandom = new SecureRandom();
         final byte[] iv = new byte[12];
-        secureRandom.nextBytes(iv);
+        SECURE_RANDOM.nextBytes(iv);
         return iv;
     }
 

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoAndroidMOrGreater.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoAndroidMOrGreater.java
@@ -22,7 +22,7 @@ import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.GCMParameterSpec;
 
-/**
+/*
  * Created by Alpar Szotyori on 08.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.
@@ -86,6 +86,7 @@ class GiniCryptoAndroidMOrGreater extends GiniCrypto {
                 .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setRandomizedEncryptionRequired(false)
+                .setUserAuthenticationRequired(false) // Intentional: key is used for app credential storage, not user-facing data //NOSONAR java:S6288
                 .build();
         keyGenerator.init(spec);
         keyGenerator.generateKey();

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoException.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoException.java
@@ -1,6 +1,6 @@
 package net.gini.android.core.api.authorization.crypto;
 
-/**
+/*
  * Created by Alpar Szotyori on 08.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoPreAndroidM.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/authorization/crypto/GiniCryptoPreAndroidM.java
@@ -30,7 +30,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.x500.X500Principal;
 
-/**
+/*
  * Created by Alpar Szotyori on 08.10.2018.
  *
  * Copyright (c) 2018 Gini GmbH.
@@ -42,6 +42,7 @@ import javax.security.auth.x500.X500Principal;
 class GiniCryptoPreAndroidM extends GiniCrypto {
 
     private static final String AES_KEY = "GiniKey";
+    // PKCS1Padding is required for API < 23; OAEP is not reliably available via AndroidOpenSSL on pre-M devices
     private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
 
     private final SharedPreferences mSharedPreferences;
@@ -118,6 +119,7 @@ class GiniCryptoPreAndroidM extends GiniCrypto {
                 .apply();
     }
 
+    @SuppressWarnings("java:S5542") // PKCS1Padding is required for API < 23; no OAEP support via AndroidOpenSSL on pre-M
     private byte[] rsaEncrypt(byte[] secret)
             throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException,
             InvalidKeyException, BadPaddingException, IllegalBlockSizeException,
@@ -129,6 +131,7 @@ class GiniCryptoPreAndroidM extends GiniCrypto {
         return cipher.doFinal(secret);
     }
 
+    @SuppressWarnings("java:S5542") // PKCS1Padding is required for API < 23; no OAEP support via AndroidOpenSSL on pre-M
     private byte[] rsaDecrypt(byte[] encrypted)
             throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
             UnrecoverableEntryException, IOException, NoSuchProviderException,
@@ -155,6 +158,7 @@ class GiniCryptoPreAndroidM extends GiniCrypto {
         return getKeyStore().containsAlias(SECRET_KEY_ALIAS);
     }
 
+    @SuppressWarnings("deprecation") // KeyPairGeneratorSpec is required for API < 23 compatibility; no modern alternative available for pre-M
     private void generateKeyPair() throws NoSuchProviderException, NoSuchAlgorithmException,
             InvalidAlgorithmParameterException {
         Calendar start = Calendar.getInstance();

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/http/GiniHttpClientProvider.kt
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/http/GiniHttpClientProvider.kt
@@ -47,7 +47,7 @@ import okhttp3.OkHttpClient
  *
  * @see DefaultGiniHttpClientProvider for the SDK's default implementation
  */
-interface GiniHttpClientProvider {
+fun interface GiniHttpClientProvider {
     /**
      * Provides a configured [OkHttpClient] instance for use by the Gini API libraries.
      *

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/internal/BundleHelper.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/internal/BundleHelper.java
@@ -15,6 +15,8 @@ import java.util.Map;
  */
 public class BundleHelper {
 
+    private BundleHelper() {}
+
     public static <V extends Parcelable> Bundle mapToBundle(Map<String, V> map) {
         final Bundle bundle = new Bundle();
         for (final Map.Entry<String, V> entry : map.entrySet()) {
@@ -31,12 +33,13 @@ public class BundleHelper {
         return bundle;
     }
 
-    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle, ClassLoader classLoader) {
+    public static <V extends Parcelable> Map<String, V> bundleToMap(Bundle bundle, ClassLoader classLoader) {
         bundle.setClassLoader(classLoader);
         return bundleToMap(bundle);
     }
 
-    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle) {
+    @SuppressWarnings("deprecation") // Generic type V makes the typed getParcelable(key, Class) API impractical
+    public static <V extends Parcelable> Map<String, V> bundleToMap(Bundle bundle) {
         final HashMap<String, V> map = new HashMap<>(bundle.keySet().size());
         for (final String key : bundle.keySet()) {
             map.put(key, bundle.<V>getParcelable(key));
@@ -51,5 +54,4 @@ public class BundleHelper {
         }
         return mapList;
     }
-
 }

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/internal/BundleHelper.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/internal/BundleHelper.java
@@ -33,13 +33,13 @@ public class BundleHelper {
         return bundle;
     }
 
-    public static <V extends Parcelable> Map<String, V> bundleToMap(Bundle bundle, ClassLoader classLoader) {
+    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle, ClassLoader classLoader) { //NOSONAR java:S1319 — return type is part of the public binary API; widening to Map would break callers compiled against the old signature
         bundle.setClassLoader(classLoader);
         return bundleToMap(bundle);
     }
 
     @SuppressWarnings("deprecation") // Generic type V makes the typed getParcelable(key, Class) API impractical
-    public static <V extends Parcelable> Map<String, V> bundleToMap(Bundle bundle) {
+    public static <V extends Parcelable> HashMap<String, V> bundleToMap(Bundle bundle) { //NOSONAR java:S1319 — return type is part of the public binary API; widening to Map would break callers compiled against the old signature
         final HashMap<String, V> map = new HashMap<>(bundle.keySet().size());
         for (final String key : bundle.keySet()) {
             map.put(key, bundle.<V>getParcelable(key));

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/Document.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/Document.java
@@ -227,7 +227,7 @@ public class Document implements Parcelable {
         final List<Uri> partialDocuments = new ArrayList<>();
         in.readTypedList(partialDocuments, Uri.CREATOR);
         return new Document(documentId, processingState, fileName, pageCount, creationDate, expirationDate,
-                sourceClassification, uri, partialDocuments, partialDocuments);
+                sourceClassification, uri, compositeDocuments, partialDocuments);
     }
 
     @Override

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/Document.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/Document.java
@@ -4,6 +4,7 @@ package net.gini.android.core.api.models;
 import static net.gini.android.core.api.Utils.checkNotNull;
 
 import android.net.Uri;
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.Nullable;
@@ -70,6 +71,7 @@ public class Document implements Parcelable {
     private final List<Uri> mCompositeDocuments;
     private final List<Uri> mPartialDocuments;
 
+    @SuppressWarnings("java:S107") // Public API — Builder is available as the preferred alternative
     public Document(final String id, final ProcessingState state, final String filename,
                     final Integer pageCount,
                     final Date creationDate, final Date expirationDate,
@@ -203,18 +205,29 @@ public class Document implements Parcelable {
         final ProcessingState processingState = ProcessingState.valueOf(in.readString());
         final int pageCount = in.readInt();
         final String fileName = in.readString();
-        final Date creationDate = (Date) in.readSerializable();
-        final Date expirationDate = (Date) in.readSerializable();
+        final Date creationDate;
+        final Date expirationDate;
+        final Uri uri;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            creationDate = in.readSerializable(null, Date.class);
+            expirationDate = in.readSerializable(null, Date.class);
+        } else {
+            creationDate = (Date) in.readSerializable();
+            expirationDate = (Date) in.readSerializable();
+        }
         final SourceClassification sourceClassification = SourceClassification.valueOf(
                 in.readString());
-        final Uri uri = in.readParcelable(Document.class.getClassLoader());
-        final List<Uri> parents = new ArrayList<>();
-        in.readTypedList(parents, Uri.CREATOR);
-        //noinspection unchecked
-        final List<Uri> subdocuments = new ArrayList<>();
-        in.readTypedList(subdocuments, Uri.CREATOR);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            uri = in.readParcelable(Document.class.getClassLoader(), Uri.class);
+        } else {
+            uri = in.readParcelable(Document.class.getClassLoader());
+        }
+        final List<Uri> compositeDocuments = new ArrayList<>();
+        in.readTypedList(compositeDocuments, Uri.CREATOR);
+        final List<Uri> partialDocuments = new ArrayList<>();
+        in.readTypedList(partialDocuments, Uri.CREATOR);
         return new Document(documentId, processingState, fileName, pageCount, creationDate, expirationDate,
-                sourceClassification, uri, subdocuments, subdocuments);
+                sourceClassification, uri, partialDocuments, partialDocuments);
     }
 
     @Override
@@ -235,6 +248,7 @@ public class Document implements Parcelable {
         dest.writeTypedList(getCompositeDocuments());
         dest.writeTypedList(getPartialDocuments());
     }
+
 
     public static final Parcelable.Creator<Document> CREATOR = new Parcelable.Creator<Document>() {
 

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/Extraction.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/Extraction.java
@@ -2,6 +2,7 @@ package net.gini.android.core.api.models;
 
 import static net.gini.android.core.api.Utils.checkNotNull;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.Nullable;
@@ -37,7 +38,11 @@ public class Extraction implements Parcelable {
     protected Extraction(final Parcel in) {
         mEntity = in.readString();
         mValue = in.readString();
-        mBox = in.readParcelable(Box.class.getClassLoader());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mBox = in.readParcelable(Box.class.getClassLoader(), Box.class);
+        } else {
+            mBox = in.readParcelable(Box.class.getClassLoader());
+        }
         mIsDirty = in.readInt() != 0;
     }
 

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/ExtractionsContainer.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/ExtractionsContainer.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import androidx.annotation.NonNull;
 
-/**
+/*
  * Created by Alpar Szotyori on 13.02.2020.
  *
  * Copyright (c) 2020 Gini GmbH.

--- a/core-api-library/library/src/main/java/net/gini/android/core/api/models/SpecificExtraction.java
+++ b/core-api-library/library/src/main/java/net/gini/android/core/api/models/SpecificExtraction.java
@@ -42,7 +42,7 @@ public class SpecificExtraction extends Extraction {
     private SpecificExtraction(final Parcel in) {
         super(in);
         mName = in.readString();
-        final List<Extraction> candidates = new ArrayList<Extraction>();
+        final List<Extraction> candidates = new ArrayList<>();
         in.readTypedList(candidates, Extraction.CREATOR);
         mCandidates = candidates;
     }


### PR DESCRIPTION
This pull request focuses on improving code quality and maintainability in the core API library, primarily by refactoring tests, enhancing error handling, and improving code clarity and consistency. The changes include updating test assertions, removing unnecessary exception handling, centralizing constant values, and refining null safety and type usage.

**Test improvements and refactoring:**
- Replaced deprecated or less clear assertions in `EncryptedCredentialsStoreTest` with `assertNotEquals` and improved assertion order in `assertEquals` calls for better readability. Also removed unnecessary `throws Exception` from test setup/teardown methods. [[1]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6R7-L8) [[2]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6L32-R40) [[3]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6L55-R56) [[4]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6L101-R102) [[5]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6L138-R138) [[6]](diffhunk://#diff-b13636332fb98ee7cd874bfbe056dee7daf7631d9c89a030b7f20fd7a40f2bf6L152-R153)
- Removed unused imports and unnecessary `throws Exception` from test methods in `DocumentMetadataTest`, `MediaTypesTest`, and `SessionTest`. [[1]](diffhunk://#diff-50afe757df69fb467ade8d66e1d54bd9d168a634b40af7d288ed9807f7274303L11) [[2]](diffhunk://#diff-50afe757df69fb467ade8d66e1d54bd9d168a634b40af7d288ed9807f7274303L32-R31) [[3]](diffhunk://#diff-6b765dd3cd74d24d0cd9cceab0a0907d92bfdd210bb88e2447bf38fb60fecdc4L8) [[4]](diffhunk://#diff-5c9725220c90e9cf51c593da9e1e60ee6c6a6d31df9714d040b46baecf0abbd8L14-L15) [[5]](diffhunk://#diff-5c9725220c90e9cf51c593da9e1e60ee6c6a6d31df9714d040b46baecf0abbd8L37-R42) [[6]](diffhunk://#diff-5c9725220c90e9cf51c593da9e1e60ee6c6a6d31df9714d040b46baecf0abbd8L53-R51)
- Added a clarifying comment for expected exceptions in `SharedPreferencesCredentialsStoreTest`.

**Error handling and constant management:**
- Centralized the "Empty response body" error message into a private constant (`EMPTY_RESPONSE_BODY`) in `DocumentRemoteSource` and updated all usages to reference this constant instead of duplicating the string. [[1]](diffhunk://#diff-21209bf1232031e360fc4ef2c62769f75364db53753e65457a86dfd2401b1ce4L61-R75) [[2]](diffhunk://#diff-21209bf1232031e360fc4ef2c62769f75364db53753e65457a86dfd2401b1ce4L85-R85) [[3]](diffhunk://#diff-21209bf1232031e360fc4ef2c62769f75364db53753e65457a86dfd2401b1ce4L94-R94) [[4]](diffhunk://#diff-21209bf1232031e360fc4ef2c62769f75364db53753e65457a86dfd2401b1ce4L107-R128) [[5]](diffhunk://#diff-21209bf1232031e360fc4ef2c62769f75364db53753e65457a86dfd2401b1ce4R159)
- Centralized the JSON content type string into a constant (`JSON_CONTENT_TYPE`) in `DocumentRepository` and updated all relevant usages. [[1]](diffhunk://#diff-dd6af7714b05db07405b3892f70cb2c6492ae9a153b5141b663a0311d9906139L207-R207) [[2]](diffhunk://#diff-dd6af7714b05db07405b3892f70cb2c6492ae9a153b5141b663a0311d9906139L228-R228) [[3]](diffhunk://#diff-dd6af7714b05db07405b3892f70cb2c6492ae9a153b5141b663a0311d9906139L268-R268) [[4]](diffhunk://#diff-dd6af7714b05db07405b3892f70cb2c6492ae9a153b5141b663a0311d9906139R471)

**Code clarity and safety improvements:**
- Replaced deprecated charset initialization with `StandardCharsets.US_ASCII` in `DocumentMetadata` for better type safety and clarity. [[1]](diffhunk://#diff-66ef19f44e8a9da205e968a97197255a433b7b256e71db87d5d6f0e7d080dce9R9-R13) [[2]](diffhunk://#diff-66ef19f44e8a9da205e968a97197255a433b7b256e71db87d5d6f0e7d080dce9L43-R44)
- Improved null safety and return types in `DocumentRemoteSource` by making `uriRelativeToBaseUri` non-nullable and removing unnecessary null checks.
- Fixed a potential null pointer issue by using the elvis operator to provide a fallback empty list in `DocumentRepository` when extracting candidates.
- Removed unnecessary null checks in document state handling in `DocumentRepository`.