### PR TITLE
ci: Gate Firebase example publishing behind manual approval

### DIFF
--- a/.github/workflows/bank-sdk.publish.firebase.example.yml
+++ b/.github/workflows/bank-sdk.publish.firebase.example.yml
@@ -29,6 +29,7 @@ jobs:
 
   publish_to_firebase_distribution:
     needs: check
+    environment: firebase-manual-deploy
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/gpc.publish.firebase.example.yml
+++ b/.github/workflows/gpc.publish.firebase.example.yml
@@ -15,6 +15,7 @@ jobs:
 
   publish_to_firebase_distribution:
     needs: check
+    environment: firebase-manual-deploy
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/health-sdk.publish.firebase.example.yml
+++ b/.github/workflows/health-sdk.publish.firebase.example.yml
@@ -29,6 +29,7 @@ jobs:
 
   publish_to_firebase_distribution:
     needs: check
+    environment: firebase-manual-deploy
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
## Pull Request Description

Gates the Firebase example-app distribution jobs behind the GitHub `firebase-manual-deploy` deployment environment, so the example apps are only uploaded after that environment's protection rules (e.g. manual approval) are satisfied — instead of publishing automatically on every triggering event.

- Adds `environment: firebase-manual-deploy` to the `publish_to_firebase_distribution` job in:
  - `.github/workflows/bank-sdk.publish.firebase.example.yml`
  - `.github/workflows/health-sdk.publish.firebase.example.yml`
  - `.github/workflows/gpc.publish.firebase.example.yml`

Mirrors the same change already applied in the `gini-mobile-ios` repo (bank + health Firebase workflows).

_No Jira ticket — CI/infra change._

## Notes for Reviewers

**How it was verified**
- `git diff --stat main..HEAD` shows only the three workflow files, `+1` line each — the `environment:` key added to the existing `publish_to_firebase_distribution` job (placed between `needs: check` and `runs-on: ubuntu-latest`). No other YAML changed.

**Requires**
- The `firebase-manual-deploy` environment must exist under **Settings → Environments** with the desired approval rules, and any secrets those jobs rely on scoped to it. Until it is configured, the jobs run as before but without gating.

**Scope**
- CI only; no product code, modules, or tests are affected.

**Note**
- `gpc.publish.firebase.example.yml` is gated here too, even though iOS has no `gpc` equivalent — included for consistency across all Firebase example publishers. Easy to drop if not wanted.
