### PR TITLE
feat(skill): Add skill to update Figma links in Confluence documentation

### DIFF
--- a/.claude/skills/update-figma-links/SKILL.md
+++ b/.claude/skills/update-figma-links/SKILL.md
@@ -22,6 +22,23 @@ The user wants to point the Android Gini Bank SDK "Figma Links" documentation
 page at a newer Figma UI-customisation guide (new SDK version). The page contains
 many Figma links, one per screen/section.
 
+## How to run
+
+Type `/update-figma-links` and paste the new Figma guide URL, or just say in
+plain words: *"update the Android Figma links to this new guide: <URL>"*.
+
+You normally provide **only the new Figma guide URL** — the Confluence page is
+already known (see Repo defaults). Example:
+
+```
+/update-figma-links https://www.figma.com/design/<NEW_KEY>/Android-Gini-Bank-SDK-<version>-UI-Customisation
+```
+
+What happens next: it reads the page, verifies each screen's node-id in the new
+file, shows you a ✅/❌ table, and **pauses for your sign-off** (and asks you to
+paste the correct link for any screen that moved) before writing. You approve; it
+writes and then diffs to confirm. Nothing is written without your OK.
+
 ## Repo defaults (Android)
 
 This skill targets the **Android** Gini Bank SDK documentation. Use these unless
@@ -29,7 +46,9 @@ the user overrides them:
 
 - **Confluence page:** "Figma Links in public documentation" — page ID `435257345`
   (`https://gini.atlassian.net/wiki/spaces/GBSV/pages/435257345/Figma+Links+in+public+documentation`)
-- **Confluence site (cloudId):** `gini.atlassian.net`
+- **Confluence site:** `gini.atlassian.net` — pass this as the `cloudId` argument to
+  the Atlassian MCP tools (they accept a site hostname, so the literal cloudId UUID
+  is not needed here).
 - **Guide name pattern:** `Android-Gini-Bank-SDK-<version>-UI-Customisation`
 
 Because the page is already known, the user normally only needs to paste the

--- a/.claude/skills/update-figma-links/SKILL.md
+++ b/.claude/skills/update-figma-links/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: update-figma-links
+description: >-
+  Update the Figma design links on the Android Gini Bank SDK "Figma Links in
+  public documentation" Confluence page to a new UI-customisation guide (new SDK
+  version). Verifies every node-id actually resolves to the CORRECT screen in the
+  new Figma file (not just that it exists), handles all three Confluence embed
+  formats, strips share tokens, and writes back safely with a post-write diff.
+  Use when migrating that Android page from one SDK version's Figma file to a
+  newer one — e.g. 4.0 → 4.4.
+---
+
+# Update Figma links on a Confluence documentation page
+
+Migrate all Figma links on a Confluence page from an old Figma file/version to a
+new one, correctly and safely. This encodes a process that was validated by hand;
+follow it in order and do not skip the verification or sign-off steps.
+
+## When to use
+
+The user wants to point the Android Gini Bank SDK "Figma Links" documentation
+page at a newer Figma UI-customisation guide (new SDK version). The page contains
+many Figma links, one per screen/section.
+
+## Repo defaults (Android)
+
+This skill targets the **Android** Gini Bank SDK documentation. Use these unless
+the user overrides them:
+
+- **Confluence page:** "Figma Links in public documentation" — page ID `435257345`
+  (`https://gini.atlassian.net/wiki/spaces/GBSV/pages/435257345/Figma+Links+in+public+documentation`)
+- **Confluence site (cloudId):** `gini.atlassian.net`
+- **Guide name pattern:** `Android-Gini-Bank-SDK-<version>-UI-Customisation`
+
+Because the page is already known, the user normally only needs to paste the
+**new** Figma guide URL. Still confirm the page + old→new versions back to the
+user before writing.
+
+---
+
+## STEP 0 — Inputs (accept plain pasted URLs; STOP only if genuinely missing)
+
+Users think in URLs, not in file keys. Ask for / accept these as **whole pasted
+links** — never make the user type a cryptic file key or a separate version:
+
+1. **Confluence page** — paste the page URL (or ID). Extract the numeric page ID,
+   e.g. `.../pages/435257345/...` → `435257345`.
+2. **New Figma customisation guide** — paste the WHOLE Figma URL of the new file.
+   Derive from it (do NOT ask separately):
+   - **new file key** = the segment right after `/design/`
+     (e.g. `https://www.figma.com/design/IkSOLWfZB02MS165Yw6uMt/...` → `IkSOLWfZB02MS165Yw6uMt`)
+   - **new version label** = the number in
+     `Android-Gini-Bank-SDK-<version>-UI-Customisation` (e.g. `4.4`).
+     Only if the pasted URL has no version in its name, ask the user for the version.
+
+Do **not** proceed if the page or the new Figma URL is missing — editing the
+wrong page or wrong file is hard to undo and outward-facing. But once you have
+those two pasted links, derive everything else; don't demand more typing.
+
+**Auto-detected (do NOT ask):** the *old* Figma file key and version — read them
+from the page's existing links. After detecting, confirm back, e.g.
+"This page currently points to the 4.0 file (`m7YX7baCajRp2NlyPEezfX`) →
+migrating to 4.4 (`IkSOLWfZB02MS165Yw6uMt`). Proceeding."
+
+**Optional inputs:** per-screen node-id overrides (for moved screens — see Step 3,
+and the user may simply paste a screen's Figma link).
+
+**Format policy (DEFAULT: standardise every link to the embed preview).** This
+page should show one uniform **live Figma preview per section**, like the
+**Colors** section. So by default convert every link — plain link boxes
+(`block-card`) and "Figma for Confluence" plugin boxes — into the same
+`embed-card` format (see Step 2, `--to-embed`). Only skip standardising if the
+user explicitly says to keep the existing formats.
+
+---
+
+## Key facts you must know
+
+**Three embed formats** appear on these pages; all three contain the same
+`figma.com` URL text, so a whole-page string substitution covers all of them.
+You only need the formats to *verify* afterward and to not miss any:
+
+| Format | Where the URL lives | Looks like on the page |
+|---|---|---|
+| `block-card` | `data-url` + `<a href>` + visible text (3 copies) | a plain clickable link box |
+| `embed-card` | `<iframe src>` | a live Figma preview window |
+| plugin extension (`figma-for-confluence-lite`) | inside the `data-parameters` JSON (`url` field, `&quot;`-encoded) | a "Figma for Confluence LITE" box |
+
+**The `t=` token** — the trailing `&t=...` on a Figma URL is a per-session share
+token, not needed for the link to work. Strip it from every link. (Tell-tale
+sign the links were bulk-copied: they all share the same token.)
+
+**node-id caveat (the important one)** — a `node-id` from the old file does **not**
+reliably point to the same screen in the new file. Some screens move, get
+renamed, or are new. You MUST verify each one (Step 3). Blindly swapping the file
+key can silently send a link to the wrong screen.
+
+**Frame-name caveat** — in these files, many big container frames are generically
+named "Onboarding - Light Mode" even when they contain Review/Help/etc. So a
+name check alone is unreliable — confirm ambiguous ones with a screenshot.
+
+**inline-comment / `data-local-id` risk** — the MCP write replaces the whole page
+body and drops the invisible `data-local-id` tags that anchor **inline comments**.
+Harmless on pages with no inline comments; on pages that HAVE them it can detach
+them. Step 5 checks for this before writing.
+
+---
+
+## STEP 1 — Read the page and enumerate the links
+
+1. `mcp__claude_ai_Atlassian__getConfluencePage` with `contentFormat: "html"` and
+   the page ID. (Load Atlassian MCP tools via ToolSearch if deferred.)
+2. Save the returned `body` HTML to a working file, e.g.
+   `<scratchpad>/page_before.html`.
+3. Enumerate every `figma.com` link with its section heading and `node-id`.
+   Detect the old file key + version from these URLs and confirm to the user.
+
+## STEP 2 — Compute the proposed new links (deterministic)
+
+**Never hardcode a version.** The old version/key are auto-detected from the page;
+the new version/key come from the Figma URL the user pasted. Any `4.0`/`4.4`
+elsewhere in this skill are illustrative examples only — always use the detected
+and pasted values.
+
+Use the helper script (avoids hand-retyping the large body):
+
+```
+python3 <skill-dir>/transform_links.py \
+  --in <scratchpad>/page_before.html \
+  --out <scratchpad>/page_after.html \
+  --old-key <DETECTED_OLD_KEY> --new-key <NEW_KEY_FROM_PASTED_URL> \
+  --old-version <DETECTED_OLD_VERSION> --new-version <NEW_VERSION_FROM_PASTED_URL> \
+  --strip-token \
+  --to-embed \
+  [--map OLD_NODEID=NEW_NODEID ...]
+```
+
+It swaps the file key, swaps the version in the file-name segment, strips `t=`
+tokens, applies any node-id overrides, and prints a before→after audit of every
+Figma URL. Review that audit.
+
+**`--to-embed` (default policy)** additionally standardises every link into the
+uniform live-preview format used by the Colors section:
+`<div data-type="embed-card" data-layout="center" data-width="100"><iframe src="URL"></iframe></div>`
+It converts `block-card` link boxes and "Figma for Confluence" plugin boxes into
+this format and leaves any non-Figma element untouched. Omit `--to-embed` only if
+the user asked to keep each link's existing format (then links are re-pointed in
+place).
+
+## STEP 3 — Verify every node-id in the NEW file (REQUIRED — do not skip)
+
+Verification is judgment, not string work. Delegate it to a subagent so the heavy
+Figma metadata output stays out of the main context:
+
+- Give the subagent the NEW file key and the list of `section → node-id`.
+- It calls `mcp__claude_ai_Figma__get_metadata` (fileKey + nodeId) for each and
+  reports: exists? / the node's name / whether it matches the section.
+- For any it flags as a mismatch, or any ambiguous generic name, **confirm
+  visually** with `mcp__claude_ai_Figma__get_screenshot` (small `maxDimension`).
+- Produce a table: ✅ safe (correct screen) vs ❌ needs a corrected node-id.
+
+### Step 3b — Handling a wrong or moved screen (the important case)
+
+A node-id from the old file may resolve, in the NEW file, to a **different** screen
+(e.g. the old "Onboarding" node = Typography in 4.4) or to a generic container.
+When verification flags a link ❌, resolve it like this — never write it unresolved:
+
+1. **Try to auto-locate the correct screen** in the new file:
+   - Call `get_metadata` on the new file with **no nodeId** to list top-level pages,
+     and/or scan frames whose name matches the section (e.g. "Onboarding",
+     "Document Import").
+   - Screenshot the best candidate with `get_screenshot` and confirm its content
+     matches the section.
+2. If a confident match is found → show the user the screenshot and propose it;
+   on approval, record it as a `--map OLD=NEW` override.
+3. If **not** found confidently → **STOP and ask the user to paste that ONE
+   screen's Figma link** from the new file. Extract the node-id from the pasted
+   URL and use it as the override.
+4. A flagged link stays ❌ (excluded from the write) until resolved. Never write a
+   link whose target screen you could not confirm.
+
+After resolving overrides, re-run Step 2 with the `--map` values.
+
+## STEP 4 — Human sign-off gate (REQUIRED)
+
+Show the user the final table (every link: old URL → new URL, with ✅/❌ status).
+**Do not write** until the user confirms, and until every ❌ is resolved to a ✅
+via an override. Never write a link you could not verify.
+
+## STEP 5 — Write back safely (MCP method + inline-comment check)
+
+1. **Inline-comment check:** call
+   `mcp__claude_ai_Atlassian__getConfluencePageInlineComments` for the page.
+   - If it returns any inline comments → **STOP**. Warn the user that the
+     whole-body write would drop their anchors, and offer the REST-API mode
+     (below) or manual editing. Do not write.
+   - If none → proceed.
+2. Write with `mcp__claude_ai_Atlassian__updateConfluencePage`,
+   `contentFormat: "html"`, body = the reviewed `page_after.html` contents,
+   and a clear `versionMessage` (e.g. "Migrate Figma links 4.0 → 4.4").
+
+## STEP 6 — Verify the write (REQUIRED)
+
+1. Re-fetch the page (`getConfluencePage`, html).
+2. Diff it against `page_before.html`. Confirm that the ONLY differences are the
+   intended Figma URLs (file key, version, stripped token, overridden node-ids)
+   — plus the harmless `data-local-id` normalisation. Nothing else — no headings,
+   other links, or macros changed.
+3. Report the result to the user. Everything is versioned/undoable via page history.
+
+---
+
+## Optional: REST-API mode (loss-free, for pages WITH inline comments)
+
+Only needed when Step 5 finds inline comments and the user still wants automation.
+Requires an Atlassian API token (do not hard-code it):
+
+- Auth: `curl -u "$ATLASSIAN_EMAIL:$ATLASSIAN_API_TOKEN"`.
+- `GET /wiki/rest/api/content/<id>?expand=body.storage,version` → transform the
+  `body.storage.value` with `transform_links.py` → `PUT` the new storage value
+  with `version.number + 1`. Storage format round-trips `data-local-id`, so
+  inline-comment anchors survive.
+
+## Guardrails recap
+
+- Mandatory inputs, or STOP (Step 0).
+- Verify every node-id resolves to the CORRECT screen, or STOP (Step 3).
+- Human sign-off before writing, all ❌ resolved (Step 4).
+- Inline-comment check before writing (Step 5).
+- Post-write diff to confirm only intended changes (Step 6).

--- a/.claude/skills/update-figma-links/transform_links.py
+++ b/.claude/skills/update-figma-links/transform_links.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+transform_links.py — re-point (and optionally reformat) Figma links in a
+Confluence page body for the Android Gini Bank SDK docs.
+
+Two things it can do:
+
+1) RE-POINT (default): swap every figma.com URL from the old file/version to the
+   new one, in place, keeping each link's existing wrapper. Applies:
+     - old file key   -> new file key
+     - old version     -> new version  (in the Android-Gini-Bank-SDK-<v>-UI-Customisation name)
+     - strips the &t=... share token (with --strip-token)
+     - optional per-node-id remap (--map OLD=NEW) for screens that moved
+
+2) STANDARDISE TO EMBED (--to-embed): in addition to re-pointing, rewrite EVERY
+   Figma link into the same live-preview format as the Colors section, i.e.
+     <div data-type="embed-card" data-layout="center" data-width="100"><iframe src="URL"></iframe></div>
+   This converts block-card link boxes and "Figma for Confluence" plugin boxes
+   (and normalises existing embed-cards) into one uniform full-width, centered
+   preview per section.
+
+The re-point pass covers all wrapper formats because it substitutes over the raw
+URL text. The --to-embed pass replaces the wrapper element itself. "&amp;"-encoded
+ampersands are handled. This script never touches Confluence — the skill fetches
+the body (MCP), runs this, writes it back (MCP), and diffs to verify.
+
+Usage (re-point only):
+  python3 transform_links.py --in before.html --out after.html \
+      --new-key NEWKEY --old-version 4.0 --new-version 4.4 --strip-token [--map OLD=NEW ...]
+
+Usage (re-point + standardise to embed previews):
+  python3 transform_links.py --in before.html --out after.html \
+      --new-key NEWKEY --old-version 4.0 --new-version 4.4 --strip-token --to-embed [--map ...]
+"""
+import argparse
+import re
+import sys
+
+FIGMA_URL_RE = re.compile(r'https://www\.figma\.com/[^\s"\'<>]+')
+
+# Uniform preview wrapper, matching the Colors section (centered, full width).
+EMBED_TMPL = ('<div data-type="embed-card" data-layout="center" data-width="100">'
+              '<iframe src="{url}"></iframe></div>')
+
+# Whole link-wrapper elements (none of these contain nested <div>, so .*?</div>
+# closes at the element's own </div>).
+BLOCK_RE = re.compile(r'<div\s+data-type="block-card"[^>]*>.*?</div>', re.DOTALL)
+EMBED_RE = re.compile(r'<div\s+data-type="embed-card"[^>]*>.*?</div>', re.DOTALL)
+EXT_RE = re.compile(r'<div\s+data-type="extension"[^>]*>.*?</div>', re.DOTALL)
+
+DATA_URL_RE = re.compile(r'data-url="([^"]+)"')
+IFRAME_SRC_RE = re.compile(r'<iframe[^>]*\bsrc="([^"]+)"')
+EXT_URL_RE = re.compile(r'&quot;url&quot;:&quot;(.*?)&quot;')
+
+
+def strip_share_token(url: str) -> str:
+    url = re.sub(r'(?:&amp;|&)t=[^&"\'<>]*', '', url)
+    url = re.sub(r'\?t=[^&"\'<>]*(?:&amp;|&)?', '?', url)
+    return url.replace('?&amp;', '?').replace('?&', '?').rstrip('?&')
+
+
+def transform_value(url, args, node_map):
+    """Apply key/version/node-id/token changes to a single URL string."""
+    if args.old_key and args.new_key:
+        url = url.replace(args.old_key, args.new_key)
+    if args.old_version and args.new_version:
+        url = url.replace(
+            f'Android-Gini-Bank-SDK-{args.old_version}-UI-Customisation',
+            f'Android-Gini-Bank-SDK-{args.new_version}-UI-Customisation')
+    for old_node, new_node in node_map.items():
+        url = url.replace(f'node-id={old_node}', f'node-id={new_node}')
+    if args.strip_token:
+        url = strip_share_token(url)
+    return url
+
+
+def make_wrapper_converter(args, node_map, report):
+    def convert(match, kind):
+        block = match.group(0)
+        if kind == 'block':
+            m = DATA_URL_RE.search(block) or FIGMA_URL_RE.search(block)
+            url = m.group(1) if m and m.re is DATA_URL_RE else (m.group(0) if m else None)
+        elif kind == 'embed':
+            m = IFRAME_SRC_RE.search(block)
+            url = m.group(1) if m else None
+        else:  # extension
+            m = EXT_URL_RE.search(block)
+            url = m.group(1) if m else None
+        if not url or 'figma.com' not in url:
+            return block  # not a Figma link wrapper — leave untouched
+        new_url = transform_value(url, args, node_map)
+        report.append((url, new_url, kind))
+        return EMBED_TMPL.format(url=new_url)
+    return convert
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument('--in', dest='infile', required=True)
+    p.add_argument('--out', dest='outfile', required=True)
+    p.add_argument('--old-key', help='old Figma file key (auto-detected if omitted)')
+    p.add_argument('--new-key', required=True, help='new Figma file key')
+    p.add_argument('--old-version', help='old version label, e.g. 4.0')
+    p.add_argument('--new-version', help='new version label, e.g. 4.4')
+    p.add_argument('--strip-token', action='store_true')
+    p.add_argument('--to-embed', action='store_true',
+                   help='standardise every link to the embed-card preview format')
+    p.add_argument('--map', action='append', default=[], metavar='OLD=NEW')
+    args = p.parse_args()
+
+    node_map = {}
+    for m in args.map:
+        if '=' not in m:
+            print(f'ERROR: bad --map value {m!r}, expected OLD=NEW', file=sys.stderr)
+            return 2
+        old, new = m.split('=', 1)
+        node_map[old.strip()] = new.strip()
+
+    with open(args.infile, encoding='utf-8') as f:
+        body = f.read()
+
+    if args.old_key is None:
+        keys = re.findall(r'figma\.com/design/([A-Za-z0-9]+)', body)
+        if keys:
+            args.old_key = max(set(keys), key=keys.count)
+            print(f'[auto-detected old key] {args.old_key}')
+
+    all_urls_before = FIGMA_URL_RE.findall(body)
+    report = []
+
+    if args.to_embed:
+        conv = make_wrapper_converter(args, node_map, report)
+        # Re-point existing embed-cards FIRST, so embeds created from block/ext
+        # below are not re-scanned (keeps the report accurate, output unchanged).
+        body = EMBED_RE.sub(lambda m: conv(m, 'embed'), body)
+        body = BLOCK_RE.sub(lambda m: conv(m, 'block'), body)
+        body = EXT_RE.sub(lambda m: conv(m, 'extension'), body)
+        mode = 'STANDARDISE TO EMBED (+ re-point)'
+    else:
+        def repoint(mo):
+            before = mo.group(0)
+            after = transform_value(before, args, node_map)
+            if after != before:
+                report.append((before, after, 'url'))
+            return after
+        body = FIGMA_URL_RE.sub(repoint, body)
+        mode = 'RE-POINT (in place)'
+
+    with open(args.outfile, 'w', encoding='utf-8') as f:
+        f.write(body)
+
+    print(f'\nMode: {mode}')
+    print(f'Figma links found: {len(all_urls_before)}   changed: {len(report)}\n')
+    for i, (before, after, kind) in enumerate(report, 1):
+        print(f'{i:>2}. [{kind}]')
+        print(f'    BEFORE: {before}')
+        print(f'    AFTER : {after}\n')
+    print(f'Wrote: {args.outfile}')
+    print('Next: verify node-ids in the NEW file, get sign-off, then write back and diff.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/.claude/skills/update-figma-links/transform_links.py
+++ b/.claude/skills/update-figma-links/transform_links.py
@@ -70,8 +70,13 @@ def transform_value(url, args, node_map):
         url = url.replace(
             f'Android-Gini-Bank-SDK-{args.old_version}-UI-Customisation',
             f'Android-Gini-Bank-SDK-{args.new_version}-UI-Customisation')
-    for old_node, new_node in node_map.items():
-        url = url.replace(f'node-id={old_node}', f'node-id={new_node}')
+    # Single-pass, anchored node-id remap: the capture group matches a WHOLE
+    # node-id (stops at & " ' < or whitespace), so a mapped id that is a prefix
+    # of another id can't corrupt the longer one; and each id is looked up in the
+    # map exactly once, so sequential entries never chain (a->b, b->c).
+    if node_map:
+        url = re.sub(r'node-id=([^&"\'\s<]+)',
+                     lambda m: f'node-id={node_map.get(m.group(1), m.group(1))}', url)
     if args.strip_token:
         url = strip_share_token(url)
     return url
@@ -139,6 +144,22 @@ def main() -> int:
         body = EMBED_RE.sub(lambda m: conv(m, 'embed'), body)
         body = BLOCK_RE.sub(lambda m: conv(m, 'block'), body)
         body = EXT_RE.sub(lambda m: conv(m, 'extension'), body)
+        # Catch inline / straggler Figma links that are NOT inside the three
+        # wrappers (e.g. a plain <a href> in a paragraph) — otherwise they would
+        # silently keep the old file key and never appear in the audit.
+        # GUARD: only touch URLs that still contain the OLD key, so URLs already
+        # converted by the wrapper passes (new key) are skipped entirely. This is
+        # essential: re-running the remap over converted URLs could otherwise
+        # re-apply a map entry and re-introduce the chaining bug.
+        def catch(mo):
+            before = mo.group(0)
+            if not args.old_key or args.old_key not in before:
+                return before
+            after = transform_value(before, args, node_map)
+            if after != before:
+                report.append((before, after, 'inline'))
+            return after
+        body = FIGMA_URL_RE.sub(catch, body)
         mode = 'STANDARDISE TO EMBED (+ re-point)'
     else:
         def repoint(mo):

--- a/.claude/skills/update-figma-links/transform_links.py
+++ b/.claude/skills/update-figma-links/transform_links.py
@@ -36,7 +36,10 @@ import argparse
 import re
 import sys
 
-FIGMA_URL_RE = re.compile(r'https://www\.figma\.com/[^\s"\'<>]+')
+# Stops at whitespace / real quotes / < > AND at an encoded quote `&quot;` (the JSON
+# string delimiter inside the plugin extension), while still keeping `&amp;` — the
+# real param separator inside the URL.
+FIGMA_URL_RE = re.compile(r'https://www\.figma\.com/(?:(?!&quot;)[^\s"\'<>])+')
 
 # Uniform preview wrapper, matching the Colors section (centered, full width).
 EMBED_TMPL = ('<div data-type="embed-card" data-layout="center" data-width="100">'


### PR DESCRIPTION
This pull request introduces a new skill, `update-figma-links`, for safely migrating Figma design links in the Android Gini Bank SDK Confluence documentation to a new UI-customisation guide. It provides a detailed, step-by-step process for updating, verifying, and standardizing Figma links, with strong guardrails to prevent errors. The PR also adds a supporting script, `transform_links.py`, which automates the link transformation and reformatting.

The most important changes are:

**New skill documentation and process:**
* [`.claude/skills/update-figma-links/SKILL.md`](diffhunk://#diff-933f08b0929313f07d4d4186bdb8d6f6b734bfe7ff388d74fefca66a5c05a0b1R1-R230): Adds comprehensive documentation for the `update-figma-links` skill, detailing when and how to use it, mandatory verification steps, guardrails, and handling of all Figma link formats in the Confluence page. The process ensures every migrated link points to the correct screen and includes human sign-off and post-write verification.

**Automation script for link migration:**
* `.claude/skills/update-figma-links/transform_links.py`: Introduces a Python script that automates the migration of Figma links in Confluence HTML. It supports:
  - Swapping old file keys and version numbers for new ones.
  - Stripping unnecessary share tokens from URLs.
  - Remapping node-ids for screens that moved.
  - Optionally standardizing all links to a uniform live-preview embed format.
  - Producing a detailed audit of all link changes for review.

These changes provide a robust, auditable, and user-friendly workflow for updating Figma links in documentation, minimizing the risk of broken or misdirected links.