### PR TITLE
fix(capture-sdk): Fix QR Code scanning after invalid QR Code recognition

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -471,6 +471,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
                 new QRCodePopup<>(mFragment, mCameraFrameWrapper, mActivityIndicatorBackground, null,
                         getHideQRCodeDetectedPopupDelayMs(), false, null, () -> {
                     mQRCodeContent = null;
+                    mInterfaceHidden = false;
                     return null;
                 });
         qrCodeEducationPopup = new QRCodeEducationPopup<>(view.findViewById(R.id.gc_qr_code_education_compose_view));

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -193,7 +193,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
 
     private View mImageCorners;
     private PhotoThumbnail mPhotoThumbnail;
-    private boolean mInterfaceHidden;
+    @VisibleForTesting
+    boolean mInterfaceHidden;
     private boolean mInMultiPageState;
     private boolean mIsFlashEnabled = true;
 
@@ -235,7 +236,8 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
     private boolean mImportDocumentButtonEnabled;
     private ImportImageFileUrisAsyncTask mImportUrisAsyncTask;
     private Group mImportButtonGroup;
-    private String mQRCodeContent;
+    @VisibleForTesting
+    String mQRCodeContent;
     private boolean shouldSendUserAnalyticsTrackerForQrCodes = true;
     private boolean isIbanDetectedOnceForUserAnalytics = false;
 
@@ -339,6 +341,12 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
             mUnsupportedQRCodePopup.show(null);
             sendQRCodeScannedEventToUserAnalytics(false);
         }
+    }
+
+    @VisibleForTesting
+    void onUnsupportedQRCodePopupHidden() {
+        mQRCodeContent = null;
+        mInterfaceHidden = false;
     }
 
     @VisibleForTesting
@@ -470,8 +478,7 @@ class CameraFragmentImpl extends CameraFragmentExtension implements CameraFragme
         mUnsupportedQRCodePopup =
                 new QRCodePopup<>(mFragment, mCameraFrameWrapper, mActivityIndicatorBackground, null,
                         getHideQRCodeDetectedPopupDelayMs(), false, null, () -> {
-                    mQRCodeContent = null;
-                    mInterfaceHidden = false;
+                    onUnsupportedQRCodePopupHidden();
                     return null;
                 });
         qrCodeEducationPopup = new QRCodeEducationPopup<>(view.findViewById(R.id.gc_qr_code_education_compose_view));

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentImplTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentImplTest.kt
@@ -17,6 +17,8 @@ import net.gini.android.capture.tracking.CameraScreenEvent
 import net.gini.android.capture.tracking.Event
 import net.gini.android.capture.tracking.EventTracker
 import net.gini.android.capture.tracking.useranalytics.UserAnalyticsEventTracker
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -107,6 +109,21 @@ class CameraFragmentImplTest {
 
         // Then
         verify(eventTracker).onCameraScreenEvent(Event(CameraScreenEvent.HELP))
+    }
+
+    @Test
+    fun `resets QR code state when unsupported popup hides so scanning resumes`() {
+        // Given: state is set as if an unsupported QR code was shown and blocked further scans
+        val fragmentImpl = CameraFragmentImplWithoutQRCodeReader(mock(), mock<CancelListener>(), false)
+        fragmentImpl.mQRCodeContent = "unsupported-qr-content"
+        fragmentImpl.mInterfaceHidden = true
+
+        // When: the unsupported QR popup hides
+        fragmentImpl.onUnsupportedQRCodePopupHidden()
+
+        // Then: state is reset so subsequent QR codes can be detected
+        assertNull(fragmentImpl.mQRCodeContent)
+        assertFalse(fragmentImpl.mInterfaceHidden)
     }
 
     private open class CameraFragmentImplWithoutQRCodeReader(fragment: FragmentImplCallback,


### PR DESCRIPTION
## Pull request overview

Fixes a QR-scanning state issue in the Capture SDK where scanning could remain blocked after an unsupported/invalid QR code was detected and the “unsupported QR” popup flow completed.

**Changes:**
- Reset the internal `mInterfaceHidden` gate when the unsupported QR code popup hide callback runs, allowing subsequent QR detections again.

PP-2564