### PR TITLE
Update license files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,5 +9,18 @@ licensee, where the licensee can gain access to a non-exclusive,
 non-transferable usage right which is restricted for the time of a contractual
 relationship between Gini and the licensee.
 
-For license related inquiries contact Gini via the email address
-technical-support@gini.net.
+For license-related inquiries, contact Gini at [technical-support@gini.net](mailto:technical-support@gini.net).
+
+## Module Licenses
+
+Each module in this repository is licensed individually. Find the applicable license for the module you are using:
+
+| Module | License |
+|--------|---------|
+| Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
+| Bank SDK | [LICENSE.md](bank-sdk/LICENSE.md) |
+| Capture API Library | [LICENSE.md](core-api-library/LICENSE.md) |
+| Capture SDK | [LICENSE.md](capture-sdk/LICENSE.md) |
+| Health API Library | [LICENSE.md](health-api-library/LICENSE.md) |
+| Health SDK | [LICENSE.md](health-sdk/LICENSE.md) |
+| Internal Payment SDK | [LICENSE.md](internal-payment-sdk/LICENSE.md) |

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -19,7 +19,7 @@ Each module in this repository is licensed individually. Find the applicable lic
 |--------|---------|
 | Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
 | Bank SDK | [LICENSE.md](bank-sdk/LICENSE.md) |
-| Capture API Library | [LICENSE.md](core-api-library/LICENSE.md) |
+| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
 | Capture SDK | [LICENSE.md](capture-sdk/LICENSE.md) |
 | Health API Library | [LICENSE.md](health-api-library/LICENSE.md) |
 | Health SDK | [LICENSE.md](health-sdk/LICENSE.md) |

--- a/bank-api-library/LICENSE.md
+++ b/bank-api-library/LICENSE.md
@@ -1,1 +1,22 @@
-Moved to https://developer.gini.net/gini-mobile-android/bank-api-library/library/html/license.html
+The Gini Bank API Library for Android is licensed under an MIT license. Please make sure to ship 
+all license notices and permissions with your application.
+
+    Copyright (c) 2014 Gini GmbH
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/bank-api-library/LICENSE.md
+++ b/bank-api-library/LICENSE.md
@@ -1,22 +1,12 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
-
-## Gini Bank API Library for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.

--- a/bank-api-library/LICENSE.md
+++ b/bank-api-library/LICENSE.md
@@ -1,22 +1,22 @@
-The Gini Bank API Library for Android is licensed under an MIT license. Please make sure to ship 
-all license notices and permissions with your application.
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
 
-    Copyright (c) 2014 Gini GmbH
+Always make sure to ship all license notices and permissions with your application.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-    
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-    
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+License
+=======
+
+## Gini Bank API Library for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/bank-api-library/README.md
+++ b/bank-api-library/README.md
@@ -25,7 +25,3 @@ The Gini Bank API Library has the following dependencies:
 * [Retrofit2](https://square.github.io/retrofit/)
 * [TrustKit from DataTheorem](https://github.com/datatheorem/TrustKit-Android)
 
-License
--------
-
-The Gini Bank API Library is available under the MIT license. See the LICENSE file for details.

--- a/bank-api-library/library/src/doc/source/license.rst
+++ b/bank-api-library/library/src/doc/source/license.rst
@@ -1,7 +1,3 @@
-=======
-License
-=======
-
 The Gini Bank API Library for Android is licensed under a Private License. Please
 make sure to ship all license notices and permissions with your application.
 

--- a/bank-api-library/library/src/doc/source/license.rst
+++ b/bank-api-library/library/src/doc/source/license.rst
@@ -2,30 +2,23 @@
 License
 =======
 
-The Gini Bank API Library for Android is licensed under an MIT license. Please
+The Gini Bank API Library for Android is licensed under a Private License. Please
 make sure to ship all license notices and permissions with your application.
 
 ::
 
-   Copyright (c) 2014-2021 Gini GmbH
-   
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-   
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-   
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   Copyright (c) 2014, Gini GmbH
+   All rights reserved.
+
+   The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
+   used, altered or copied in any way without explicit permission by Gini. The
+   terms of usage are defined in a separate usage agreement between Gini and the
+   licensee, where the licensee can gain access to a non-exclusive,
+   non-transferable usage right which is restricted for the time of a contractual
+   relationship between Gini and the licensee.
+
+   For license related inquiries contact Gini via the email address
+   technical-support@gini.net.
 
 
 Licenses and Acknowledgements for Incorporated Software

--- a/bank-api-library/library/src/doc/source/license.rst
+++ b/bank-api-library/library/src/doc/source/license.rst
@@ -1,20 +1,15 @@
-The Gini Bank API Library for Android is licensed under a Private License. Please
-make sure to ship all license notices and permissions with your application.
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
 
-::
+The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-   Copyright (c) 2014, Gini GmbH
-   All rights reserved.
-
-   The Gini Bank API Library is licensed through Gini GmbH ("Gini") and may not be
-   used, altered or copied in any way without explicit permission by Gini. The
-   terms of usage are defined in a separate usage agreement between Gini and the
-   licensee, where the licensee can gain access to a non-exclusive,
-   non-transferable usage right which is restricted for the time of a contractual
-   relationship between Gini and the licensee.
-
-   For license related inquiries contact Gini via the email address
-   technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.
 
 
 Licenses and Acknowledgements for Incorporated Software

--- a/bank-sdk/LICENSE.md
+++ b/bank-sdk/LICENSE.md
@@ -1,1 +1,22 @@
-Moved to https://developer.gini.net/gini-mobile-android/bank-sdk/sdk/html/license.html
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
+
+Always make sure to ship all license notices and permissions with your application.
+
+License
+=======
+
+## Gini Bank SDK for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/bank-sdk/LICENSE.md
+++ b/bank-sdk/LICENSE.md
@@ -11,7 +11,7 @@ License
     Copyright (c) 2014, Gini GmbH
     All rights reserved.
 
-    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    The Gini Bank SDK is licensed through Gini GmbH ("Gini") and may not be
     used, altered or copied in any way without explicit permission by Gini. The
     terms of usage are defined in a separate usage agreement between Gini and the
     licensee, where the licensee can gain access to a non-exclusive,

--- a/bank-sdk/LICENSE.md
+++ b/bank-sdk/LICENSE.md
@@ -20,3 +20,11 @@ License
 
     For license related inquiries contact Gini via the email address
     technical-support@gini.net.
+
+In order to deliver its functionality, the Gini Bank SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+
+| Module | License |
+|--------|---------|
+| Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
+| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
+| Capture SDK | [LICENSE.md](capture-sdk/LICENSE.md) |

--- a/bank-sdk/LICENSE.md
+++ b/bank-sdk/LICENSE.md
@@ -1,27 +1,17 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Bank SDK is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.
 
-## Gini Bank SDK for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Bank SDK is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
-
-In order to deliver its functionality, the Gini Bank SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+The Gini Bank SDK uses code from the following libraries:
 
 | Module | License |
 |--------|---------|

--- a/bank-sdk/LICENSE.md
+++ b/bank-sdk/LICENSE.md
@@ -25,6 +25,6 @@ In order to deliver its functionality, the Gini Bank SDK incorporates the follow
 
 | Module | License |
 |--------|---------|
-| Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
-| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
-| Capture SDK | [LICENSE.md](capture-sdk/LICENSE.md) |
+| Bank API Library | [LICENSE.md](../bank-api-library/LICENSE.md) |
+| Core API Library | [LICENSE.md](../core-api-library/LICENSE.md) |
+| Capture SDK | [LICENSE.md](../capture-sdk/LICENSE.md) |

--- a/capture-sdk/LICENSE.md
+++ b/capture-sdk/LICENSE.md
@@ -26,5 +26,5 @@ In order to deliver its functionality, the Gini Capture SDK incorporates the fol
 
 | Module | License |
 |--------|---------|
-| Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
-| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
+| Bank API Library | [LICENSE.md](../bank-api-library/LICENSE.md) |
+| Core API Library | [LICENSE.md](../core-api-library/LICENSE.md) |

--- a/capture-sdk/LICENSE.md
+++ b/capture-sdk/LICENSE.md
@@ -1,28 +1,17 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.
 
-## Gini Capture SDK and Gini Capture Default Network for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
-
-
-In order to deliver its functionality, the Gini Capture SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+The Gini Capture SDK uses code from the following libraries:
 
 | Module | License |
 |--------|---------|

--- a/capture-sdk/LICENSE.md
+++ b/capture-sdk/LICENSE.md
@@ -20,3 +20,11 @@ License
 
     For license related inquiries contact Gini via the email address
     technical-support@gini.net.
+
+
+In order to deliver its functionality, the Gini Capture SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+
+| Module | License |
+|--------|---------|
+| Bank API Library | [LICENSE.md](bank-api-library/LICENSE.md) |
+| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |

--- a/capture-sdk/LICENSE.md
+++ b/capture-sdk/LICENSE.md
@@ -1,1 +1,22 @@
-Moved to https://developer.gini.net/gini-mobile-android/capture-sdk/sdk/html/license.html
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
+
+Always make sure to ship all license notices and permissions with your application.
+
+License
+=======
+
+## Gini Capture SDK and Gini Capture Default Network for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/core-api-library/LICENSE.md
+++ b/core-api-library/LICENSE.md
@@ -1,21 +1,21 @@
-MIT License
+The Gini Core API Library for Android is licensed under an MIT license. Please make sure to ship all license notices and permissions with your application.
 
-Copyright (c) 2014-2021 Gini GmbH
+    Copyright (c) 2014 Gini GmbH
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/core-api-library/LICENSE.md
+++ b/core-api-library/LICENSE.md
@@ -1,21 +1,22 @@
-The Gini Core API Library for Android is licensed under an MIT license. Please make sure to ship all license notices and permissions with your application.
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
 
-    Copyright (c) 2014 Gini GmbH
+Always make sure to ship all license notices and permissions with your application.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-    
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-    
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+License
+=======
+
+## Gini Core API Library for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Core API Library is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/core-api-library/LICENSE.md
+++ b/core-api-library/LICENSE.md
@@ -1,22 +1,12 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Core API Library is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
-
-## Gini Core API Library for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Core API Library is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.

--- a/health-api-library/LICENSE.md
+++ b/health-api-library/LICENSE.md
@@ -1,22 +1,12 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
-
-## Gini Health API Library for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.

--- a/health-api-library/LICENSE.md
+++ b/health-api-library/LICENSE.md
@@ -1,22 +1,22 @@
-The Gini Health API Library for Android is licensed under an MIT license. Please make sure to ship 
-all license notices and permissions with your application.
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
 
-    Copyright (c) 2014 Gini GmbH
+Always make sure to ship all license notices and permissions with your application.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-    
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-    
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+License
+=======
+
+## Gini Health API Library for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/health-api-library/LICENSE.md
+++ b/health-api-library/LICENSE.md
@@ -1,1 +1,22 @@
-Moved to https://developer.gini.net/gini-mobile-android/health-api-library/library/html/license.html
+The Gini Health API Library for Android is licensed under an MIT license. Please make sure to ship 
+all license notices and permissions with your application.
+
+    Copyright (c) 2014 Gini GmbH
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/health-api-library/README.md
+++ b/health-api-library/README.md
@@ -23,8 +23,3 @@ The Gini Health API Library has the following dependencies:
 
 * [Retrofit2](https://square.github.io/retrofit/)
 * [TrustKit from DataTheorem](https://github.com/datatheorem/TrustKit-Android)
-
-License
--------
-
-The Gini Health API Library is available under the MIT license. See the LICENSE file for details.

--- a/health-api-library/library/src/doc/source/license.rst
+++ b/health-api-library/library/src/doc/source/license.rst
@@ -2,30 +2,23 @@
 License
 =======
 
-The Gini Health API Library for Android is licensed under an MIT license. Please
+The Gini Health API Library for Android is licensed under a Private License. Please
 make sure to ship all license notices and permissions with your application.
 
 ::
 
-   Copyright (c) 2014-2022 Gini GmbH
-   
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-   
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-   
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   Copyright (c) 2014, Gini GmbH
+   All rights reserved.
+
+   The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
+   used, altered or copied in any way without explicit permission by Gini. The
+   terms of usage are defined in a separate usage agreement between Gini and the
+   licensee, where the licensee can gain access to a non-exclusive,
+   non-transferable usage right which is restricted for the time of a contractual
+   relationship between Gini and the licensee.
+
+   For license related inquiries contact Gini via the email address
+   technical-support@gini.net.
 
 
 Licenses and Acknowledgements for Incorporated Software

--- a/health-api-library/library/src/doc/source/license.rst
+++ b/health-api-library/library/src/doc/source/license.rst
@@ -1,24 +1,15 @@
-=======
-License
-=======
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
 
-The Gini Health API Library for Android is licensed under a Private License. Please
-make sure to ship all license notices and permissions with your application.
+The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-::
-
-   Copyright (c) 2014, Gini GmbH
-   All rights reserved.
-
-   The Gini Health API Library is licensed through Gini GmbH ("Gini") and may not be
-   used, altered or copied in any way without explicit permission by Gini. The
-   terms of usage are defined in a separate usage agreement between Gini and the
-   licensee, where the licensee can gain access to a non-exclusive,
-   non-transferable usage right which is restricted for the time of a contractual
-   relationship between Gini and the licensee.
-
-   For license related inquiries contact Gini via the email address
-   technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.
 
 
 Licenses and Acknowledgements for Incorporated Software

--- a/health-sdk/LICENSE.md
+++ b/health-sdk/LICENSE.md
@@ -11,7 +11,7 @@ License
     Copyright (c) 2014, Gini GmbH
     All rights reserved.
 
-    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    The Gini Health SDK is licensed through Gini GmbH ("Gini") and may not be
     used, altered or copied in any way without explicit permission by Gini. The
     terms of usage are defined in a separate usage agreement between Gini and the
     licensee, where the licensee can gain access to a non-exclusive,

--- a/health-sdk/LICENSE.md
+++ b/health-sdk/LICENSE.md
@@ -1,1 +1,22 @@
-Moved to https://developer.gini.net/gini-mobile-android/health-sdk/sdk/html/license.html
+Copyright (c) 2014, Gini GmbH
+All rights reserved.
+
+Always make sure to ship all license notices and permissions with your application.
+
+License
+=======
+
+## Gini Health SDK for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.

--- a/health-sdk/LICENSE.md
+++ b/health-sdk/LICENSE.md
@@ -1,28 +1,17 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Health SDK is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.
 
-## Gini Health SDK for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Health SDK is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
-
-
-In order to deliver its functionality, the Gini Health SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+The Gini Health SDK uses code from the following libraries:
 
 | Module | License |
 |--------|---------|

--- a/health-sdk/LICENSE.md
+++ b/health-sdk/LICENSE.md
@@ -20,3 +20,12 @@ License
 
     For license related inquiries contact Gini via the email address
     technical-support@gini.net.
+
+
+In order to deliver its functionality, the Gini Health SDK incorporates the following libraries, whose respective licenses and copyright notices are provided below:
+
+| Module | License |
+|--------|---------|
+| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
+| Health API Library | [LICENSE.md](health-api-library/LICENSE.md) |
+| Internal Payment SDK | [LICENSE.md](internal-payment-sdk/LICENSE.md) |

--- a/health-sdk/LICENSE.md
+++ b/health-sdk/LICENSE.md
@@ -26,6 +26,6 @@ In order to deliver its functionality, the Gini Health SDK incorporates the foll
 
 | Module | License |
 |--------|---------|
-| Core API Library | [LICENSE.md](core-api-library/LICENSE.md) |
-| Health API Library | [LICENSE.md](health-api-library/LICENSE.md) |
-| Internal Payment SDK | [LICENSE.md](internal-payment-sdk/LICENSE.md) |
+| Core API Library | [LICENSE.md](../core-api-library/LICENSE.md) |
+| Health API Library | [LICENSE.md](../health-api-library/LICENSE.md) |
+| Internal Payment SDK | [LICENSE.md](../internal-payment-sdk/LICENSE.md) |

--- a/internal-payment-sdk/LICENSE.md
+++ b/internal-payment-sdk/LICENSE.md
@@ -1,22 +1,12 @@
 Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-Always make sure to ship all license notices and permissions with your application.
+The Gini Internal Payment SDK is licensed through Gini GmbH ("Gini") and may not be
+used, altered or copied in any way without explicit permission by Gini. The
+terms of usage are defined in a separate usage agreement between Gini and the
+licensee, where the licensee can gain access to a non-exclusive,
+non-transferable usage right which is restricted for the time of a contractual
+relationship between Gini and the licensee.
 
-License
-=======
-
-## Gini Internal Payment SDK for Android is licensed under a Private License.
-
-    Copyright (c) 2014, Gini GmbH
-    All rights reserved.
-
-    The Gini Internal Payment SDK is licensed through Gini GmbH ("Gini") and may not be
-    used, altered or copied in any way without explicit permission by Gini. The
-    terms of usage are defined in a separate usage agreement between Gini and the
-    licensee, where the licensee can gain access to a non-exclusive,
-    non-transferable usage right which is restricted for the time of a contractual
-    relationship between Gini and the licensee.
-
-    For license related inquiries contact Gini via the email address
-    technical-support@gini.net.
+For license related inquiries contact Gini via the email address
+technical-support@gini.net.

--- a/internal-payment-sdk/LICENSE.md
+++ b/internal-payment-sdk/LICENSE.md
@@ -11,7 +11,7 @@ License
     Copyright (c) 2014, Gini GmbH
     All rights reserved.
 
-    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    The Gini Internal Payment SDK is licensed through Gini GmbH ("Gini") and may not be
     used, altered or copied in any way without explicit permission by Gini. The
     terms of usage are defined in a separate usage agreement between Gini and the
     licensee, where the licensee can gain access to a non-exclusive,

--- a/internal-payment-sdk/LICENSE.md
+++ b/internal-payment-sdk/LICENSE.md
@@ -1,12 +1,22 @@
-Copyright (c) 2014-2024, Gini GmbH
+Copyright (c) 2014, Gini GmbH
 All rights reserved.
 
-The Gini Internal Payment SDK is licensed through Gini GmbH ("Gini") and may not be
-used, altered or copied in any way without explicit permission by Gini. The
-terms of usage are defined in a separate usage agreement between Gini and the
-licensee, where the licensee can gain access to a non-exclusive,
-non-transferable usage right which is restricted for the time of a contractual
-relationship between Gini and the licensee.
+Always make sure to ship all license notices and permissions with your application.
 
-For license related inquiries contact Gini via the email address
-technical-support@gini.net.
+License
+=======
+
+## Gini Internal Payment SDK for Android is licensed under a Private License.
+
+    Copyright (c) 2014, Gini GmbH
+    All rights reserved.
+
+    The Gini Capture SDK is licensed through Gini GmbH ("Gini") and may not be
+    used, altered or copied in any way without explicit permission by Gini. The
+    terms of usage are defined in a separate usage agreement between Gini and the
+    licensee, where the licensee can gain access to a non-exclusive,
+    non-transferable usage right which is restricted for the time of a contractual
+    relationship between Gini and the licensee.
+
+    For license related inquiries contact Gini via the email address
+    technical-support@gini.net.


### PR DESCRIPTION
## Pull request overview

Updates and consolidates licensing information across the monorepo by replacing “moved to …” placeholders with in-repo license texts and adding a root-level index of per-module licenses.

**Changes:**
- Updated the root `LICENSE.md` to include a “Module Licenses” section linking to each module’s license.
- Replaced external “Moved to …” links with full license text in multiple module `LICENSE.md` files.
- Standardized license notice phrasing across SDKs/libraries (MIT vs Private license wording).


PP-2638