### PR TITLE
fix(capture-sdk): Pin unsupported QR warning type only when first warning is shown

### DIFF
--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureViewModel.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/GiniCaptureViewModel.kt
@@ -17,13 +17,13 @@ internal class GiniCaptureViewModel(
     init {
         // DataStore is the single source of truth for the configuration flags.
         //
-        // isUnsupportedQRCodeWarningEnabled must stay constant for the whole session. Normally
-        // this observer pins it to the first persisted value emitted by DataStore — not to a
-        // synchronous in-memory default: on a relaunch a persisted `true` may not have been
-        // loaded yet, and pinning to the cold default would incorrectly disable the warning for
-        // the entire run. The pin is first-wins and shared via UnsupportedQrWarningSessionPin:
-        // should an unsupported QR code be scanned before the first emission, the camera screen
-        // pins the session value instead (see CameraFragmentExtension).
+        // isUnsupportedQRCodeWarningEnabled must stay constant for the whole session, but it is
+        // deliberately NOT pinned here. The first DataStore emission is the value cached by the
+        // *previous* session; pinning it would latch that stale value and ignore the fresh remote
+        // configuration saved later in this session — every session would run with the previous
+        // session's flag. Instead the provider always tracks the latest persisted value, and the
+        // camera screen pins it at the moment the first unsupported-QR warning is actually shown
+        // (see CameraFragmentExtension.isUnsupportedQRCodeWarningEnabled).
         //
         // clientID and amplitudeApiKey are not persisted, so they are preserved from whatever the
         // provider already holds (empty on first launch, real after the API responds).
@@ -31,14 +31,10 @@ internal class GiniCaptureViewModel(
             clientConfigurationStorage.getConfiguration()
                 .filterNotNull()
                 .collect { config ->
-                    val pinnedQrCodeWarningEnabled = unsupportedQrWarningSessionPin.pinIfAbsent {
-                        config.isUnsupportedQRCodeWarningEnabled
-                    }
                     giniBankConfigurationProvider.update { current ->
                         config.copy(
                             clientID = current.clientID,
-                            amplitudeApiKey = current.amplitudeApiKey,
-                            isUnsupportedQRCodeWarningEnabled = pinnedQrCodeWarningEnabled
+                            amplitudeApiKey = current.amplitudeApiKey
                         )
                     }
                 }

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentExtension.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/camera/CameraFragmentExtension.kt
@@ -45,9 +45,11 @@ internal abstract class CameraFragmentExtension {
 
     /**
      * Decides which unsupported-QR-code warning to show and pins that decision for the rest of
-     * the capture session, so the warning type cannot change mid-session. Usually the pin is
-     * already set by GiniCaptureViewModel from the first persisted configuration emission; the
-     * provider read is only the fallback when a QR code is scanned before that emission arrives.
+     * the capture session, so the warning type cannot change mid-session. This is the only pin
+     * site: the decision is taken lazily from the provider's latest configuration when the first
+     * warning is shown — pinning any earlier (e.g. on the first persisted-configuration emission)
+     * would latch the previous session's cached value before the fresh remote configuration
+     * arrives. GiniCaptureViewModel releases the pin when the session ends.
      */
     fun isUnsupportedQRCodeWarningEnabled(): Boolean =
         unsupportedQrWarningSessionPin.pinIfAbsent {

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -36,8 +36,10 @@ internal class QRCodePopup<T> @JvmOverloads constructor(
     private val onScanAnotherQRCode: (() -> Unit)? = null,
     private val onCaptureDocument: (() -> Unit)? = null,
     // Supplier instead of a captured Boolean: the warning type may not be known yet when the
-    // popup is created (the persisted configuration loads asynchronously), so it is resolved
-    // when the popup is actually shown.
+    // popup is created (the persisted configuration loads and the remote configuration is
+    // fetched asynchronously). The supplier resolves the session-pinned decision, which is taken
+    // only when the first warning is shown (see
+    // CameraFragmentExtension.isUnsupportedQRCodeWarningEnabled).
     private val isNewWarningEnabled: () -> Boolean = { false }
 ) {
 

--- a/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/provider/UnsupportedQrWarningSessionPin.kt
+++ b/capture-sdk/sdk/src/main/java/net/gini/android/capture/internal/provider/UnsupportedQrWarningSessionPin.kt
@@ -5,11 +5,11 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Pins the unsupported QR code warning type for the duration of one capture session.
  *
- * The warning type must not change while a session is running: it is decided once — by whichever
- * caller of [pinIfAbsent] comes first (the configuration observer when the persisted configuration
- * is loaded, or the camera screen when the first unsupported QR code is scanned) — and every later
- * caller observes that same decision. A configuration change received mid-session therefore only
- * takes effect in the next session.
+ * The warning type must not change while a session is running: it is decided once — by the camera
+ * screen when the first unsupported QR code warning is shown (see
+ * `CameraFragmentExtension.isUnsupportedQRCodeWarningEnabled`) — and every later caller observes
+ * that same decision. A configuration change received after the first warning was shown therefore
+ * only takes effect in the next session.
  *
  * The session boundary is the lifetime of `GiniCaptureViewModel`, which calls [reset] when it is
  * cleared. This class is a process-wide Koin singleton, so without the reset a pinned value would
@@ -21,8 +21,11 @@ internal class UnsupportedQrWarningSessionPin {
 
     /**
      * Returns the pinned value, computing and pinning it with [compute] if nothing has been
-     * pinned yet. Only the first caller's value wins; concurrent callers all observe the same
-     * pinned result.
+     * pinned yet. Only the first caller's value wins: [compute] may still be invoked by a losing
+     * concurrent caller, but its result is discarded and the already-pinned value is returned, so
+     * concurrent callers all observe the same pinned result. The trailing `?: candidate` fallback
+     * only applies if [reset] runs concurrently with a pin attempt — it cannot occur in practice
+     * because [reset] is called at the session boundary, after which no caller pins anymore.
      */
     fun pinIfAbsent(compute: () -> Boolean): Boolean {
         pinned.get()?.let { return it }

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/GiniCaptureViewModelTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/GiniCaptureViewModelTest.kt
@@ -1,0 +1,123 @@
+package net.gini.android.capture
+
+import androidx.lifecycle.ViewModelStore
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import net.gini.android.capture.internal.network.Configuration
+import net.gini.android.capture.internal.provider.GiniBankConfigurationProvider
+import net.gini.android.capture.internal.provider.UnsupportedQrWarningSessionPin
+import net.gini.android.capture.internal.storage.ClientConfigurationStorage
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GiniCaptureViewModelTest {
+
+    private val persistedConfiguration = MutableStateFlow<Configuration?>(null)
+    private val clientConfigurationStorage = mockk<ClientConfigurationStorage> {
+        every { getConfiguration() } returns persistedConfiguration
+    }
+    private val configurationProvider = GiniBankConfigurationProvider()
+    private val sessionPin = UnsupportedQrWarningSessionPin()
+
+    @Before
+    fun setup() {
+        // The DataStore observer launches in viewModelScope, which dispatches on Main.
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `provider tracks the fresh configuration instead of latching the stale first emission`() {
+        createViewModel()
+
+        // Given: the first DataStore emission is the configuration cached by the previous
+        // session, in which the new unsupported-QR warning was still enabled
+        persistedConfiguration.value = configuration(isUnsupportedQRCodeWarningEnabled = true)
+
+        // When: the fresh remote configuration of this session disables the warning
+        persistedConfiguration.value = configuration(isUnsupportedQRCodeWarningEnabled = false)
+
+        // Then: the provider reflects the fresh value — the observer must not pin the stale one
+        assertThat(configurationProvider.provide().isUnsupportedQRCodeWarningEnabled).isFalse()
+
+        // And: the first warning shown in this session pins the fresh value, not the stale one
+        val pinnedAtFirstWarning = sessionPin.pinIfAbsent {
+            configurationProvider.provide().isUnsupportedQRCodeWarningEnabled
+        }
+        assertThat(pinnedAtFirstWarning).isFalse()
+    }
+
+    @Test
+    fun `observer preserves the clientID and amplitudeApiKey already held by the provider`() {
+        // Given: the configuration API already delivered the non-persisted values
+        configurationProvider.update {
+            it.copy(clientID = "client-id", amplitudeApiKey = "amplitude-key")
+        }
+        createViewModel()
+
+        // When: DataStore emits a persisted configuration, which never carries them
+        persistedConfiguration.value = configuration(isUnsupportedQRCodeWarningEnabled = true)
+
+        // Then: the persisted flags are taken over while the in-memory values survive
+        val provided = configurationProvider.provide()
+        assertThat(provided.clientID).isEqualTo("client-id")
+        assertThat(provided.amplitudeApiKey).isEqualTo("amplitude-key")
+        assertThat(provided.isUnsupportedQRCodeWarningEnabled).isTrue()
+    }
+
+    @Test
+    fun `clearing the ViewModel releases the pinned warning type for the next session`() {
+        val viewModelStore = ViewModelStore()
+        viewModelStore.put("gini-capture", createViewModel())
+
+        // Given: the old yellow warning was pinned when the first warning was shown, and the
+        // configuration enabled the new warning afterwards
+        assertThat(sessionPin.pinIfAbsent { false }).isFalse()
+        persistedConfiguration.value = configuration(isUnsupportedQRCodeWarningEnabled = true)
+        assertThat(sessionPin.pinIfAbsent { true }).isFalse()
+
+        // When: the session ends (onCleared is called)
+        viewModelStore.clear()
+
+        // Then: the next session pins the fresh configuration value
+        val pinnedInNextSession = sessionPin.pinIfAbsent {
+            configurationProvider.provide().isUnsupportedQRCodeWarningEnabled
+        }
+        assertThat(pinnedInNextSession).isTrue()
+    }
+
+    private fun createViewModel() = GiniCaptureViewModel(
+        clientConfigurationStorage = clientConfigurationStorage,
+        giniBankConfigurationProvider = configurationProvider,
+        unsupportedQrWarningSessionPin = sessionPin,
+    )
+
+    private fun configuration(isUnsupportedQRCodeWarningEnabled: Boolean) = Configuration(
+        clientID = "",
+        isUserJourneyAnalyticsEnabled = false,
+        isSkontoEnabled = false,
+        isReturnAssistantEnabled = false,
+        isTransactionDocsEnabled = false,
+        isQrCodeEducationEnabled = false,
+        isInstantPaymentEnabled = false,
+        isEInvoiceEnabled = false,
+        amplitudeApiKey = "",
+        isSavePhotosLocallyEnabled = false,
+        isAlreadyPaidHintEnabled = false,
+        isPaymentDueHintEnabled = false,
+        isUnsupportedQRCodeWarningEnabled = isUnsupportedQRCodeWarningEnabled,
+    )
+}

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
@@ -4,14 +4,17 @@ import com.google.common.truth.Truth.assertThat
 import net.gini.android.capture.di.getGiniCaptureKoin
 import net.gini.android.capture.internal.provider.GiniBankConfigurationProvider
 import net.gini.android.capture.internal.provider.UnsupportedQrWarningSessionPin
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.koin.core.module.Module
 import org.koin.dsl.module
 
 class CameraFragmentExtensionTest {
 
     private lateinit var configurationProvider: GiniBankConfigurationProvider
     private lateinit var sessionPin: UnsupportedQrWarningSessionPin
+    private lateinit var koinTestModule: Module
     private lateinit var extension: CameraFragmentExtension
 
     @Before
@@ -20,17 +23,21 @@ class CameraFragmentExtensionTest {
         // which is shared by all tests running in the same JVM.
         configurationProvider = GiniBankConfigurationProvider()
         sessionPin = UnsupportedQrWarningSessionPin()
-        getGiniCaptureKoin().loadModules(
-            listOf(
-                module {
-                    single { configurationProvider }
-                    single { sessionPin }
-                }
-            )
-        )
+        koinTestModule = module {
+            single { configurationProvider }
+            single { sessionPin }
+        }
+        getGiniCaptureKoin().loadModules(listOf(koinTestModule))
         extension = object : CameraFragmentExtension() {
             override fun hideImageCorners() = Unit
         }
+    }
+
+    @After
+    fun tearDown() {
+        // Restores the production singletons so the test instances don't leak into other test
+        // classes sharing the same Koin context.
+        getGiniCaptureKoin().unloadModules(listOf(koinTestModule))
     }
 
     @Test

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
@@ -35,9 +35,14 @@ class CameraFragmentExtensionTest {
 
     @After
     fun tearDown() {
-        // Restores the production singletons so the test instances don't leak into other test
-        // classes sharing the same Koin context.
+        // Koin's unloadModules drops the overriding definitions instead of restoring the
+        // production ones, so the session pin is re-declared here: otherwise the shared Koin
+        // context is left with no UnsupportedQrWarningSessionPin definition and every later
+        // test in this JVM that resolves it fails with NoDefinitionFoundException.
         getGiniCaptureKoin().unloadModules(listOf(koinTestModule))
+        getGiniCaptureKoin().loadModules(
+            listOf(module { single { UnsupportedQrWarningSessionPin() } })
+        )
     }
 
     @Test

--- a/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
+++ b/capture-sdk/sdk/src/test/java/net/gini/android/capture/camera/CameraFragmentExtensionTest.kt
@@ -1,0 +1,75 @@
+package net.gini.android.capture.camera
+
+import com.google.common.truth.Truth.assertThat
+import net.gini.android.capture.di.getGiniCaptureKoin
+import net.gini.android.capture.internal.provider.GiniBankConfigurationProvider
+import net.gini.android.capture.internal.provider.UnsupportedQrWarningSessionPin
+import org.junit.Before
+import org.junit.Test
+import org.koin.dsl.module
+
+class CameraFragmentExtensionTest {
+
+    private lateinit var configurationProvider: GiniBankConfigurationProvider
+    private lateinit var sessionPin: UnsupportedQrWarningSessionPin
+    private lateinit var extension: CameraFragmentExtension
+
+    @Before
+    fun setup() {
+        // Fresh instances per test: both are singletons in the SDK's isolated Koin context,
+        // which is shared by all tests running in the same JVM.
+        configurationProvider = GiniBankConfigurationProvider()
+        sessionPin = UnsupportedQrWarningSessionPin()
+        getGiniCaptureKoin().loadModules(
+            listOf(
+                module {
+                    single { configurationProvider }
+                    single { sessionPin }
+                }
+            )
+        )
+        extension = object : CameraFragmentExtension() {
+            override fun hideImageCorners() = Unit
+        }
+    }
+
+    @Test
+    fun `second unsupported QR scan shows the same warning type even if the configuration changed in between`() {
+        // Given: the configuration endpoint has not responded when the first invalid QR code is
+        // scanned, so the default (old yellow warning) is pinned for the session
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isFalse()
+
+        // When: the configuration endpoint resolves in between and enables the new warning
+        configurationProvider.update { it.copy(isUnsupportedQRCodeWarningEnabled = true) }
+
+        // Then: a second scan in the same session still shows the old yellow warning
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isFalse()
+    }
+
+    @Test
+    fun `configuration arriving before the first scan decides the warning type for the session`() {
+        // Given: the configuration was loaded before any invalid QR code was scanned
+        configurationProvider.update { it.copy(isUnsupportedQRCodeWarningEnabled = true) }
+
+        // When/Then: the first scan pins the loaded value
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isTrue()
+
+        // And: a configuration flip after the first warning does not change the running session
+        configurationProvider.update { it.copy(isUnsupportedQRCodeWarningEnabled = false) }
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isTrue()
+    }
+
+    @Test
+    fun `configuration change applies from the next session onward`() {
+        // Given: the old yellow warning was pinned in this session, then the configuration
+        // enabled the new warning
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isFalse()
+        configurationProvider.update { it.copy(isUnsupportedQRCodeWarningEnabled = true) }
+
+        // When: the session ends (GiniCaptureViewModel.onCleared releases the pin)
+        sessionPin.reset()
+
+        // Then: the next session picks up the changed configuration
+        assertThat(extension.isUnsupportedQRCodeWarningEnabled()).isTrue()
+    }
+}


### PR DESCRIPTION
## What

Fixes the unsupported-QR-code warning showing the wrong (stale) warning type on first launch by changing *when* the warning type is pinned for the session.

- `GiniCaptureViewModel` no longer pins `isUnsupportedQRCodeWarningEnabled` from the first DataStore emission — the configuration provider now always tracks the latest persisted value.
- The session pin is taken in a single place, lazily, when the camera screen shows the first unsupported-QR warning (`CameraFragmentExtension.isUnsupportedQRCodeWarningEnabled`).
- Updated the documentation comments on `QRCodePopup` and `UnsupportedQrWarningSessionPin` to describe the single pin site.
- Added `CameraFragmentExtensionTest` covering that the warning type stays constant within a session regardless of when the configuration arrives.

## Why

The first DataStore emission is the configuration cached by the *previous* session. Pinning the flag on that emission latched the stale value and ignored the fresh remote configuration fetched later in the current session — so every session ran with the previous session's warning type, and on first launch the new warning popup never showed even when remotely enabled.

Pinning only at the moment the first warning is actually shown keeps the in-session guarantee (the warning type cannot change mid-session) while letting each session use the freshest configuration available at that moment.

## Ticket

[PP-3241](https://ginis.atlassian.net/browse/PP-3241)

[PP-3241]: https://ginis.atlassian.net/browse/PP-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ