### PR TITLE
Heal 533 rc health sdk 6.1.0

### DIFF
--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -20,11 +20,11 @@ Release order for :internal-payment-sdk:sdk 2.1.0:
  2. :health-api-library:library 6.1.0
  3. :internal-payment-sdk:sdk 2.1.0
 
-Release order for :health-sdk:sdk 6.0.0:
+Release order for :health-sdk:sdk 6.1.0:
  1. :core-api-library:library 3.5.0
  2. :health-api-library:library 6.1.0
  3. :internal-payment-sdk:sdk 2.1.0
- 4. :health-sdk:sdk 6.0.0
+ 4. :health-sdk:sdk 6.1.0
 
 Release order for :capture-sdk:default-network 4.4.0:
  1. :core-api-library:library 3.5.0

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -11,18 +11,18 @@ Release order for :bank-api-library:library 4.4.0:
  1. :core-api-library:library 3.5.0
  2. :bank-api-library:library 4.4.0
 
-Release order for :health-api-library:library 6.0.0:
+Release order for :health-api-library:library 6.1.0:
  1. :core-api-library:library 3.5.0
- 2. :health-api-library:library 6.0.0
+ 2. :health-api-library:library 6.1.0
 
 Release order for :internal-payment-sdk:sdk 2.0.0:
  1. :core-api-library:library 3.5.0
- 2. :health-api-library:library 6.0.0
+ 2. :health-api-library:library 6.1.0
  3. :internal-payment-sdk:sdk 2.0.0
 
 Release order for :health-sdk:sdk 6.0.0:
  1. :core-api-library:library 3.5.0
- 2. :health-api-library:library 6.0.0
+ 2. :health-api-library:library 6.1.0
  3. :internal-payment-sdk:sdk 2.0.0
  4. :health-sdk:sdk 6.0.0
 

--- a/RELEASE-ORDER.md
+++ b/RELEASE-ORDER.md
@@ -15,15 +15,15 @@ Release order for :health-api-library:library 6.1.0:
  1. :core-api-library:library 3.5.0
  2. :health-api-library:library 6.1.0
 
-Release order for :internal-payment-sdk:sdk 2.0.0:
+Release order for :internal-payment-sdk:sdk 2.1.0:
  1. :core-api-library:library 3.5.0
  2. :health-api-library:library 6.1.0
- 3. :internal-payment-sdk:sdk 2.0.0
+ 3. :internal-payment-sdk:sdk 2.1.0
 
 Release order for :health-sdk:sdk 6.0.0:
  1. :core-api-library:library 3.5.0
  2. :health-api-library:library 6.1.0
- 3. :internal-payment-sdk:sdk 2.0.0
+ 3. :internal-payment-sdk:sdk 2.1.0
  4. :health-sdk:sdk 6.0.0
 
 Release order for :capture-sdk:default-network 4.4.0:

--- a/health-api-library/library/gradle.properties
+++ b/health-api-library/library/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-health-api-lib
-version=6.0.0
+version=6.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 

--- a/health-api-library/library/src/doc/source/guides/getting-started.rst
+++ b/health-api-library/library/src/doc/source/guides/getting-started.rst
@@ -13,7 +13,7 @@ build.gradle:
 .. code-block:: groovy
 
     dependencies {
-        implementation 'net.gini.android:gini-health-api-lib:6.0.0'
+        implementation 'net.gini.android:gini-health-api-lib:6.1.0'
     }
 
 Integrating the Gini Health API Library

--- a/health-sdk/sdk/gradle.properties
+++ b/health-sdk/sdk/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-health-sdk
-version=6.0.0
+version=6.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=1000
 

--- a/health-sdk/sdk/src/doc/source/setup.rst
+++ b/health-sdk/sdk/src/doc/source/setup.rst
@@ -11,7 +11,7 @@ build.gradle:
 .. code-block:: groovy
 
     dependencies {
-        implementation 'net.gini.android:gini-health-sdk:6.0.0'
+        implementation 'net.gini.android:gini-health-sdk:6.1.0'
     }
 
 Gini Pay Deep Link For Your App

--- a/internal-payment-sdk/sdk/gradle.properties
+++ b/internal-payment-sdk/sdk/gradle.properties
@@ -1,7 +1,7 @@
 # Maven coordinates
 # groupId is in the root gradle.properties
 artifactId=gini-internal-payment-sdk
-version=2.0.0
+version=2.1.0
 # Version code is visible only in the generated BuildConfig file
 versionCode=0
 # Maven POM properties


### PR DESCRIPTION
This pull request updates the versions of several libraries and SDKs in preparation for new releases. It ensures that all version numbers are consistent across configuration and documentation files, and updates the release order documentation to reflect the new versions.

Version updates:

* Bumped `health-api-library` to version `6.1.0` in both `gradle.properties` and documentation (`getting-started.rst`). [[1]](diffhunk://#diff-ed064f0e32eb26061ccfcb636c20fbd1c505868acb7cb9dde941666c6c4ce623L4-R4) [[2]](diffhunk://#diff-0b0a6cd3a8c5a72032e737d45fdf9667f3509624dd3bb62c407f2b66fc79a21bL16-R16)
* Bumped `internal-payment-sdk` to version `2.1.0` in `gradle.properties`.
* Bumped `health-sdk` to version `6.1.0` in both `gradle.properties` and documentation (`setup.rst`). [[1]](diffhunk://#diff-f34490b99ecd150c309df7ba4c2a7505bb88e41f81a8acd1d6f98ceb9fa3b182L4-R4) [[2]](diffhunk://#diff-d1b1b938cb43512b7f114d8123db27c3ed37d0d2be1c1f78b87a997aa5b763e0L14-R14)

Documentation and release process:

* Updated `RELEASE-ORDER.md` to reflect the new versions and their release dependencies for `health-api-library`, `internal-payment-sdk`, and `health-sdk`.