### PR TITLE
Pp 2562 save to gallery feature section turns to black as soon as toggled on

### DIFF
--- a/.github/workflows/bank-api-library.release.yml
+++ b/.github/workflows/bank-api-library.release.yml
@@ -106,5 +106,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/bank-api-library.docs.release.yml
     secrets:
-      RELEASE_GITHUB_USER: ${{ secrets.RELEASE_GITHUB_USER }}
-      RELEASE_GITHUB_PASSWORD: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/bank-sdk.release.yml
+++ b/.github/workflows/bank-sdk.release.yml
@@ -120,5 +120,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/bank-sdk.docs.release.yml
     secrets:
-      RELEASE_GITHUB_USER: ${{ secrets.RELEASE_GITHUB_USER }}
-      RELEASE_GITHUB_PASSWORD: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/capture-sdk.release.yml
+++ b/.github/workflows/capture-sdk.release.yml
@@ -110,5 +110,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/capture-sdk.docs.release.yml
     secrets:
-      RELEASE_GITHUB_USER: ${{ secrets.RELEASE_GITHUB_USER }}
-      RELEASE_GITHUB_PASSWORD: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/generate-sboms.yml
+++ b/.github/workflows/generate-sboms.yml
@@ -69,7 +69,7 @@ jobs:
       # Step 2: Loop over each SBOM file and submit it
       - name: Submit SBOMs to GitHub Dependency Graph
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha=$(git rev-parse HEAD)
           timestamp=$(date +%s)

--- a/.github/workflows/health-api-library.release.yml
+++ b/.github/workflows/health-api-library.release.yml
@@ -71,5 +71,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/health-api-library.docs.release.yml
     secrets:
-      RELEASE_GITHUB_USER: ${{ secrets.RELEASE_GITHUB_USER }}
-      RELEASE_GITHUB_PASSWORD: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/health-sdk.release.yml
+++ b/.github/workflows/health-sdk.release.yml
@@ -73,5 +73,5 @@ jobs:
     needs: release
     uses: ./.github/workflows/health-sdk.docs.release.yml
     secrets:
-      RELEASE_GITHUB_USER: ${{ secrets.RELEASE_GITHUB_USER }}
-      RELEASE_GITHUB_PASSWORD: ${{ secrets.RELEASE_GITHUB_PASSWORD }}
+      MOBILE_CI_APP_ID: ${{ secrets.MOBILE_CI_APP_ID }}
+      MOBILE_CI_APP_PRIVATE_KEY: ${{ secrets.MOBILE_CI_APP_PRIVATE_KEY }}

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/CaptureFlowHostActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/CaptureFlowHostActivity.kt
@@ -5,11 +5,13 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.fragment.app.FragmentContainerView
 import dagger.hilt.android.AndroidEntryPoint
 import net.gini.android.bank.sdk.exampleapp.ExampleApp
 import net.gini.android.bank.sdk.exampleapp.R
 import net.gini.android.bank.sdk.exampleapp.core.ExampleUtil.isIntentActionViewOrSend
+import net.gini.android.capture.util.SharedPreferenceHelper
 
 @AndroidEntryPoint
 class CaptureFlowHostActivity : AppCompatActivity() {
@@ -17,6 +19,10 @@ class CaptureFlowHostActivity : AppCompatActivity() {
     private val configurationViewModel: ConfigurationViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Applied before super.onCreate() so it takes effect without recreating the activity.
+        // This forces the theme for the SDK flow only; the rest of the example app is unaffected,
+        // simulating a client that pins the SDK's appearance (see ConfigurationActivity QA toggles).
+        applyForcedSdkTheme()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_capture_flow_host)
 
@@ -48,7 +54,25 @@ class CaptureFlowHostActivity : AppCompatActivity() {
         configurationViewModel.configureGiniBank(this)
     }
 
+    /**
+     * QA-only: applies the force-theme preference set in [ConfigurationActivity] as a *local*
+     * night mode, so only the SDK capture flow is forced into dark/light while the host app keeps
+     * following the system. No preference (or an unknown value) leaves it system-driven.
+     */
+    private fun applyForcedSdkTheme() {
+        delegate.localNightMode = when (SharedPreferenceHelper.getString(FORCE_SDK_THEME_KEY, this)) {
+            FORCE_SDK_THEME_DARK -> AppCompatDelegate.MODE_NIGHT_YES
+            FORCE_SDK_THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+    }
+
     companion object {
+        // QA force-theme preference shared with ConfigurationActivity.
+        const val FORCE_SDK_THEME_KEY = "force_sdk_theme_key"
+        const val FORCE_SDK_THEME_DARK = "dark"
+        const val FORCE_SDK_THEME_LIGHT = "light"
+
         fun newIntent(context: Context) = Intent(context, CaptureFlowHostActivity::class.java)
     }
 

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
@@ -578,6 +578,45 @@ class ConfigurationActivity : AppCompatActivity() {
                 isChecked
             )
         }
+        setupForceSdkThemeToggles()
+    }
+
+    /**
+     * QA-only: two mutually-exclusive switches that force the SDK into dark or light theme,
+     * simulating a client that pins the SDK's appearance. The preference is read by
+     * [CaptureFlowHostActivity], which applies it as a *local* night mode so only the SDK flow is
+     * affected — the example app itself keeps following the system setting. Both switches off
+     * restores the normal, system-driven behaviour.
+     */
+    private fun setupForceSdkThemeToggles() {
+        val toggles = binding.layoutDebugDevelopmentOptionsToggles
+        // Reflect the persisted setting when (re)opening the screen.
+        when (SharedPreferenceHelper.getString(CaptureFlowHostActivity.FORCE_SDK_THEME_KEY, this)) {
+            CaptureFlowHostActivity.FORCE_SDK_THEME_DARK -> toggles.switchForceDarkTheme.isChecked = true
+            CaptureFlowHostActivity.FORCE_SDK_THEME_LIGHT -> toggles.switchForceLightTheme.isChecked = true
+        }
+
+        toggles.switchForceDarkTheme.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked && toggles.switchForceLightTheme.isChecked) {
+                toggles.switchForceLightTheme.isChecked = false
+            }
+            persistForcedSdkTheme(toggles.switchForceDarkTheme.isChecked, toggles.switchForceLightTheme.isChecked)
+        }
+        toggles.switchForceLightTheme.setOnCheckedChangeListener { _, isChecked ->
+            if (isChecked && toggles.switchForceDarkTheme.isChecked) {
+                toggles.switchForceDarkTheme.isChecked = false
+            }
+            persistForcedSdkTheme(toggles.switchForceDarkTheme.isChecked, toggles.switchForceLightTheme.isChecked)
+        }
+    }
+
+    private fun persistForcedSdkTheme(forceDark: Boolean, forceLight: Boolean) {
+        val value = when {
+            forceDark -> CaptureFlowHostActivity.FORCE_SDK_THEME_DARK
+            forceLight -> CaptureFlowHostActivity.FORCE_SDK_THEME_LIGHT
+            else -> ""
+        }
+        SharedPreferenceHelper.saveString(CaptureFlowHostActivity.FORCE_SDK_THEME_KEY, value, this)
     }
 
     private fun applyClientSecretAndClientId() {

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/ConfigurationActivity.kt
@@ -589,7 +589,7 @@ class ConfigurationActivity : AppCompatActivity() {
      * restores the normal, system-driven behaviour.
      */
     private fun setupForceSdkThemeToggles() {
-        val toggles = binding.layoutDebugDevelopmentOptionsToggles
+        val toggles = binding.layoutGeneralUiCustomizationToggles
         // Reflect the persisted setting when (re)opening the screen.
         when (SharedPreferenceHelper.getString(CaptureFlowHostActivity.FORCE_SDK_THEME_KEY, this)) {
             CaptureFlowHostActivity.FORCE_SDK_THEME_DARK -> toggles.switchForceDarkTheme.isChecked = true

--- a/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
+++ b/bank-sdk/example-app/src/main/java/net/gini/android/bank/sdk/exampleapp/ui/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.IntentCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -31,6 +32,7 @@ import net.gini.android.capture.EntryPoint
 import net.gini.android.capture.GiniCapture
 import net.gini.android.capture.ProductTag
 import net.gini.android.capture.util.CancellationToken
+import net.gini.android.capture.util.SharedPreferenceHelper
 
 /**
  * Entry point for the screen api example app.
@@ -206,6 +208,12 @@ class MainActivity : AppCompatActivity() {
     private fun startGiniBankSdk(intent: Intent? = null) {
         configureGiniBank()
 
+        // QA: the Bank SDK capture flow launched here runs in the SDK's own CaptureFlowActivity,
+        // which we can't set a local night mode on from the app side. So we force it globally just
+        // before launching; it's restored in onCaptureResult when the flow returns. The SDK screen
+        // is full-screen, so the example app behind it isn't visible while forced.
+        applyForcedSdkThemeGlobally()
+
         if (intent != null) {
             cancellationToken = GiniBank.startCaptureFlowForIntent(
                 captureImportLauncher, this@MainActivity, intent
@@ -215,7 +223,26 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun applyForcedSdkThemeGlobally() {
+        val nightMode = when (SharedPreferenceHelper.getString(CaptureFlowHostActivity.FORCE_SDK_THEME_KEY, this)) {
+            CaptureFlowHostActivity.FORCE_SDK_THEME_DARK -> AppCompatDelegate.MODE_NIGHT_YES
+            CaptureFlowHostActivity.FORCE_SDK_THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+        if (AppCompatDelegate.getDefaultNightMode() != nightMode) {
+            AppCompatDelegate.setDefaultNightMode(nightMode)
+        }
+    }
+
+    private fun restoreExampleAppTheme() {
+        if (AppCompatDelegate.getDefaultNightMode() != AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+        }
+    }
+
     private fun onCaptureResult(result: CaptureResult) {
+        // Undo the QA force-theme applied for the SDK flow so the example app returns to normal.
+        restoreExampleAppTheme()
         when (result) {
             is CaptureResult.Success -> {
                 startActivity(ExtractionsActivity.getStartIntent(

--- a/bank-sdk/example-app/src/main/res/layout/layout_debug_development_toggles.xml
+++ b/bank-sdk/example-app/src/main/res/layout/layout_debug_development_toggles.xml
@@ -141,28 +141,4 @@
         android:layout_marginTop="@dimen/gc_medium_12"
         android:text="@string/custom_http_client_switch_label" />
 
-    <TextView
-        android:id="@+id/textView_forceThemeTitle"
-        style="@style/SwitchConfigurationStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/gc_medium_12"
-        android:text="@string/force_theme_label" />
-
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/switch_forceDarkTheme"
-        style="@style/SwitchConfigurationStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/gc_medium_12"
-        android:text="@string/force_dark_theme_switch_label" />
-
-    <com.google.android.material.switchmaterial.SwitchMaterial
-        android:id="@+id/switch_forceLightTheme"
-        style="@style/SwitchConfigurationStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/gc_medium_12"
-        android:text="@string/force_light_theme_switch_label" />
-
 </LinearLayout>

--- a/bank-sdk/example-app/src/main/res/layout/layout_debug_development_toggles.xml
+++ b/bank-sdk/example-app/src/main/res/layout/layout_debug_development_toggles.xml
@@ -141,4 +141,28 @@
         android:layout_marginTop="@dimen/gc_medium_12"
         android:text="@string/custom_http_client_switch_label" />
 
+    <TextView
+        android:id="@+id/textView_forceThemeTitle"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_theme_label" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_forceDarkTheme"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_dark_theme_switch_label" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_forceLightTheme"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_light_theme_switch_label" />
+
 </LinearLayout>

--- a/bank-sdk/example-app/src/main/res/layout/layout_ui_customization_toggles.xml
+++ b/bank-sdk/example-app/src/main/res/layout/layout_ui_customization_toggles.xml
@@ -44,4 +44,28 @@
         android:layout_marginTop="@dimen/gc_medium_12"
         android:text="@string/custom_primary_compose_button_switch_label" />
 
+    <TextView
+        android:id="@+id/textView_forceThemeTitle"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_theme_label" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_forceDarkTheme"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_dark_theme_switch_label" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/switch_forceLightTheme"
+        style="@style/SwitchConfigurationStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gc_medium_12"
+        android:text="@string/force_light_theme_switch_label" />
+
 </LinearLayout>

--- a/bank-sdk/example-app/src/main/res/values-night/styles.xml
+++ b/bank-sdk/example-app/src/main/res/values-night/styles.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="Root.AppTheme">
-        <item name="android:windowLightStatusBar">false</item>
-    </style>
-
+    <!-- Force SDK to use the light theme variant even in dark mode, matching the DB client's
+         behaviour where forceDarkAllowed=false (on certain OEMs) also prevents DayNight switching. -->
+    <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme"/>
 </resources>

--- a/bank-sdk/example-app/src/main/res/values-night/styles.xml
+++ b/bank-sdk/example-app/src/main/res/values-night/styles.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Force SDK to use the light theme variant even in dark mode, matching the DB client's
-         behaviour where forceDarkAllowed=false (on certain OEMs) also prevents DayNight switching. -->
-    <style name="GiniCaptureTheme" parent="Root.GiniCaptureTheme"/>
+    <!-- The example app itself follows the system Day/Night setting. The SDK's theme is NOT
+         statically pinned here: it is driven at runtime by the "Force dark/light theme (QA)"
+         toggles in ConfigurationActivity, which set a local night mode on CaptureFlowHostActivity
+         so only the SDK flow is forced. Both toggles off = the SDK follows the system too. -->
+    <style name="AppTheme" parent="Root.AppTheme">
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
 </resources>

--- a/bank-sdk/example-app/src/main/res/values/strings.xml
+++ b/bank-sdk/example-app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="gini_client_id_label">Client Id</string>
     <string name="client_secret_label">Client Secret</string>
     <string name="custom_http_client_switch_label">Enable Custom HTTP Client</string>
-    <string name="force_theme_label">Force SDK theme </string>
+    <string name="force_theme_label">Force SDK theme</string>
     <string name="force_dark_theme_switch_label">Force dark theme</string>
     <string name="force_light_theme_switch_label">Force light theme</string>
 

--- a/bank-sdk/example-app/src/main/res/values/strings.xml
+++ b/bank-sdk/example-app/src/main/res/values/strings.xml
@@ -148,6 +148,9 @@
     <string name="gini_client_id_label">Client Id</string>
     <string name="client_secret_label">Client Secret</string>
     <string name="custom_http_client_switch_label">Enable Custom HTTP Client</string>
+    <string name="force_theme_label">Force SDK theme </string>
+    <string name="force_dark_theme_switch_label">Force dark theme</string>
+    <string name="force_light_theme_switch_label">Force light theme</string>
 
     <string name="configuration_transaction_docs_enabled">Transaction Docs enabled</string>
     <string name="configuration_transaction_docs_always_attach_docs">Always attach invoices</string>

--- a/capture-sdk/sdk/src/main/res/drawable-night/gc_bg_off_save_invoices_locally.xml
+++ b/capture-sdk/sdk/src/main/res/drawable-night/gc_bg_off_save_invoices_locally.xml
@@ -1,8 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@android:color/transparent" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/gc_light_05" />
-    <corners android:radius="8dp" />
-</shape>

--- a/capture-sdk/sdk/src/main/res/drawable-night/gc_bg_on_save_invoices_locally.xml
+++ b/capture-sdk/sdk/src/main/res/drawable-night/gc_bg_on_save_invoices_locally.xml
@@ -1,8 +1,0 @@
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="@color/gc_dark_02" />
-    <stroke
-        android:width="1dp"
-        android:color="@color/gc_dark_02" />
-    <corners android:radius="8dp" />
-</shape>

--- a/capture-sdk/sdk/src/main/res/drawable/gc_bg_off_save_invoices_locally.xml
+++ b/capture-sdk/sdk/src/main/res/drawable/gc_bg_off_save_invoices_locally.xml
@@ -3,6 +3,6 @@
     <solid android:color="@android:color/transparent" />
     <stroke
         android:width="1dp"
-        android:color="@color/gc_light_05" />
+        android:color="?attr/dividerColor" />
     <corners android:radius="8dp" />
 </shape>

--- a/capture-sdk/sdk/src/main/res/drawable/gc_bg_on_save_invoices_locally.xml
+++ b/capture-sdk/sdk/src/main/res/drawable/gc_bg_on_save_invoices_locally.xml
@@ -1,8 +1,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/gc_light_01" />
+    <solid android:color="?attr/colorSurface" />
     <stroke
         android:width="1dp"
-        android:color="@color/gc_light_01" />
+        android:color="?attr/colorSurface" />
     <corners android:radius="8dp" />
 </shape>


### PR DESCRIPTION
This pull request introduces a QA-only feature to the example app, allowing testers to force the SDK capture flow into light or dark mode independently of the system or host app theme. This is achieved by adding toggles in the `ConfigurationActivity` that persist the preference, and by applying the selected theme only to the SDK flow. Additionally, drawable resources for invoice-saving backgrounds were refactored to improve theme compatibility and maintainability.

**SDK Theme Forcing Feature:**

- Added two mutually-exclusive toggles in `ConfigurationActivity` to force the SDK capture flow into dark or light mode for QA purposes. The selected preference is saved and reflected in the UI. [[1]](diffhunk://#diff-14d18736dc96e6300d248ecb96183c2eaa04474b3a5aaac1a0c88ba32269e9c7R581-R619) [[2]](diffhunk://#diff-d3e0d17e1330ed08d63e907b2dc0128a3edea57284ed555ee0e8668a0e05e016R144-R167) [[3]](diffhunk://#diff-bacfeae51d7ece518bd90892bb3bc2f7ee88f7c8fc0fd39159008cfe85f11cf5R151-R153)
- Implemented logic in `CaptureFlowHostActivity` to read the forced theme preference and apply it as a local night mode, ensuring only the SDK flow is affected. [[1]](diffhunk://#diff-c230bc7afbd9adfea5b959845f79979dc94206f321b8b0a3cc1dab8b95716de2R8-R25) [[2]](diffhunk://#diff-c230bc7afbd9adfea5b959845f79979dc94206f321b8b0a3cc1dab8b95716de2R57-R75)
- Updated `MainActivity` to globally apply the forced theme just before launching the SDK capture flow (when using the screen API), and to restore the example app theme when the flow returns. [[1]](diffhunk://#diff-257e52b44d512e5321600310259599b373a825638566f550477a0b54fa4805c8R12) [[2]](diffhunk://#diff-257e52b44d512e5321600310259599b373a825638566f550477a0b54fa4805c8R35) [[3]](diffhunk://#diff-257e52b44d512e5321600310259599b373a825638566f550477a0b54fa4805c8R211-R216) [[4]](diffhunk://#diff-257e52b44d512e5321600310259599b373a825638566f550477a0b54fa4805c8R226-R245)

**Drawable and Theme Resource Updates:**

- Refactored SDK drawable resources for invoice-saving backgrounds to use theme attributes (`colorSurface` and `dividerColor`) instead of hardcoded colors, improving compatibility with dynamic themes. [[1]](diffhunk://#diff-e28e2247fbeaa805ba9fe2388f5b9570fcff3f812842921d83ef776234d18e3cL6-R6) [[2]](diffhunk://#diff-daf617a2d800e2a9cb7f4dac35d40bd012f91b3500454c7600c3a606c1847743L3-R6)
- Removed obsolete night mode drawable resources in favor of using theme-driven attributes. [[1]](diffhunk://#diff-b34a6e3d7508cec75aad0de989d470d65865906a7eef957df99e12b125ad7675L1-L8) [[2]](diffhunk://#diff-f78882911fdcf924d4a538f6539567bc82350944571dc4189e7c34797f5affc1L1-L8)
- Clarified in the night mode `styles.xml` that the app follows the system theme, and the SDK theme is now controlled at runtime via the new QA toggles.