### PR TITLE
HEAL-132 address Copilot issues on new target SDK for health

### DIFF
--- a/internal-payment-sdk/sdk/src/main/java/net/gini/android/internal/payment/review/reviewComponent/ReviewView.kt
+++ b/internal-payment-sdk/sdk/src/main/java/net/gini/android/internal/payment/review/reviewComponent/ReviewView.kt
@@ -174,10 +174,12 @@ class ReviewView(private val context: Context, attrs: AttributeSet?) :
      *
      * - No need to handle the bottom sheet case, system insets are applied automatically.
      * - For standard fragments:
-     *   - On Android 15+ (API 35+), applying insetter causes unwanted bottom padding when keyboard
-     *   is visible.
+     *   - On Android 15+ (API 35+), relying on the raw WindowInsetsCompat ime inset adds unwanted
+     *   bottom padding when the keyboard is visible.
      *     So we manually observe keyboard visibility and apply the correct height.
-     *   - On Android 14 and below, WindowInsetsCompat listener is used.
+     *   - On Android 14 and below, a WindowInsetsCompat listener is used, with an attach-aware
+     *   insets request so the padding is applied even when the listener is installed after the
+     *   initial insets dispatch.
      */
 
     private fun handleViewInsets() {
@@ -209,6 +211,7 @@ class ReviewView(private val context: Context, attrs: AttributeSet?) :
                     v.updatePadding(bottom = bottom)
                     insets
                 }
+                requestApplyInsetsWhenAttached(binding.gpsPaymentDetails)
             }
         }
     }
@@ -312,12 +315,23 @@ class ReviewView(private val context: Context, attrs: AttributeSet?) :
             insets
         }
 
+        requestApplyInsetsWhenAttached(view)
+    }
+
+    /**
+     * Triggers an insets pass for [target] as soon as this view is attached to the window.
+     *
+     * A freshly installed [ViewCompat.setOnApplyWindowInsetsListener] only runs on the next insets
+     * dispatch. When the listener is installed after the initial dispatch it may never run until an
+     * unrelated insets event occurs, so we explicitly request an insets pass once we are attached.
+     */
+    private fun requestApplyInsetsWhenAttached(target: View) {
         if (isAttachedToWindow) {
-            ViewCompat.requestApplyInsets(view)
+            ViewCompat.requestApplyInsets(target)
         } else {
             addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
                 override fun onViewAttachedToWindow(v: View) {
-                    ViewCompat.requestApplyInsets(v)
+                    ViewCompat.requestApplyInsets(target)
                     v.removeOnAttachStateChangeListener(this)
                 }
 

--- a/internal-payment-sdk/sdk/src/main/java/net/gini/android/internal/payment/utils/extensions/View.kt
+++ b/internal-payment-sdk/sdk/src/main/java/net/gini/android/internal/payment/utils/extensions/View.kt
@@ -2,6 +2,7 @@ package net.gini.android.internal.payment.utils.extensions
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.Rect
 import android.os.Build
 import android.util.TypedValue
 import android.view.KeyEvent
@@ -96,10 +97,20 @@ fun View.applyWindowInsetsWithTopPadding(
         if (navigationBars) typeMask = typeMask or WindowInsetsCompat.Type.navigationBars()
         if (statusBars) typeMask = typeMask or WindowInsetsCompat.Type.statusBars()
         val finalTypeMask = typeMask
+        // Capture the margins defined in XML/code once, so applying insets adds to them
+        // instead of overwriting them (which would collapse any intended spacing).
+        val initialMargins = (layoutParams as? ViewGroup.MarginLayoutParams)?.let {
+            Rect(it.leftMargin, it.topMargin, it.rightMargin, it.bottomMargin)
+        } ?: Rect()
         ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
             val i = insets.getInsets(finalTypeMask)
             (v.layoutParams as? ViewGroup.MarginLayoutParams)?.let { mlp ->
-                mlp.setMargins(i.left, i.top, i.right, i.bottom)
+                mlp.setMargins(
+                    initialMargins.left + i.left,
+                    initialMargins.top + i.top,
+                    initialMargins.right + i.right,
+                    initialMargins.bottom + i.bottom
+                )
                 v.layoutParams = mlp
             }
             insets


### PR DESCRIPTION
This pull request improves how window insets (such as system bars and keyboard) are handled in the payment review UI, ensuring correct padding and margin behavior across Android versions, especially when keyboard visibility changes or insets listeners are installed after initial view attachment. The changes address both the logic for applying insets and the reliability of insets updates.

**Insets handling improvements:**

* Updated the documentation and logic in `ReviewView` to clarify and improve handling of system insets, especially for Android 15+ where relying on raw IME insets could cause unwanted padding when the keyboard is visible. Now, keyboard visibility is observed manually, and for Android 14 and below, an attach-aware insets request is used to ensure padding is always applied, even if the insets listener is set after the initial dispatch.
* Added a new private function `requestApplyInsetsWhenAttached` in `ReviewView` to explicitly request an insets pass as soon as a view is attached to the window. This ensures that insets listeners installed after the initial dispatch still receive insets updates promptly.
* Applied `requestApplyInsetsWhenAttached` to relevant views (`gpsPaymentDetails`) to guarantee proper insets application.

**Margin and padding preservation:**

* In the `View.applyWindowInsetsWithTopPadding` extension, captured the initial margins of a view before applying insets, so that insets are added to existing margins rather than overwriting them. This prevents loss of intended spacing defined in XML or code.

**Minor code maintenance:**

* Added missing import for `android.graphics.Rect` to support margin calculations.
