### PR TITLE
docs: Add PR template, PR description guidance, and graphify docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Pull Request Description
+
+<!-- Briefly explain **what** this PR does and **why**. Mention the motivation, feature, or issue it's addressing. -->
+
+[TICKET-ID]<!-- Closes the ticket; replace with the JIRA ticket if relevant (e.g. PP-1234, HEAL-99, XPL-42, SDK-4) -->
+
+<!--
+
+Some description of HOW you achieved it. Give a high-level description of the changes you did. Did you need to refactor something? What tradeoffs did you take?
+
+-->
+
+## Notes for Reviewers
+
+<!--
+
+Explain how you verified the changes.
+A clear testing scenario helps colleagues who may not be familiar with this part of the code quickly understand and verify the changes. Include steps they can follow to see the impact in action.
+
+You can include:
+- Modules/SDKs affected (e.g. bank-sdk:sdk, capture-sdk:default-network)
+- Emulators/devices and API levels tested (e.g. Pixel 8, API 34)
+- Manual checks (e.g. flow tested: capture, review, payment, error states)
+- Unit or instrumented tests added or updated
+
+Include screenshots, screen recordings, or emulator gifs for UI changes.
+
+- Optional: Anything that needs extra attention in review? Are there TODOs, known limitations, or follow-up work?
+
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ fastlane/report.xml
 .kotlin/
 test.properties
 **/google-services.json
+/graphify-out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,13 +138,55 @@ over the docs and CI workflows (image assets are skipped).
   - `graphify query "<question>"` — broad context (BFS)
   - `graphify path "<A>" "<B>"` — shortest path between two concepts (e.g. `"bank-sdk" "core-api-library"`)
   - `graphify explain "<concept>"` — plain-language explanation of a node
-- Open `graphify-out/graph.html` in a browser for the interactive community view (aggregated,
-  since the full graph exceeds 5,000 nodes).
-- The graph is **not** auto-rebuilt — no git hook is installed, so it can go stale as the code
-  moves on. Rebuild manually:
-  - After pulling or switching branches: `graphify update .` (AST-only, no API cost).
-  - After changing **docs, CI workflows, or PDFs** in a session: `/graphify --update` (folds the
-    semantic content back into the graph).
-- graphify can also expose a live subset of the graph over MCP via `/graphify --mcp`
-  (`query_graph`, `get_node`, `get_neighbors`, `god_nodes`, `shortest_path`, …); no MCP server
-  is connected by default.
+- Open `graphify-out/graph.html` in a browser for the interactive community view.
+- **The graph auto-rebuilds on branch switch** via a `post-checkout` git hook (AST-only, no API
+  cost), installed at `.git/hooks/post-checkout`. This is the only hook installed: commits do
+  **not** trigger a rebuild, and a plain `git pull` does **not** either (a pull fires no checkout).
+- After a `git pull` (e.g. pulling `main`) that you don't follow with a branch switch, run
+  `graphify update .` to refresh the graph against the pulled code.
+- After changing **docs, images, or PDFs** in a session (the hook only covers code), run
+  `/graphify --update` to fold them into the graph.
+- To rebuild manually at any time: `graphify update .` (AST-only, no API cost).
+---
+
+## MCP Tools: code-review-graph (optional — only if configured)
+
+> **NOTE:** The `code-review-graph` MCP server is **not currently connected** to this project.
+> The tools below are only available once that MCP server has been added to the Claude Code /
+> Claude Desktop config. Until then, use the `graphify` CLI commands in the `## graphify` section
+> above and fall back to Grep/Glob/Read. graphify can expose a subset of these live via
+> `/graphify --mcp` (tools: `query_graph`, `get_node`, `get_neighbors`, `get_community`,
+> `god_nodes`, `graph_stats`, `shortest_path`).
+
+**IF the `code-review-graph` MCP server is configured, prefer its tools BEFORE Grep/Glob/Read
+when exploring the codebase** — the graph is faster, cheaper (fewer tokens), and gives
+structural context (callers, dependents, test coverage) that file scanning cannot.
+
+### When to use graph tools first
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of / callees_of / imports_of / tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key tools
+
+| Tool | Use when |
+|------|----------|
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow (when the MCP server is configured)
+
+1. Use `detect_changes` for code review.
+2. Use `get_affected_flows` to understand impact.
+3. Use `query_graph` with `pattern="tests_for"` to check coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,8 @@ When generating a pull request description:
 **Requirements**
 
 - Use the repository PR template (`.github/pull_request_template.md`) exactly — it is the file GitHub pre-fills when a PR is opened.
-- Extract the Jira ticket from the commit message (the `<ticket-id>` line, e.g. `PP-1234`, `HEAL-99`, `XPL-42`, `SDK-4`).
-- Replace the `[TICKET-ID]` placeholder with the real ticket.
+- If there is a Jira ticket, extract it from the commit message (the `<ticket-id>` line, e.g. `PP-1234`, `HEAL-99`, `XPL-42`, `SDK-4`).
+ - Replace the `[TICKET-ID]` placeholder with the real ticket, or `N/A` if no ticket applies.
 - Describe **what** changed, **why** the change was needed, and **how** it was implemented (high level).
 - Mention affected projects/modules explicitly in `<project>:<module>` form (e.g. `bank-sdk:sdk`, `capture-sdk:default-network`).
 - Keep the description concise and reviewer-friendly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,31 @@ Reference docs (Dokka): `./gradlew <project>:<module>:dokkaHtmlSiblingCollector`
 - `bank-sdk:example-app` uses two flavor dimensions (`environment`: prod/dev/qa; `purpose`: exampleApp/paymentProviderN) — build a single variant, e.g. `assembleDevExampleAppDebug` (CI builds `assembleQaExampleAppRelease` and `assembleProdExampleAppRelease`); a plain `assembleDebug` builds every flavor combination.
 - Keep vector-drawable handling as-is (`vectorDrawables.useSupportLibrary = true`); see comments in module build files before touching drawables.
 - Complex automation belongs in fastlane lanes, not GitHub Actions steps (lanes must be runnable locally).
+
+## graphify
+
+This monorepo has a **graphify knowledge graph** at `graphify-out/` covering all seven projects
+(`core-api-library`, `health-api-library`, `bank-api-library`, `capture-sdk`, `bank-sdk`,
+`health-sdk`, `internal-payment-sdk`). It is built from Kotlin/Java AST plus semantic extraction
+over the docs and CI workflows (image assets are skipped).
+
+**Rules:**
+
+- Before answering architecture or codebase questions, read `graphify-out/GRAPH_REPORT.md` for
+  the god nodes (`CameraFragmentImpl`, `GiniCapture`, `Document()`, `ImageDocument`, `Resource`,
+  `MultiPageReviewFragment`, `GiniCaptureDocument` …) and the community structure.
+- For cross-module "how does X relate to Y" questions, prefer graph traversal over grep — it
+  follows the graph's EXTRACTED + INFERRED edges instead of scanning files:
+  - `graphify query "<question>"` — broad context (BFS)
+  - `graphify path "<A>" "<B>"` — shortest path between two concepts (e.g. `"bank-sdk" "core-api-library"`)
+  - `graphify explain "<concept>"` — plain-language explanation of a node
+- Open `graphify-out/graph.html` in a browser for the interactive community view (aggregated,
+  since the full graph exceeds 5,000 nodes).
+- The graph is **not** auto-rebuilt — no git hook is installed, so it can go stale as the code
+  moves on. Rebuild manually:
+  - After pulling or switching branches: `graphify update .` (AST-only, no API cost).
+  - After changing **docs, CI workflows, or PDFs** in a session: `/graphify --update` (folds the
+    semantic content back into the graph).
+- graphify can also expose a live subset of the graph over MCP via `/graphify --mcp`
+  (`query_graph`, `get_node`, `get_neighbors`, `god_nodes`, `shortest_path`, …); no MCP server
+  is connected by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,36 @@ Reference docs (Dokka): `./gradlew <project>:<module>:dokkaHtmlSiblingCollector`
 - Release tags: `<project-name>;<version>` (e.g. `bank-sdk;1.0.2`) — tags trigger release workflows, so never push them casually.
 - Releases follow `RELEASE.md`: `capture-sdk:default-network` is always version-bumped together with `capture-sdk`, and multiple major versions (1.x/2.x/3.x) are maintained on parallel branches — fixes for older majors must branch from the matching version branch, not `main`.
 
+## Pull request descriptions
+
+When generating a pull request description:
+
+**Requirements**
+
+- Use the repository PR template (`.github/pull_request_template.md`) exactly — it is the file GitHub pre-fills when a PR is opened.
+- Extract the Jira ticket from the commit message (the `<ticket-id>` line, e.g. `PP-1234`, `HEAL-99`, `XPL-42`, `SDK-4`).
+- Replace the `[TICKET-ID]` placeholder with the real ticket.
+- Describe **what** changed, **why** the change was needed, and **how** it was implemented (high level).
+- Mention affected projects/modules explicitly in `<project>:<module>` form (e.g. `bank-sdk:sdk`, `capture-sdk:default-network`).
+- Keep the description concise and reviewer-friendly.
+
+**Notes for Reviewers** — include:
+
+- how the changes were verified: unit tests (`./gradlew <project>:<module>:testDebugUnitTest`), lint/detekt/ktlint, or the `/gini-check` skill; instrumented tests via `connectedCheck` or the `/gini-connected-check` skill
+- test scenario(s) reviewers can follow
+- unit/instrumented tests added or updated
+- known limitations or follow-up work
+
+**Rules**
+
+- Do not invent missing details.
+- Use only information from the git diff, the changed files, and the commit messages.
+- If something is unknown, state it clearly instead of guessing.
+
+**PR template**
+
+The canonical PR template is [`.github/pull_request_template.md`](.github/pull_request_template.md) — the file GitHub pre-fills when a pull request is opened. Use it verbatim as the structure for every generated PR description; do not redefine or paraphrase the template here, so the two never drift apart.
+
 ## Gotchas
 
 - Gradle must run on JDK 17 (newer JDKs cause `IllegalAccessError` in the build).


### PR DESCRIPTION
## Pull Request Description

Adds repository tooling and agent documentation — no product code is affected. Mirrors the setup already present in the `gini-mobile-ios` repo.

- **PR template** (`.github/pull_request_template.md`): introduces a standard *Pull Request Description* / *Notes for Reviewers* structure that GitHub pre-fills for new PRs. Uses a generic `[TICKET-ID]` placeholder because this repo uses several Jira prefixes (`PP-`, `HEAL-`, `XPL-`, `SDK-`).
- **PR description guidance** (`AGENTS.md`): a new *Pull request descriptions* section telling agents to use the template verbatim as the single source of truth, extract the ticket from the commit message, describe what/why/how, name affected `<project>:<module>`s, and verify via the gradle tasks and the `/gini-check` / `/gini-connected-check` skills.
- **graphify** (`AGENTS.md`): a new *graphify* section documenting the local knowledge graph at `graphify-out/` — god nodes, `query`/`path`/`explain` usage, and manual rebuild commands. `graphify-out/` is added to `.gitignore` so it stays local and is never committed.

_No Jira ticket — this is a repository tooling/documentation change._

## Notes for Reviewers

**How it was verified**
- `git diff --stat main..HEAD` touches only `.github/pull_request_template.md`, `.gitignore`, and `AGENTS.md` — no source, build, or CI logic changed.
- `.github/pull_request_template.md` renders as the default body when a new PR is opened.
- The new `AGENTS.md` sections read correctly and the relative link to the PR template resolves.

**Scope & testing**
- Docs/tooling only; no unit or instrumented tests apply and no module behaviour changes.

