### PR TITLE
docs(SKILL.md): update release skill to create jira release and fix something in health release

### DIFF
--- a/.claude/skills/gini-release/SKILL.md
+++ b/.claude/skills/gini-release/SKILL.md
@@ -40,21 +40,20 @@ Use the Atlassian connector. One ticket per side — Bank releases in project **
 - **Title:** `[Android] RC for Android Gini Bank SDK <new-version>` / `[Android] RC for Android Gini Health SDK <new-version>` — the version is the main SDK's new version from the user's list in step 1.
 - **Description:** built from **the tickets that share this release's fix version**, not from your own reading of the diffs. Read the two most recent Release Candidate tickets in the target project — `project = <KEY> AND issuetype = "Release Candidate" ORDER BY created DESC` — and match their shape; some are much terser than others, so follow the fuller example. The usual sections:
 
-  1. **Tickets in this release** — a link per ticket, `https://ginis.atlassian.net/browse/<KEY>`. Find them with `fixVersion in ("<version>", …)` using the same fix versions the RC ticket carries.
+  1. **Tickets in this release** — a link per ticket, `https://ginis.atlassian.net/browse/<TICKET-KEY>` (an issue key such as `PP-123` or `HEAL-456`, not the project key). Find them with `fixVersion in ("<version>", …)` using the same fix versions the RC ticket carries.
   2. **Modules released** — old → new per module.
   3. **Scope of testing** — frequently included, especially for Health. **Ask the user for it; do not invent it** — they decide smoke-test breadth and which OS versions QA runs. Optionally follow it with the areas most likely to be affected, derived from the diffs (version-gated code paths, transitive dependency uplifts), calling out anything with no ticket of its own.
-  4. **Listed Releases** — the release report of each fix version:
+  4. **Listed Releases** — the Jira **release report** page of each fix version:
 
-  ```
-  You can find all the tickets related to this release here:
-  https://ginis.atlassian.net/projects/<KEY>/versions/<version-id>/tab/release-report-all-issues
-  ```
+     ```
+     You can find all the tickets related to this release here:
+     https://ginis.atlassian.net/projects/<KEY>/versions/<version-id>/tab/release-report-all-issues
+     ```
 
+     Look up the Jira release matching the new SDK version in the project's releases (PP or HEAL) to get its numeric `<version-id>`. If other released modules (e.g. bank-api-library) have their own Jira release, add their report links too.
   5. **Attachments / build for testing** — the Firebase App Distribution links for the example-app build QA installs. Ask the user for these; they come from the CI/Firebase build and cannot be generated here.
 
-  The link is the Jira **release report** page of this release's fix version. Look up the Jira release matching the new SDK version in the project's releases (PP or HEAL) to get its numeric `<version-id>`; if the Jira release doesn't exist yet, create it first (per `RELEASE.md` step 1 — tickets get connected via "Fix versions", and the release description later carries the markdown release notes). If other released modules (e.g. bank-api-library) have their own Jira release, add their report links too.
-
-**Check the Jira releases exist, and create the missing ones.** Open the project's Releases page at `https://ginis.atlassian.net/projects/<KEY>?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=all` — `status=all` matters, the default filter hides released versions. There should be one release per released module that has release notes of its own (see the ownership note at the end of step 4); the one you want is the latest `UNRELEASED` entry matching that product and version. Watch out for permanent placeholder `UNRELEASED` versions kept for parking bug tickets, so match on name rather than taking the last row.
+**Check the Jira releases exist, and create the missing ones** (per `RELEASE.md` step 1 — tickets get connected to a release via "Fix versions", and the release description later carries the markdown release notes). Open the project's Releases page at `https://ginis.atlassian.net/projects/<KEY>?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=all` — `status=all` matters, the default filter hides released versions. There should be one release per released module that has release notes of its own (see the ownership note at the end of step 4); the one you want is the latest `UNRELEASED` entry matching that product and version. Watch out for permanent placeholder `UNRELEASED` versions kept for parking bug tickets, so match on name rather than taking the last row.
 
 For any that are missing, create them **through that page in the browser** — the Atlassian connector has no tool for creating Jira versions, and Jira rejects an unknown `fixVersions` name (`Version name '…' is not valid`) instead of auto-creating it. Naming follows `<Platform> Gini <Product> <version>`, so keep the `Android`/`iOS` prefix to avoid colliding with the other platform's releases. In the `Create release` dialog: fill Release name and Description, and **clear the prefilled Release date** — it defaults to today, which is wrong for a version that hasn't shipped. Clear it by clicking the field, `cmd+a`, `Backspace`, then click the dialog heading to dismiss the date picker; setting an empty string via `form_input` does not work. After saving, **reload the page** — the table does not refresh, so a successful create looks like a failure. Don't click `Create release` twice either; the second click closes the dialog. Read each version's numeric id off its table link (`/projects/<KEY>/versions/<id>/tab/...`).
 
@@ -70,7 +69,7 @@ Report the created ticket key(s) — they go into every bump commit.
 
 Three major versions (1.x/2.x/3.x lines) are maintained on parallel branches. If the target version's major matches the version on `main`, branch from `main`; otherwise the release must branch from the matching version branch — check the wiki page linked in `RELEASE.md` step 2 and confirm with the user before proceeding.
 
-Create the RC branch (used to release **all** modules of this release): `PP-XXX-RC-bank-SDK-x.x.x` (bank) or `HEAL-XXX-RC-Health-SDK-x.x.x` (insurance). For "both", use a single branch named after the bank ticket unless the user wants separate branches — confirm.
+Create the RC branch (used to release **all** modules of this release): `PP-XXX-RC-bank-SDK-x.x.x` (bank) or `HEAL-XXX-RC-Health-SDK-x.x.x` (health). For "both", use a single branch named after the bank ticket unless the user wants separate branches — confirm.
 
 ## 4. Bump versions, one commit per module, in release order
 

--- a/.claude/skills/gini-release/SKILL.md
+++ b/.claude/skills/gini-release/SKILL.md
@@ -34,18 +34,35 @@ Show a summary table (module, old → new version) and get an explicit confirmat
 
 ## 2. Create the RC ticket(s) in Jira
 
-Use the Atlassian connector. One ticket per side — Bank releases in project **PP**, Health releases in project **IPC**; choosing "both" creates **two tickets**, one in each project.
+Use the Atlassian connector. One ticket per side — Bank releases in project **PP**, Health releases in project **HEAL**; choosing "both" creates **two tickets**, one in each project. Health releases used to live in a since-removed `IPC` project, which is why older bump commits carry `IPC-` ticket ids.
 
 - **Issue type:** `Release Candidate`
 - **Title:** `[Android] RC for Android Gini Bank SDK <new-version>` / `[Android] RC for Android Gini Health SDK <new-version>` — the version is the main SDK's new version from the user's list in step 1.
-- **Description:**
+- **Description:** built from **the tickets that share this release's fix version**, not from your own reading of the diffs. Read the two most recent Release Candidate tickets in the target project — `project = <KEY> AND issuetype = "Release Candidate" ORDER BY created DESC` — and match their shape; some are much terser than others, so follow the fuller example. The usual sections:
+
+  1. **Tickets in this release** — a link per ticket, `https://ginis.atlassian.net/browse/<KEY>`. Find them with `fixVersion in ("<version>", …)` using the same fix versions the RC ticket carries.
+  2. **Modules released** — old → new per module.
+  3. **Scope of testing** — frequently included, especially for Health. **Ask the user for it; do not invent it** — they decide smoke-test breadth and which OS versions QA runs. Optionally follow it with the areas most likely to be affected, derived from the diffs (version-gated code paths, transitive dependency uplifts), calling out anything with no ticket of its own.
+  4. **Listed Releases** — the release report of each fix version:
 
   ```
   You can find all the tickets related to this release here:
-  https://ginis.atlassian.net/projects/PP/versions/<version-id>/tab/release-report-all-issues
+  https://ginis.atlassian.net/projects/<KEY>/versions/<version-id>/tab/release-report-all-issues
   ```
 
-  The link is the Jira **release report** page of this release's fix version. Look up the Jira release matching the new SDK version in the project's releases (PP or IPC) to get its numeric `<version-id>`; if the Jira release doesn't exist yet, create it first (per `RELEASE.md` step 1 — tickets get connected via "Fix versions", and the release description later carries the markdown release notes). If other released modules (e.g. bank-api-library) have their own Jira release, add their report links too.
+  5. **Attachments / build for testing** — the Firebase App Distribution links for the example-app build QA installs. Ask the user for these; they come from the CI/Firebase build and cannot be generated here.
+
+  The link is the Jira **release report** page of this release's fix version. Look up the Jira release matching the new SDK version in the project's releases (PP or HEAL) to get its numeric `<version-id>`; if the Jira release doesn't exist yet, create it first (per `RELEASE.md` step 1 — tickets get connected via "Fix versions", and the release description later carries the markdown release notes). If other released modules (e.g. bank-api-library) have their own Jira release, add their report links too.
+
+**Check the Jira releases exist, and create the missing ones.** Open the project's Releases page at `https://ginis.atlassian.net/projects/<KEY>?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=all` — `status=all` matters, the default filter hides released versions. There should be one release per released module that has release notes of its own (see the ownership note at the end of step 4); the one you want is the latest `UNRELEASED` entry matching that product and version. Watch out for permanent placeholder `UNRELEASED` versions kept for parking bug tickets, so match on name rather than taking the last row.
+
+For any that are missing, create them **through that page in the browser** — the Atlassian connector has no tool for creating Jira versions, and Jira rejects an unknown `fixVersions` name (`Version name '…' is not valid`) instead of auto-creating it. Naming follows `<Platform> Gini <Product> <version>`, so keep the `Android`/`iOS` prefix to avoid colliding with the other platform's releases. In the `Create release` dialog: fill Release name and Description, and **clear the prefilled Release date** — it defaults to today, which is wrong for a version that hasn't shipped. Clear it by clicking the field, `cmd+a`, `Backspace`, then click the dialog heading to dismiss the date picker; setting an empty string via `form_input` does not work. After saving, **reload the page** — the table does not refresh, so a successful create looks like a failure. Don't click `Create release` twice either; the second click closes the dialog. Read each version's numeric id off its table link (`/projects/<KEY>/versions/<id>/tab/...`).
+
+Once the versions exist, set them as `fixVersions` on the RC ticket with `editJiraIssue`; names work at that point. Do the same on the work tickets that belong to this release, otherwise the release report comes back empty. Fix versions are **project-scoped**, so a ticket in another project cannot carry this project's version.
+
+**Put the ticket in the active sprint.** A freshly created ticket has no sprint, so it appears only in the backlog and never on a board — expect to be asked why it "isn't there". The connector has no board or sprint listing tool, so derive it from an existing issue: run `project = <KEY> AND sprint in openSprints()`, fetch one result with `expand: names`, and find the `customfield_*` whose name is `Sprint`. That is the field id to write; its value carries each sprint's numeric `id`, `state` and `boardId`. Take the entry whose `state` is `active` and set it on the RC ticket via `editJiraIssue`. Note the active sprint may belong to a board other than the project's own board, in which case the ticket legitimately won't show on the project board — point at the `boardId` from the sprint record. Also note JQL against a value that doesn't exist returns an empty result set rather than an error, so "no results" never proves absence.
+
+**Drive the ticket's status yourself** — don't leave it for the user. Move it to `In Progress` when you start the bumps, and to `Waiting for QA` at the step 5 gate, using `transitionJiraIssue`. **Resolve transitions per ticket, never by hardcoded id:** call `getTransitionsForJiraIssue` on the actual ticket and match on the transition **name**, case-insensitively (the same status is spelled `Waiting for QA` in one project and `WAITING FOR QA` in the other). Ids are per-project and collide across projects — the same number can name a harmless transition in one and `Cancelled` in the other — so copying a list of ids between projects will silently move a ticket to the wrong status.
 
 Report the created ticket key(s) — they go into every bump commit.
 
@@ -53,7 +70,7 @@ Report the created ticket key(s) — they go into every bump commit.
 
 Three major versions (1.x/2.x/3.x lines) are maintained on parallel branches. If the target version's major matches the version on `main`, branch from `main`; otherwise the release must branch from the matching version branch — check the wiki page linked in `RELEASE.md` step 2 and confirm with the user before proceeding.
 
-Create the RC branch (used to release **all** modules of this release): `PP-XXX-RC-bank-SDK-x.x.x` (bank) or `IPC-XXX-RC-Health-SDK-x.x.x` (insurance). For "both", use a single branch named after the bank ticket unless the user wants separate branches — confirm.
+Create the RC branch (used to release **all** modules of this release): `PP-XXX-RC-bank-SDK-x.x.x` (bank) or `HEAL-XXX-RC-Health-SDK-x.x.x` (insurance). For "both", use a single branch named after the bank ticket unless the user wants separate branches — confirm.
 
 ## 4. Bump versions, one commit per module, in release order
 
@@ -69,7 +86,7 @@ For each module in the confirmed set, in `RELEASE-ORDER.md` order (fewest depend
    <RC-ticket-id>
    ```
 
-   The `<project>` slug is the top-level folder, except `capture-sdk:default-network` which uses `default-network` (e.g. `feat(default-network): Bump version to 4.3.2`). Use the ticket of the module's side (PP for bank-chain modules, IPC for health-chain); for `core-api-library` in a "both" release, include both ticket ids.
+   The `<project>` slug is the top-level folder, except `capture-sdk:default-network` which uses `default-network` (e.g. `feat(default-network): Bump version to 4.3.2`). Use the ticket of the module's side (PP for bank-chain modules, HEAL for health-chain); for `core-api-library` in a "both" release, include both ticket ids.
 
 Then run the `/gini-check` skill for the affected modules before pushing, and push the RC branch (normal push — no tags yet).
 
@@ -91,7 +108,7 @@ The lane finds every project whose `gradle.properties` version has no matching `
 
 1. **Sonatype / Maven Central** (credentials in 1Password: "Maven Central Sonatype account for net.gini"): after all release builds finish, in Staging Repositories select all → `Close` (pre-release checks), check email for Sonatype Lift vulnerability reports, then select all → `Release`.
 2. **GitHub releases**: create one per pushed tag at github.com/gini/gini-mobile-android/releases, using the markdown release notes from the Jira release (samples linked in `RELEASE.md`).
-3. **Jira**: make sure each Jira release has its tickets connected via "Fix versions" and markdown notes in the description; publish the releases in PP/IPC.
+3. **Jira**: make sure each Jira release has its tickets connected via "Fix versions" and markdown notes in the description; publish the releases in PP/HEAL.
 4. Move the RC ticket(s) to `Done` and merge the RC branch into `main` (or the version branch it came from).
 
 ## 8. Report


### PR DESCRIPTION
This pull request updates the release process documentation to reflect changes in Jira project naming and procedures, clarifies ticket and branch naming conventions, and expands the details for creating Release Candidate (RC) tickets. The most important updates are:

**Jira Project Naming and Ticket Handling:**
* Updates all references from the old Health Jira project `IPC` to the new `HEAL` project throughout the documentation, including ticket creation, branch naming, and release publishing. [[1]](diffhunk://#diff-8ab7789c884cb22c8b3456b948d09b85140dd085a740eec30dd2dc175883e68dL37-R73) [[2]](diffhunk://#diff-8ab7789c884cb22c8b3456b948d09b85140dd085a740eec30dd2dc175883e68dL72-R89) [[3]](diffhunk://#diff-8ab7789c884cb22c8b3456b948d09b85140dd085a740eec30dd2dc175883e68dL94-R111)
* Adds context explaining why older commits reference `IPC-` ticket IDs, improving clarity for anyone reviewing historical changes.

**Release Candidate Ticket Creation and Management:**
* Expands the instructions for RC ticket creation: details how to build the ticket description, requires checking and creating missing Jira releases, and provides guidance on setting the active sprint and driving ticket status transitions.
* Clarifies how to handle fix versions and sprints in Jira, including step-by-step instructions for setting and verifying these fields to ensure tickets appear correctly on boards.

**Branch and Commit Naming:**
* Updates branch and commit naming conventions to use the new `HEAL` project key for Health releases, replacing `IPC`. [[1]](diffhunk://#diff-8ab7789c884cb22c8b3456b948d09b85140dd085a740eec30dd2dc175883e68dL37-R73) [[2]](diffhunk://#diff-8ab7789c884cb22c8b3456b948d09b85140dd085a740eec30dd2dc175883e68dL72-R89)

**Release Publishing:**
* Updates the Jira release publishing step to reference the new `HEAL` project instead of `IPC`.