### PR TITLE
fix(ci): run the SonarCloud scanner with Java 21

### DIFF
--- a/.github/workflows/bank-api-library.check.yml
+++ b/.github/workflows/bank-api-library.check.yml
@@ -225,7 +225,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
 
       - name: Generate coverage report

--- a/.github/workflows/bank-sdk.check.yml
+++ b/.github/workflows/bank-sdk.check.yml
@@ -273,7 +273,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
 
       # Build both modules (example-app depends on sdk)

--- a/.github/workflows/capture-sdk.check.yml
+++ b/.github/workflows/capture-sdk.check.yml
@@ -335,7 +335,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
 
       # Build both modules (default-network depends on sdk)

--- a/.github/workflows/core-api-library.check.yml
+++ b/.github/workflows/core-api-library.check.yml
@@ -219,7 +219,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
 
       - name: Generate coverage report

--- a/.github/workflows/health-api-library.check.yml
+++ b/.github/workflows/health-api-library.check.yml
@@ -251,7 +251,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Generate coverage report
         run: ./gradlew :health-api-library:library:jacocoTestReport

--- a/.github/workflows/health-sdk.check.yml
+++ b/.github/workflows/health-sdk.check.yml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
           cache: "gradle"
       - name: Create google-services.json
         run: |

--- a/.github/workflows/internal-payment-sdk.check.yml
+++ b/.github/workflows/internal-payment-sdk.check.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
 
       - name: Build Internal Payment SDK
         run: ./gradlew :internal-payment-sdk:sdk:assembleDebug


### PR DESCRIPTION
SonarQube Cloud no longer supports Java 17 scanners - every main-branch analysis has been hard-failing, leaving the PR quality gates comparing against months-old baselines.